### PR TITLE
Release mic when category changes

### DIFF
--- a/sdk/objc/components/audio/RTCAudioSession.h
+++ b/sdk/objc/components/audio/RTCAudioSession.h
@@ -100,7 +100,7 @@ RTC_OBJC_EXPORT
                 error:(NSError *)error;
 
 /** Called when audio session changed from output-only to input & output */
-- (void)audioSessionWillRecord:(RTC_OBJC_TYPE(RTCAudioSession) *)audioSession;
+- (void)audioSessionDidChangeRecordingEnabled:(RTC_OBJC_TYPE(RTCAudioSession) *)audioSession;
 
 @end
 

--- a/sdk/objc/components/audio/RTCAudioSession.mm
+++ b/sdk/objc/components/audio/RTCAudioSession.mm
@@ -103,7 +103,7 @@ NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
                   options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
                   context:(__bridge void *)RTC_OBJC_TYPE(RTCAudioSession).class];
 
-    self.isRecordingEnabled = [_session.category isEqualToString:AVAudioSessionCategoryPlayAndRecord];
+    _isRecordingEnabled = [self sessionCategoryIsRecordingEnabled];
 
     RTCLog(@"RTC_OBJC_TYPE(RTCAudioSession) (%p): init.", self);
   }
@@ -492,14 +492,13 @@ NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
       RTCLog(@"Audio route changed: OldDeviceUnavailable");
       break;
     case AVAudioSessionRouteChangeReasonCategoryChange:
-      RTCLog(@"Audio route changed: CategoryChange to :%@",
-             self.session.category);
-      if (!self.isRecordingEnabled && [self.session.category isEqualToString:AVAudioSessionCategoryPlayAndRecord]) {
-        self.isRecordingEnabled = true;
-        [self notifyWillRecord];
-      }
-      if (self.isRecordingEnabled && [self.session.category isEqualToString:AVAudioSessionCategoryPlayback]) {
-        self.isRecordingEnabled = false;
+      RTCLog(@"Audio route changed: CategoryChange to :%@", self.session.category);
+      {
+        BOOL newValue = [self sessionCategoryIsRecordingEnabled];
+        if (_isRecordingEnabled != newValue) {
+          _isRecordingEnabled = newValue;
+          [self notifyDidChangeAudioSessionRecordingEnabled];
+        }
       }
       break;
     case AVAudioSessionRouteChangeReasonOverride:
@@ -713,7 +712,7 @@ NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
   }
   RTCLog(@"Unconfiguring audio session for WebRTC.");
   [self setActive:NO error:outError];
-  self.isRecordingEnabled = NO;
+  _isRecordingEnabled = NO;
 
   return YES;
 }
@@ -926,14 +925,18 @@ NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
   }
 }
 
-- (void)notifyWillRecord {
+- (void)notifyDidChangeAudioSessionRecordingEnabled {
   for (auto delegate : self.delegates) {
-    SEL sel = @selector(audioSessionWillRecord:);
+    SEL sel = @selector(audioSessionDidChangeRecordingEnabled:);
     if ([delegate respondsToSelector:sel]) {
-      [delegate audioSessionWillRecord:self];
+      [delegate audioSessionDidChangeRecordingEnabled:self];
     }
   }
 }
 
+-(BOOL)sessionCategoryIsRecordingEnabled {
+  return [_session.category isEqualToString:AVAudioSessionCategoryPlayAndRecord] || 
+    [_session.category isEqualToString:AVAudioSessionCategoryRecord];
+}
 
 @end

--- a/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
+++ b/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
@@ -86,9 +86,9 @@
   _observer->OnChangedOutputVolume();
 }
 
-- (void)audioSessionWillRecord:(RTC_OBJC_TYPE(RTCAudioSession) *)session {
+- (void)audioSessionDidChangeRecordingEnabled:(RTC_OBJC_TYPE(RTCAudioSession) *)session {
   // re-trigger audio unit init, by using interrupt ended callback
-  _observer->OnAudioWillRecord();
+  _observer->OnChangedRecordingEnabled();
 }
 
 @end

--- a/sdk/objc/native/src/audio/audio_device_ios.h
+++ b/sdk/objc/native/src/audio/audio_device_ios.h
@@ -145,7 +145,7 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
   void OnValidRouteChange() override;
   void OnCanPlayOrRecordChange(bool can_play_or_record) override;
   void OnChangedOutputVolume() override;
-  void OnAudioWillRecord() override;
+  void OnChangedRecordingEnabled() override;
 
   // VoiceProcessingAudioUnitObserver methods.
   OSStatus OnDeliverRecordedData(AudioUnitRenderActionFlags* flags,
@@ -173,7 +173,7 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
   void HandleSampleRateChange(float sample_rate);
   void HandlePlayoutGlitchDetected();
   void HandleOutputVolumeChange();
-  void HandleAudioWillRecord();
+  void HandleAudioSessionRecordingEnabledChange();
 
   // Uses current |playout_parameters_| and |record_parameters_| to inform
   // the audio device buffer (ADB) about our internal audio parameters.

--- a/sdk/objc/native/src/audio/audio_device_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_ios.mm
@@ -68,7 +68,7 @@ enum AudioDeviceMessageType : uint32_t {
   kMessageTypeCanPlayOrRecordChange,
   kMessageTypePlayoutGlitchDetected,
   kMessageOutputVolumeChange,
-  kMessageTypeAudioWillRecord,
+  kMessageTypeRecordingEnabledChange,
 };
 
 using ios::CheckAndLogError;
@@ -368,9 +368,9 @@ void AudioDeviceIOS::OnChangedOutputVolume() {
   thread_->Post(RTC_FROM_HERE, this, kMessageOutputVolumeChange);
 }
 
-void AudioDeviceIOS::OnAudioWillRecord() {
+void AudioDeviceIOS::OnChangedRecordingEnabled() {
   RTC_DCHECK(thread_);
-  thread_->Post(RTC_FROM_HERE, this, kMessageTypeAudioWillRecord);
+  thread_->Post(RTC_FROM_HERE, this, kMessageTypeRecordingEnabledChange);
 }
 
 OSStatus AudioDeviceIOS::OnDeliverRecordedData(AudioUnitRenderActionFlags* flags,
@@ -503,8 +503,9 @@ void AudioDeviceIOS::OnMessage(rtc::Message* msg) {
     case kMessageOutputVolumeChange:
       HandleOutputVolumeChange();
       break;
-    case kMessageTypeAudioWillRecord:
-      HandleAudioWillRecord();
+    case kMessageTypeRecordingEnabledChange:
+      HandleAudioSessionRecordingEnabledChange();
+      break;
   }
 }
 
@@ -668,10 +669,10 @@ void AudioDeviceIOS::HandleOutputVolumeChange() {
   last_output_volume_change_time_ = rtc::TimeMillis();
 }
 
-void AudioDeviceIOS::HandleAudioWillRecord() {
+void AudioDeviceIOS::HandleAudioSessionRecordingEnabledChange() {
   RTC_DCHECK_RUN_ON(&thread_checker_);
 
-  LOGI() << "HandleAudioWillRecord";
+  LOGI() << "HandleAudioSessionRecordingEnabledChange";
 
   // If we don't have an audio unit yet, or the audio unit is uninitialized,
   // there is no work to do.

--- a/sdk/objc/native/src/audio/audio_session_observer.h
+++ b/sdk/objc/native/src/audio/audio_session_observer.h
@@ -32,7 +32,7 @@ class AudioSessionObserver {
 
   virtual void OnChangedOutputVolume() = 0;
 
-  virtual void OnAudioWillRecord() = 0;
+  virtual void OnChangedRecordingEnabled() = 0;
 
  protected:
   virtual ~AudioSessionObserver() {}


### PR DESCRIPTION
- Restart AudioUnit any time category changes between mic-using-category / non-mic-using category
- Rename symbols