### PR TITLE
h264 encoder patch

### DIFF
--- a/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -387,8 +387,8 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
 - (NSInteger)encode:(RTC_OBJC_TYPE(RTCVideoFrame) *)frame
     codecSpecificInfo:(nullable id<RTC_OBJC_TYPE(RTCCodecSpecificInfo)>)codecSpecificInfo
            frameTypes:(NSArray<NSNumber *> *)frameTypes {
-  RTC_DCHECK_EQ(frame.width, _width);
-  RTC_DCHECK_EQ(frame.height, _height);
+  // RTC_DCHECK_EQ(frame.width, _width);
+  // RTC_DCHECK_EQ(frame.height, _height);
   if (!_callback || !_compressionSession) {
     return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
   }
@@ -559,6 +559,7 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
   OSType framePixelFormat = [self pixelFormatOfFrame:frame];
 
   if (_compressionSession) {
+    _pixelBufferPool = VTCompressionSessionGetPixelBufferPool(_compressionSession);
     // The pool attribute `kCVPixelBufferPixelFormatTypeKey` can contain either an array of pixel
     // formats or a single pixel format.
     NSDictionary *poolAttributes =


### PR DESCRIPTION
Applies h264 encoder patch to prevent segmentation fault when downgrading simulcast.

Credit to the following patches
https://github.com/shiguredo-webrtc-build/webrtc-build/blob/master/patches/macos_simulcast.patch
https://github.com/shiguredo-webrtc-build/webrtc-build/blob/master/patches/macos_h264_encoder.patch

