### PR TITLE
Change AVAudioSession defaults to iOS defaults

### DIFF
--- a/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
+++ b/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
@@ -69,11 +69,11 @@ static RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *gWebRTCConfiguration = nil;
     // By default, using this category implies that our app’s audio is
     // nonmixable, hence activating the session will interrupt any other
     // audio sessions which are also nonmixable.
-    _category = AVAudioSessionCategoryPlayAndRecord;
-    _categoryOptions = AVAudioSessionCategoryOptionAllowBluetooth;
+    _category = AVAudioSessionCategorySoloAmbient;
+    _categoryOptions = 0;
 
     // Specify mode for two-way voice communication (e.g. VoIP).
-    _mode = AVAudioSessionModeVoiceChat;
+    _mode = AVAudioSessionModeDefault;
 
     // Set the session's sample rate or the hardware sample rate.
     // It is essential that we use the same sample rate as stream format


### PR DESCRIPTION
Currently, the default category is `AVAudioSessionCategoryPlayAndRecord` which will automatically turn-on the microphone **even for listen/view-only cases**.

Instead of forcing developer to use `playAndRecord`, developer should be responsible to set the relevant category, which will result mic to turn on if `playAndRecord` or `record` is used. (PR https://github.com/webrtc-sdk/webrtc/pull/5)

This PR sets the defaults to iOS defaults.

https://developer.apple.com/documentation/avfaudio/avaudiosession/capturing_stereo_audio_from_built-in_microphones
