### PR TITLE
Sync audio session config

### DIFF
--- a/sdk/objc/components/audio/RTCAudioSession+Private.h
+++ b/sdk/objc/components/audio/RTCAudioSession+Private.h
@@ -35,9 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, assign) BOOL isInterrupted;
 
-/** if the current category could allow recording */
-@property(nonatomic, assign) BOOL isRecordingEnabled;
-
 @property(nonatomic, strong) NSString *activeCategory;
 
 /** Adds the delegate to the list of delegates, and places it at the front of

--- a/sdk/objc/components/audio/RTCAudioSession+Private.h
+++ b/sdk/objc/components/audio/RTCAudioSession+Private.h
@@ -38,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** if the current category could allow recording */
 @property(nonatomic, assign) BOOL isRecordingEnabled;
 
+@property(nonatomic, strong) NSString *activeCategory;
+
 /** Adds the delegate to the list of delegates, and places it at the front of
  *  the list. This delegate will be notified before other delegates of
  *  audio events.

--- a/sdk/objc/components/audio/RTCAudioSession.mm
+++ b/sdk/objc/components/audio/RTCAudioSession.mm
@@ -103,8 +103,6 @@ NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
                   options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
                   context:(__bridge void *)RTC_OBJC_TYPE(RTCAudioSession).class];
 
-    _isRecordingEnabled = [self sessionCategoryIsRecordingEnabled];
-
     _activeCategory = _session.category;
 
     RTCLog(@"RTC_OBJC_TYPE(RTCAudioSession) (%p): init.", self);
@@ -496,14 +494,7 @@ NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
     case AVAudioSessionRouteChangeReasonCategoryChange:
       RTCLog(@"Audio route changed: CategoryChange to :%@", self.session.category);
       {
-        // webRTCConfiguration is used by configureWebRTCSession
-        RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *webRTCConfig = [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) webRTCConfiguration];
-        webRTCConfig.category = _session.category;
-        webRTCConfig.categoryOptions = _session.categoryOptions;
-        webRTCConfig.mode = _session.mode;
-
         if (![_session.category isEqualToString:_activeCategory]) {
-          _isRecordingEnabled = [self sessionCategoryIsRecordingEnabled];
           _activeCategory = _session.category;
           RTCLog(@"Audio route changed: Restarting Audio Unit");
           [self notifyDidChangeAudioSessionRecordingEnabled];
@@ -721,7 +712,6 @@ NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
   }
   RTCLog(@"Unconfiguring audio session for WebRTC.");
   [self setActive:NO error:outError];
-  _isRecordingEnabled = NO;
 
   return YES;
 }
@@ -941,11 +931,6 @@ NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
       [delegate audioSessionDidChangeRecordingEnabled:self];
     }
   }
-}
-
--(BOOL)sessionCategoryIsRecordingEnabled {
-  return [_session.category isEqualToString:AVAudioSessionCategoryPlayAndRecord] || 
-    [_session.category isEqualToString:AVAudioSessionCategoryRecord];
 }
 
 @end

--- a/sdk/objc/components/audio/RTCAudioSession.mm
+++ b/sdk/objc/components/audio/RTCAudioSession.mm
@@ -105,6 +105,8 @@ NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
 
     _isRecordingEnabled = [self sessionCategoryIsRecordingEnabled];
 
+    _activeCategory = _session.category;
+
     RTCLog(@"RTC_OBJC_TYPE(RTCAudioSession) (%p): init.", self);
   }
   return self;
@@ -494,9 +496,16 @@ NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
     case AVAudioSessionRouteChangeReasonCategoryChange:
       RTCLog(@"Audio route changed: CategoryChange to :%@", self.session.category);
       {
-        BOOL newValue = [self sessionCategoryIsRecordingEnabled];
-        if (_isRecordingEnabled != newValue) {
-          _isRecordingEnabled = newValue;
+        // webRTCConfiguration is used by configureWebRTCSession
+        RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *webRTCConfig = [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) webRTCConfiguration];
+        webRTCConfig.category = _session.category;
+        webRTCConfig.categoryOptions = _session.categoryOptions;
+        webRTCConfig.mode = _session.mode;
+
+        if (![_session.category isEqualToString:_activeCategory]) {
+          _isRecordingEnabled = [self sessionCategoryIsRecordingEnabled];
+          _activeCategory = _session.category;
+          RTCLog(@"Audio route changed: Restarting Audio Unit");
           [self notifyDidChangeAudioSessionRecordingEnabled];
         }
       }

--- a/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
+++ b/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
@@ -65,15 +65,17 @@ static RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *gWebRTCConfiguration = nil;
 
 - (instancetype)init {
   if (self = [super init]) {
+    // Use AVAudioSession values for default
+    AVAudioSession *session = [AVAudioSession sharedInstance];
     // Use a category which supports simultaneous recording and playback.
     // By default, using this category implies that our app’s audio is
     // nonmixable, hence activating the session will interrupt any other
     // audio sessions which are also nonmixable.
-    _category = AVAudioSessionCategorySoloAmbient;
-    _categoryOptions = 0;
+    _category = session.category;
+    _categoryOptions = session.categoryOptions;
 
     // Specify mode for two-way voice communication (e.g. VoIP).
-    _mode = AVAudioSessionModeDefault;
+    _mode = session.mode;
 
     // Set the session's sample rate or the hardware sample rate.
     // It is essential that we use the same sample rate as stream format


### PR DESCRIPTION
### Fixes Issue
Mic doesn't turn on when there are no remote audio tracks.
This does fix the issue but I'm not satisfied with it, there might be more changes.

### Changes

1. Use AVAudioSession values when initializing `RTCAudioSessionConfiguration`.
2. Always restart AudioUnit when category changes.
for example, .playAndRecord -> .record didn't restart it before this change.

~~2. Update `RTCAudioSessionConfiguration.webRTCConfiguration` when category changes.
Internally, `configureWebRTCSession` is called and `RTCAudioSessionConfiguration.webRTCConfiguration` is referenced. The values must be in sync with AVAudioSession for expected behavior.~~
