### PR TITLE
[Windows] Fixed the audio capture issue when the built-in AEC enabled

### DIFF
--- a/audio/audio_state.cc
+++ b/audio/audio_state.cc
@@ -104,6 +104,14 @@ void AudioState::AddSendingStream(webrtc::AudioSendStream* stream,
   if (!adm->Recording()) {
     if (adm->InitRecording() == 0) {
       if (recording_enabled_) {
+#if defined(WEBRTC_WIN)
+        if (adm->BuiltInAECIsAvailable() && !adm->Playing()) {
+          if (!adm->PlayoutIsInitialized()) {
+            adm->InitPlayout();
+          }
+          adm->StartPlayout();
+        }
+#endif
         adm->StartRecording();
       }
     } else {

--- a/modules/audio_device/win/audio_device_core_win.cc
+++ b/modules/audio_device/win/audio_device_core_win.cc
@@ -2356,7 +2356,7 @@ int32_t AudioDeviceWindowsCore::StartRecording() {
       }
     }
 
-    RTC_DCHECK(_hRecThread);
+    RTC_DCHECK(_hRecThread == NULL);
     _hRecThread = CreateThread(NULL, 0, lpStartAddress, this, 0, NULL);
     if (_hRecThread == NULL) {
       RTC_LOG(LS_ERROR) << "failed to create the recording thread";
@@ -2493,7 +2493,7 @@ int32_t AudioDeviceWindowsCore::StartPlayout() {
     MutexLock lockScoped(&mutex_);
 
     // Create thread which will drive the rendering.
-    RTC_DCHECK(_hPlayThread);
+    RTC_DCHECK(_hPlayThread == NULL);
     _hPlayThread = CreateThread(NULL, 0, WSAPIRenderThread, this, 0, NULL);
     if (_hPlayThread == NULL) {
       RTC_LOG(LS_ERROR) << "failed to create the playout thread";


### PR DESCRIPTION
Fixed the issue when the built-in AEC is valid under Windows, the mic cannot be captured when StartRecording is called before StartPlayout.

Trigger conditions for this bug:
1, windows and supports built-in AEC enabled
2. StartRecording is called before StartPlayOut, such as SendOnly mode, or AudioSendStream is enabled before AudioRecvStream

The raised issue, unable to capture mic and no audio stream sent
