### PR TITLE
Start/Stop receiving stream method for VideoTrack

### DIFF
--- a/api/media_stream_interface.cc
+++ b/api/media_stream_interface.cc
@@ -18,6 +18,10 @@ const char* const MediaStreamTrackInterface::kVideoKind =
 const char* const MediaStreamTrackInterface::kAudioKind =
     cricket::kMediaTypeAudio;
 
+bool VideoTrackInterface::should_receive() const {
+  return true;
+}
+
 VideoTrackInterface::ContentHint VideoTrackInterface::content_hint() const {
   return ContentHint::kNone;
 }

--- a/api/media_stream_interface.h
+++ b/api/media_stream_interface.h
@@ -188,6 +188,8 @@ class RTC_EXPORT VideoTrackInterface
 
   virtual VideoTrackSourceInterface* GetSource() const = 0;
 
+  virtual void set_should_receive(bool should_receive) {}
+  virtual bool should_receive() const;
   virtual ContentHint content_hint() const;
   virtual void set_content_hint(ContentHint hint) {}
 

--- a/media/base/media_channel.h
+++ b/media/base/media_channel.h
@@ -897,6 +897,9 @@ class VideoMediaChannel : public MediaChannel, public Delayable {
   virtual void GenerateKeyFrame(uint32_t ssrc) = 0;
 
   virtual std::vector<webrtc::RtpSource> GetSources(uint32_t ssrc) const = 0;
+
+  virtual void StartReceive(uint32_t ssrc) {}
+  virtual void StopReceive(uint32_t ssrc) {}
 };
 
 // Info about data received in DataMediaChannel.  For use in

--- a/media/engine/webrtc_video_engine.cc
+++ b/media/engine/webrtc_video_engine.cc
@@ -949,6 +949,26 @@ void WebRtcVideoChannel::RequestEncoderSwitch(
                       << format.ToString() << " not negotiated.";
 }
 
+void WebRtcVideoChannel::StartReceive(uint32_t ssrc) {
+  RTC_DCHECK_RUN_ON(&thread_checker_);
+  RTC_LOG(LS_WARNING) << "WebRtcVideoChannel::StartReceive";
+  WebRtcVideoReceiveStream* stream = FindReceiveStream(ssrc);
+  if(!stream) {
+    return;
+  }
+  stream->StartStream();
+}
+
+void WebRtcVideoChannel::StopReceive(uint32_t ssrc) {
+  RTC_DCHECK_RUN_ON(&thread_checker_);
+  RTC_LOG(LS_WARNING) << "WebRtcVideoChannel::StopReceive";
+  WebRtcVideoReceiveStream* stream = FindReceiveStream(ssrc);
+  if(!stream) {
+    return;
+  }
+  stream->StopStream();
+}
+
 bool WebRtcVideoChannel::ApplyChangedParams(
     const ChangedSendParameters& changed_params) {
   RTC_DCHECK_RUN_ON(&thread_checker_);
@@ -3014,6 +3034,19 @@ void WebRtcVideoChannel::WebRtcVideoReceiveStream::SetRecvParameters(
   }
   if (video_needs_recreation) {
     RecreateWebRtcVideoStream();
+  }
+}
+
+void WebRtcVideoChannel::WebRtcVideoReceiveStream::StartStream(){
+  RTC_LOG(LS_ERROR) << "WebRtcVideoChannel::WebRtcVideoReceiveStream::StartStream";
+  if (stream_) {
+    stream_->Start();
+  }
+}
+void WebRtcVideoChannel::WebRtcVideoReceiveStream::StopStream(){
+  RTC_LOG(LS_ERROR) << "WebRtcVideoChannel::WebRtcVideoReceiveStream::StopStream";
+  if (stream_) {
+    stream_->Stop();
   }
 }
 

--- a/media/engine/webrtc_video_engine.cc
+++ b/media/engine/webrtc_video_engine.cc
@@ -951,7 +951,6 @@ void WebRtcVideoChannel::RequestEncoderSwitch(
 
 void WebRtcVideoChannel::StartReceive(uint32_t ssrc) {
   RTC_DCHECK_RUN_ON(&thread_checker_);
-  RTC_LOG(LS_WARNING) << "WebRtcVideoChannel::StartReceive";
   WebRtcVideoReceiveStream* stream = FindReceiveStream(ssrc);
   if(!stream) {
     return;
@@ -961,7 +960,6 @@ void WebRtcVideoChannel::StartReceive(uint32_t ssrc) {
 
 void WebRtcVideoChannel::StopReceive(uint32_t ssrc) {
   RTC_DCHECK_RUN_ON(&thread_checker_);
-  RTC_LOG(LS_WARNING) << "WebRtcVideoChannel::StopReceive";
   WebRtcVideoReceiveStream* stream = FindReceiveStream(ssrc);
   if(!stream) {
     return;
@@ -3038,13 +3036,11 @@ void WebRtcVideoChannel::WebRtcVideoReceiveStream::SetRecvParameters(
 }
 
 void WebRtcVideoChannel::WebRtcVideoReceiveStream::StartStream(){
-  RTC_LOG(LS_ERROR) << "WebRtcVideoChannel::WebRtcVideoReceiveStream::StartStream";
   if (stream_) {
     stream_->Start();
   }
 }
 void WebRtcVideoChannel::WebRtcVideoReceiveStream::StopStream(){
-  RTC_LOG(LS_ERROR) << "WebRtcVideoChannel::WebRtcVideoReceiveStream::StopStream";
   if (stream_) {
     stream_->Stop();
   }

--- a/media/engine/webrtc_video_engine.h
+++ b/media/engine/webrtc_video_engine.h
@@ -245,7 +245,8 @@ class WebRtcVideoChannel : public VideoMediaChannel,
       uint32_t ssrc,
       rtc::scoped_refptr<webrtc::FrameTransformerInterface> frame_transformer)
       override;
-
+  void StartReceive(uint32_t ssrc) override;
+  void StopReceive(uint32_t ssrc) override;
  private:
   class WebRtcVideoReceiveStream;
 
@@ -479,6 +480,9 @@ class WebRtcVideoChannel : public VideoMediaChannel,
     void SetDepacketizerToDecoderFrameTransformer(
         rtc::scoped_refptr<webrtc::FrameTransformerInterface>
             frame_transformer);
+    
+    void StartStream();
+    void StopStream();
 
    private:
     void RecreateWebRtcVideoStream();

--- a/modules/video_coding/frame_buffer2.cc
+++ b/modules/video_coding/frame_buffer2.cc
@@ -356,6 +356,13 @@ void FrameBuffer::SetProtectionMode(VCMVideoProtection mode) {
   protection_mode_ = mode;
 }
 
+void FrameBuffer::Start() {
+  TRACE_EVENT0("webrtc", "FrameBuffer::Stop");
+  MutexLock lock(&mutex_);
+  if (!stopped_)
+    return;
+  stopped_ = false;
+}
 void FrameBuffer::Stop() {
   TRACE_EVENT0("webrtc", "FrameBuffer::Stop");
   MutexLock lock(&mutex_);

--- a/modules/video_coding/frame_buffer2.h
+++ b/modules/video_coding/frame_buffer2.h
@@ -78,6 +78,8 @@ class FrameBuffer {
   // Stop the frame buffer, causing any sleeping thread in NextFrame to
   // return immediately.
   void Stop();
+  // Unstop the frame buffer, re-allowing new frames to be inserted and read.
+  void Start();
 
   // Updates the RTT for jitter buffer estimation.
   void UpdateRtt(int64_t rtt_ms);

--- a/pc/media_stream_track_proxy.h
+++ b/pc/media_stream_track_proxy.h
@@ -54,6 +54,8 @@ PROXY_SECONDARY_METHOD2(void,
                         const rtc::VideoSinkWants&)
 PROXY_SECONDARY_METHOD1(void, RemoveSink, rtc::VideoSinkInterface<VideoFrame>*)
 BYPASS_PROXY_CONSTMETHOD0(VideoTrackSourceInterface*, GetSource)
+PROXY_CONSTMETHOD0(bool, should_receive)
+PROXY_METHOD1(void, set_should_receive, bool)
 
 PROXY_METHOD1(void, RegisterObserver, ObserverInterface*)
 PROXY_METHOD1(void, UnregisterObserver, ObserverInterface*)

--- a/pc/media_stream_track_proxy.h
+++ b/pc/media_stream_track_proxy.h
@@ -44,10 +44,10 @@ PROXY_PRIMARY_THREAD_DESTRUCTOR()
 BYPASS_PROXY_CONSTMETHOD0(std::string, kind)
 BYPASS_PROXY_CONSTMETHOD0(std::string, id)
 PROXY_SECONDARY_CONSTMETHOD0(TrackState, state)
-PROXY_SECONDARY_CONSTMETHOD0(bool, enabled)
-PROXY_SECONDARY_METHOD1(bool, set_enabled, bool)
-PROXY_SECONDARY_CONSTMETHOD0(ContentHint, content_hint)
-PROXY_SECONDARY_METHOD1(void, set_content_hint, ContentHint)
+PROXY_CONSTMETHOD0(bool, enabled)
+PROXY_METHOD1(bool, set_enabled, bool)
+PROXY_CONSTMETHOD0(ContentHint, content_hint)
+PROXY_METHOD1(void, set_content_hint, ContentHint)
 PROXY_SECONDARY_METHOD2(void,
                         AddOrUpdateSink,
                         rtc::VideoSinkInterface<VideoFrame>*,

--- a/pc/rtp_sender.cc
+++ b/pc/rtp_sender.cc
@@ -584,10 +584,13 @@ VideoRtpSender::~VideoRtpSender() {
 }
 
 void VideoRtpSender::OnChanged() {
+  // Running on the signaling thread.
   TRACE_EVENT0("webrtc", "VideoRtpSender::OnChanged");
   RTC_DCHECK(!stopped_);
-  if (cached_track_content_hint_ != video_track()->content_hint()) {
-    cached_track_content_hint_ = video_track()->content_hint();
+
+  auto content_hint = video_track()->content_hint();
+  if (cached_track_content_hint_ != content_hint) {
+    cached_track_content_hint_ = content_hint;
     if (can_send_track()) {
       SetSend();
     }

--- a/pc/video_rtp_receiver.cc
+++ b/pc/video_rtp_receiver.cc
@@ -53,7 +53,6 @@ VideoRtpReceiver::VideoRtpReceiver(
   RTC_DCHECK(worker_thread_);
   SetStreams(streams);
   track_->RegisterObserver(this);
-  RTC_LOG(LS_ERROR) << "VideoRtpReceiver::VideoRtpReceiver called, id = " << receiver_id;
   RTC_DCHECK_EQ(source_->state(), MediaSourceInterface::kLive);
 }
 
@@ -143,8 +142,6 @@ void VideoRtpReceiver::StopAndEndTrack() {
 }
 
 void VideoRtpReceiver::OnChanged() {
-  RTC_LOG(LS_ERROR) << "VideoRtpReceiver::OnChanged::id" << id() << ": signaling: " << (&signaling_thread_checker_)->IsCurrent();
-  RTC_LOG(LS_ERROR) << "VideoRtpReceiver::OnChanged::id" << id() << ": worker: " << (worker_thread_)->IsCurrent();
   RTC_DCHECK_RUN_ON(&signaling_thread_checker_);
   if (cached_track_should_receive_ != track_->should_receive()) {
     cached_track_should_receive_ = track_->should_receive();
@@ -161,9 +158,7 @@ void VideoRtpReceiver::OnChanged() {
   }
 }
 
-void VideoRtpReceiver::StartMediaChannel() {
-  RTC_LOG(LS_ERROR) << "VideoRtpReceiver::StartMediaChannel id = " << id();
-  
+void VideoRtpReceiver::StartMediaChannel() {  
   RTC_DCHECK_RUN_ON(worker_thread_);
   if (!media_channel_) {
     return;
@@ -172,7 +167,6 @@ void VideoRtpReceiver::StartMediaChannel() {
   OnGenerateKeyFrame();
 }
 void VideoRtpReceiver::StopMediaChannel() {
-  RTC_LOG(LS_ERROR) << "VideoRtpReceiver::StopMediaChannelid = " << id();
   RTC_DCHECK_RUN_ON(worker_thread_);
   if (!media_channel_) {
     return;
@@ -278,10 +272,6 @@ void VideoRtpReceiver::set_transport(
 void VideoRtpReceiver::SetStreams(
     const std::vector<rtc::scoped_refptr<MediaStreamInterface>>& streams) {
   RTC_DCHECK_RUN_ON(&signaling_thread_checker_);
-
-  for (size_t i = 0; i < streams.size(); ++i) {
-    RTC_LOG(LS_ERROR) << id() << ": stream_id: " << streams[i]->id();
-  }
   
   // Remove remote track from any streams that are going away.
   for (const auto& existing_stream : streams_) {

--- a/pc/video_rtp_receiver.cc
+++ b/pc/video_rtp_receiver.cc
@@ -339,10 +339,6 @@ void VideoRtpReceiver::SetMediaChannel(cricket::MediaChannel* media_channel) {
 void VideoRtpReceiver::SetMediaChannel_w(cricket::MediaChannel* media_channel) {
   if (media_channel == media_channel_)
     return;
-  
-  RTC_LOG(LS_ERROR)
-        << "VideoRtpReceiver::SetMediaChannel_w: " << typeid(media_channel).name();
-    
   bool encoded_sink_enabled = saved_encoded_sink_enabled_;
   if (encoded_sink_enabled && media_channel_) {
     // Turn off the old sink, if any.

--- a/pc/video_rtp_receiver.h
+++ b/pc/video_rtp_receiver.h
@@ -173,7 +173,7 @@ class VideoRtpReceiver : public RtpReceiverInternal,
   bool received_first_packet_ RTC_GUARDED_BY(&signaling_thread_checker_) =
       false;
 
-  bool cached_track_enabled_ RTC_GUARDED_BY(&signaling_thread_checker_);
+  bool cached_track_should_receive_ RTC_GUARDED_BY(&signaling_thread_checker_);
   const int attachment_id_;
   rtc::scoped_refptr<FrameDecryptorInterface> frame_decryptor_
       RTC_GUARDED_BY(worker_thread_);

--- a/pc/video_rtp_receiver.h
+++ b/pc/video_rtp_receiver.h
@@ -115,7 +115,6 @@ class VideoRtpReceiver : public RtpReceiverInternal,
   std::vector<RtpSource> GetSources() const override;
 
  private:
-
   void StartMediaChannel();
   void StopMediaChannel();
   void RestartMediaChannel(absl::optional<uint32_t> ssrc);

--- a/pc/video_track.cc
+++ b/pc/video_track.cc
@@ -116,15 +116,9 @@ MediaStreamTrackInterface::TrackState VideoTrack::state() const {
 
 void VideoTrack::OnChanged() {
   RTC_DCHECK_RUN_ON(&signaling_thread_);
-  worker_thread_->Invoke<void>(
-      RTC_FROM_HERE, [this, state = video_source_->state()]() {
-        // TODO(tommi): Calling set_state() this way isn't ideal since we're
-        // currently blocking the signaling thread and set_state() may
-        // internally fire notifications via `FireOnChanged()` which may further
-        // amplify the blocking effect on the signaling thread.
-        rtc::Thread::ScopedDisallowBlockingCalls no_blocking_calls;
-        set_state(state == MediaSourceInterface::kEnded ? kEnded : kLive);
-      });
+  rtc::Thread::ScopedDisallowBlockingCalls no_blocking_calls;
+  MediaSourceInterface::SourceState state = video_source_->state();
+  set_state(state == MediaSourceInterface::kEnded ? kEnded : kLive);
 }
 
 rtc::scoped_refptr<VideoTrack> VideoTrack::Create(

--- a/pc/video_track.cc
+++ b/pc/video_track.cc
@@ -69,6 +69,19 @@ VideoTrackSourceInterface* VideoTrack::GetSource() const {
   return video_source_.get();
 }
 
+void VideoTrack::set_should_receive(bool receive) {
+  RTC_DCHECK_RUN_ON(&signaling_thread_);
+  if (should_receive_ == receive)
+    return;
+  should_receive_ = receive;
+  Notifier<VideoTrackInterface>::FireOnChanged();
+}
+
+bool VideoTrack::should_receive() const {
+  RTC_DCHECK_RUN_ON(&signaling_thread_);
+  return should_receive_;
+}
+
 VideoTrackInterface::ContentHint VideoTrack::content_hint() const {
   RTC_DCHECK_RUN_ON(&signaling_thread_);
   return content_hint_;

--- a/pc/video_track.h
+++ b/pc/video_track.h
@@ -60,7 +60,12 @@ class VideoTrack : public MediaStreamTrack<VideoTrackInterface>,
   RTC_NO_UNIQUE_ADDRESS webrtc::SequenceChecker signaling_thread_;
   rtc::Thread* const worker_thread_;
   const rtc::scoped_refptr<VideoTrackSourceInterface> video_source_;
-  ContentHint content_hint_ RTC_GUARDED_BY(worker_thread_);
+  ContentHint content_hint_ RTC_GUARDED_BY(signaling_thread_);
+  // Cached `enabled` state for the worker thread. This is kept in sync with
+  // the state maintained on the signaling thread via set_enabled() but can
+  // be queried without blocking on the worker thread by callers that don't
+  // use an api proxy to call the `enabled()` method.
+  bool enabled_w_ RTC_GUARDED_BY(worker_thread_) = true;
 };
 
 }  // namespace webrtc

--- a/pc/video_track.h
+++ b/pc/video_track.h
@@ -40,6 +40,9 @@ class VideoTrack : public MediaStreamTrack<VideoTrackInterface>,
   void RemoveSink(rtc::VideoSinkInterface<VideoFrame>* sink) override;
   VideoTrackSourceInterface* GetSource() const override;
 
+  void set_should_receive(bool should_receive) override;
+  bool should_receive() const override;
+
   ContentHint content_hint() const override;
   void set_content_hint(ContentHint hint) override;
   bool set_enabled(bool enable) override;
@@ -66,6 +69,7 @@ class VideoTrack : public MediaStreamTrack<VideoTrackInterface>,
   // be queried without blocking on the worker thread by callers that don't
   // use an api proxy to call the `enabled()` method.
   bool enabled_w_ RTC_GUARDED_BY(worker_thread_) = true;
+  bool should_receive_ RTC_GUARDED_BY(signaling_thread_) = true;
 };
 
 }  // namespace webrtc

--- a/sdk/android/api/org/webrtc/VideoTrack.java
+++ b/sdk/android/api/org/webrtc/VideoTrack.java
@@ -55,18 +55,18 @@ public class VideoTrack extends MediaStreamTrack {
   }
 
   /**
-   * For a remote video track, starts receiving the video stream.
+   * For a remote video track, starts/stops receiving the video stream.
    * 
-   * If the VideoTrack was already receiving, this is a no-op.
+   * If this is a local video track, this is a no-op.
    */
   public void setShouldReceive(boolean shouldReceive){
     nativeSetShouldReceive(getNativeMediaStreamTrack(), shouldReceive);
   }
 
   /**
-   * For a remote video track, stops receiving the video stream.
+   * The current receive status for a remote video track.
    * 
-   * If the VideoTrack was already receiving, this is a no-op.
+   * This has no meaning for a local video track.
    */
   public boolean shouldReceive(){
     return nativeGetShouldReceive(getNativeMediaStreamTrack());

--- a/sdk/android/api/org/webrtc/VideoTrack.java
+++ b/sdk/android/api/org/webrtc/VideoTrack.java
@@ -54,6 +54,24 @@ public class VideoTrack extends MediaStreamTrack {
     }
   }
 
+  /**
+   * For a remote video track, starts receiving the video stream.
+   * 
+   * If the VideoTrack was already receiving, this is a no-op.
+   */
+  public void setShouldReceive(boolean shouldReceive){
+    nativeSetShouldReceive(getNativeMediaStreamTrack(), shouldReceive);
+  }
+
+  /**
+   * For a remote video track, stops receiving the video stream.
+   * 
+   * If the VideoTrack was already receiving, this is a no-op.
+   */
+  public boolean shouldReceive(){
+    return nativeGetShouldReceive(getNativeMediaStreamTrack());
+  }
+
   @Override
   public void dispose() {
     for (long nativeSink : sinks.values()) {
@@ -73,4 +91,6 @@ public class VideoTrack extends MediaStreamTrack {
   private static native void nativeRemoveSink(long track, long nativeSink);
   private static native long nativeWrapSink(VideoSink sink);
   private static native void nativeFreeSink(long sink);
+  private static native void nativeSetShouldReceive(long track, boolean shouldReceive);
+  private static native boolean nativeGetShouldReceive(long track);
 }

--- a/sdk/android/src/jni/video_track.cc
+++ b/sdk/android/src/jni/video_track.cc
@@ -45,5 +45,16 @@ static void JNI_VideoTrack_FreeSink(JNIEnv* jni,
   delete reinterpret_cast<rtc::VideoSinkInterface<VideoFrame>*>(j_native_sink);
 }
 
+static void JNI_VideoTrack_SetShouldReceive(JNIEnv* jni,
+                                      jlong j_native_track,
+                                      jboolean should_receive) {
+  reinterpret_cast<VideoTrackInterface*>(j_native_track)->set_should_receive(should_receive);
+}
+
+static jboolean JNI_VideoTrack_GetShouldReceive(JNIEnv* jni,
+                                      jlong j_native_track) {
+  return reinterpret_cast<VideoTrackInterface*>(j_native_track)->should_receive();
+}
+
 }  // namespace jni
 }  // namespace webrtc

--- a/sdk/objc/api/peerconnection/RTCVideoTrack.h
+++ b/sdk/objc/api/peerconnection/RTCVideoTrack.h
@@ -25,6 +25,9 @@ RTC_OBJC_EXPORT
 /** The video source for this video track. */
 @property(nonatomic, readonly) RTC_OBJC_TYPE(RTCVideoSource) *source;
 
+/** The receive state, if this is a remote video track. */
+@property(nonatomic, assign) BOOL shouldReceive;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 /** Register a renderer that will render all frames received on this track. */

--- a/sdk/objc/api/peerconnection/RTCVideoTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCVideoTrack.mm
@@ -69,6 +69,14 @@
   return _source;
 }
 
+- (BOOL)shouldReceive {
+  return _nativeTrack->shouldReceive();
+}
+
+- (void)setShouldReceive:(BOOL)shouldReceive {
+  _nativeTrack->set_should_receive(shouldReceive);
+}
+
 - (void)addRenderer:(id<RTC_OBJC_TYPE(RTCVideoRenderer)>)renderer {
   // Make sure we don't have this renderer yet.
   for (RTCVideoRendererAdapter *adapter in _adapters) {

--- a/sdk/objc/api/peerconnection/RTCVideoTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCVideoTrack.mm
@@ -70,11 +70,11 @@
 }
 
 - (BOOL)shouldReceive {
-  return _nativeTrack->shouldReceive();
+  return self.nativeVideoTrack->should_receive();
 }
 
 - (void)setShouldReceive:(BOOL)shouldReceive {
-  _nativeTrack->set_should_receive(shouldReceive);
+  self.nativeVideoTrack->set_should_receive(shouldReceive);
 }
 
 - (void)addRenderer:(id<RTC_OBJC_TYPE(RTCVideoRenderer)>)renderer {

--- a/video/video_receive_stream2.cc
+++ b/video/video_receive_stream2.cc
@@ -337,8 +337,7 @@ void VideoReceiveStream2::Start() {
     return;
   }
 
-  frame_buffer_.reset(
-      new video_coding::FrameBuffer(clock_, timing_.get(), &stats_proxy_));
+  frame_buffer_->Start();
   const bool protected_by_fec = config_.rtp.protected_by_flexfec ||
                                 rtp_video_stream_receiver_.IsUlpfecEnabled();
 

--- a/video/video_receive_stream2.cc
+++ b/video/video_receive_stream2.cc
@@ -337,6 +337,8 @@ void VideoReceiveStream2::Start() {
     return;
   }
 
+  frame_buffer_.reset(
+      new video_coding::FrameBuffer(clock_, timing_.get(), &stats_proxy_));
   const bool protected_by_fec = config_.rtp.protected_by_flexfec ||
                                 rtp_video_stream_receiver_.IsUlpfecEnabled();
 


### PR DESCRIPTION
Used to mitigate decoder limitations (android crashes if there are too many decoders, iOS freezes up).