### PR TITLE
[Windows] Fix can't open mic alone when built-in AEC is enabled.

### DIFF
--- a/audio/audio_state.cc
+++ b/audio/audio_state.cc
@@ -104,6 +104,14 @@ void AudioState::AddSendingStream(webrtc::AudioSendStream* stream,
   if (!adm->Recording()) {
     if (adm->InitRecording() == 0) {
       if (recording_enabled_) {
+#if defined(WEBRTC_WIN)
+        if (adm->BuiltInAECIsAvailable() && !adm->Playing()) {
+          if (!adm->PlayoutIsInitialized()) {
+            adm->InitPlayout();
+          }
+          adm->StartPlayout();
+        }
+#endif
         adm->StartRecording();
       }
     } else {


### PR DESCRIPTION
Fixed the issue when the built-in AEC is valid under Windows, the mic cannot be captured when StartRecording is called before StartPlayout.

Trigger conditions for this bug:
1, windows and supports built-in AEC enabled
2. StartRecording is called before StartPlayOut, such as SendOnly mode, or AudioSendStream is enabled before AudioRecvStream

The raised issue, unable to capture mic and no audio stream sent