### PR TITLE
Fix: rotationOverride should not be assign

### DIFF
--- a/sdk/objc/components/renderer/metal/RTCMTLVideoView.h
+++ b/sdk/objc/components/renderer/metal/RTCMTLVideoView.h
@@ -53,7 +53,7 @@ RTC_OBJC_EXPORT
 
 /** @abstract Wrapped RTCVideoRotation, or nil.
  */
-@property(nonatomic, assign, nullable) NSValue* rotationOverride;
+@property(nonatomic, nullable) NSValue* rotationOverride;
 
 + (BOOL)isMetalAvailable;
 


### PR DESCRIPTION
I shouldn't have changed `rotationOverride` property to **assign**. 
https://github.com/webrtc-sdk/webrtc/pull/40/files#diff-e109b4ed1ade961213b59bfbf1e06b7982988ef7426a012cc83dce7656af0ea1R56
