### PR TITLE
Added "stopped"  RtpTransceiverDirection value

### DIFF
--- a/sdk/android/api/org/webrtc/RtpTransceiver.java
+++ b/sdk/android/api/org/webrtc/RtpTransceiver.java
@@ -38,7 +38,8 @@ public class RtpTransceiver {
     SEND_RECV(0),
     SEND_ONLY(1),
     RECV_ONLY(2),
-    INACTIVE(3);
+    INACTIVE(3),
+    STOPPED(4);
 
     private final int nativeIndex;
 


### PR DESCRIPTION
[https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiverdirection](https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiverdirection)
According to the native api of webrtc added fifth argument to java implementation of this interface