### PR TITLE
fix: Restarting the playout without audio send streams makes the mic indicator off.

### DIFF
--- a/audio/audio_state.cc
+++ b/audio/audio_state.cc
@@ -124,6 +124,17 @@ void AudioState::RemoveSendingStream(webrtc::AudioSendStream* stream) {
   UpdateAudioTransportWithSendingStreams();
   if (sending_streams_.empty()) {
     config_.audio_device_module->StopRecording();
+#if defined(WEBRTC_IOS)
+    auto* adm = config_.audio_device_module.get();
+    if (adm->Playing()) {
+      adm->StopPlayout();
+      if (adm->InitPlayout() == 0) {
+        if (playout_enabled_) {
+          adm->StartPlayout();
+        }
+      }
+    }
+#endif
   }
 }
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -22,7 +22,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^RTCOnAudioDevicesDidUpdate)();
+typedef void (^RTCOnAudioDevicesDidUpdate)(void);
 
 RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCAudioDeviceModule) : NSObject

--- a/sdk/objc/components/audio/RTCAudioSession+Configuration.mm
+++ b/sdk/objc/components/audio/RTCAudioSession+Configuration.mm
@@ -16,8 +16,8 @@
 @implementation RTC_OBJC_TYPE (RTCAudioSession)
 (Configuration)
 
-    - (BOOL)setConfiguration : (RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *)configuration error
-    : (NSError **)outError {
+- (BOOL)setConfiguration: (RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *)configuration
+                   error: (NSError **)outError {
   return [self setConfiguration:configuration
                          active:NO
                 shouldSetActive:NO

--- a/sdk/objc/components/audio/RTCAudioSession+Private.h
+++ b/sdk/objc/components/audio/RTCAudioSession+Private.h
@@ -14,13 +14,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RTC_OBJC_TYPE(RTCAudioSessionConfiguration);
 
-@interface RTC_OBJC_TYPE (RTCAudioSession)
-()
+@interface RTC_OBJC_TYPE (RTCAudioSession)()
 
-    /** Number of times setActive:YES has succeeded without a balanced call to
-     *  setActive:NO.
-     */
-    @property(nonatomic, readonly) int activationCount;
+/** Number of times setActive:YES has succeeded without a balanced call to
+ *  setActive:NO.
+ */
+@property(nonatomic, readonly) int activationCount;
 
 /** The number of times `beginWebRTCSession` was called without a balanced call
  *  to `endWebRTCSession`.

--- a/sdk/objc/components/audio/RTCAudioSession.h
+++ b/sdk/objc/components/audio/RTCAudioSession.h
@@ -253,8 +253,8 @@ RTC_OBJC_EXPORT
      *  returned.
      *  `lockForConfiguration` must be called first.
      */
-    - (BOOL)setConfiguration : (RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *)configuration error
-    : (NSError **)outError;
+- (BOOL)setConfiguration: (RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *)configuration
+                   error: (NSError **)outError;
 
 /** Convenience method that calls both setConfiguration and setActive.
  *  `lockForConfiguration` must be called first.


### PR DESCRIPTION
fix: Restarting the playout without audio send streams makes the mic indicator off.