### PR TITLE
AudioUnit: Don't rely on category switch for mic indicator to turn off

### DIFF
--- a/sdk/objc/components/audio/RTCAudioSession+Private.h
+++ b/sdk/objc/components/audio/RTCAudioSession+Private.h
@@ -35,8 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, assign) BOOL isInterrupted;
 
-@property(nonatomic, strong) NSString *activeCategory;
-
 /** Adds the delegate to the list of delegates, and places it at the front of
  *  the list. This delegate will be notified before other delegates of
  *  audio events.

--- a/sdk/objc/components/audio/RTCAudioSession.h
+++ b/sdk/objc/components/audio/RTCAudioSession.h
@@ -102,9 +102,6 @@ RTC_OBJC_EXPORT
 - (void)audioSession:(RTC_OBJC_TYPE(RTCAudioSession) *)audioSession
     audioUnitStartFailedWithError:(NSError *)error;
 
-/** Called when audio session changed from output-only to input & output */
-- (void)audioSessionDidChangeRecordingEnabled:(RTC_OBJC_TYPE(RTCAudioSession) *)audioSession;
-
 @end
 
 /** This is a protocol used to inform RTCAudioSession when the audio session

--- a/sdk/objc/components/audio/RTCAudioSession.mm
+++ b/sdk/objc/components/audio/RTCAudioSession.mm
@@ -114,8 +114,6 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
                   options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
                   context:(__bridge void *)RTC_OBJC_TYPE(RTCAudioSession).class];
 
-    _activeCategory = _session.category;
-
     RTCLog(@"RTC_OBJC_TYPE(RTCAudioSession) (%p): init.", self);
   }
   return self;
@@ -543,13 +541,6 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
       break;
     case AVAudioSessionRouteChangeReasonCategoryChange:
       RTCLog(@"Audio route changed: CategoryChange to :%@", self.session.category);
-      {
-        if (![_session.category isEqualToString:_activeCategory]) {
-          _activeCategory = _session.category;
-          RTCLog(@"Audio route changed: Restarting Audio Unit");
-          [self notifyDidChangeAudioSessionRecordingEnabled];
-        }
-      }
       break;
     case AVAudioSessionRouteChangeReasonOverride:
       RTCLog(@"Audio route changed: Override");
@@ -1001,15 +992,6 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
     SEL sel = @selector(audioSession:failedToSetActive:error:);
     if ([delegate respondsToSelector:sel]) {
       [delegate audioSession:self failedToSetActive:active error:error];
-    }
-  }
-}
-
-- (void)notifyDidChangeAudioSessionRecordingEnabled {
-  for (auto delegate : self.delegates) {
-    SEL sel = @selector(audioSessionDidChangeRecordingEnabled:);
-    if ([delegate respondsToSelector:sel]) {
-      [delegate audioSessionDidChangeRecordingEnabled:self];
     }
   }
 }

--- a/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
+++ b/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
@@ -86,9 +86,4 @@
   _observer->OnChangedOutputVolume();
 }
 
-- (void)audioSessionDidChangeRecordingEnabled:(RTC_OBJC_TYPE(RTCAudioSession) *)session {
-  // re-trigger audio unit init, by using interrupt ended callback
-  _observer->OnChangedRecordingEnabled();
-}
-
 @end

--- a/sdk/objc/native/src/audio/audio_device_ios.h
+++ b/sdk/objc/native/src/audio/audio_device_ios.h
@@ -147,7 +147,6 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
   void OnValidRouteChange() override;
   void OnCanPlayOrRecordChange(bool can_play_or_record) override;
   void OnChangedOutputVolume() override;
-  void OnChangedRecordingEnabled() override;
 
   // VoiceProcessingAudioUnitObserver methods.
   OSStatus OnDeliverRecordedData(AudioUnitRenderActionFlags* flags,
@@ -175,7 +174,8 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
   void HandleSampleRateChange();
   void HandlePlayoutGlitchDetected();
   void HandleOutputVolumeChange();
-  void HandleAudioSessionRecordingEnabledChange();
+
+  bool RestartAudioUnit(bool enable_input);
 
   // Uses current `playout_parameters_` and `record_parameters_` to inform the
   // audio device buffer (ADB) about our internal audio parameters.
@@ -205,7 +205,7 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
 
   // Activates our audio session, creates and initializes the voice-processing
   // audio unit and verifies that we got the preferred native audio parameters.
-  bool InitPlayOrRecord();
+  bool InitPlayOrRecord(bool enable_input);
 
   // Closes and deletes the voice-processing I/O unit.
   void ShutdownPlayOrRecord();
@@ -269,18 +269,20 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
   // will be changed dynamically to account for this behavior.
   rtc::BufferT<int16_t> record_audio_buffer_;
 
+  // Set to 1 when recording is initialized and 0 otherwise.
+  volatile int recording_is_initialized_;
+
   // Set to 1 when recording is active and 0 otherwise.
   volatile int recording_;
+
+  // Set to 1 when playout is initialized and 0 otherwise.
+  volatile int playout_is_initialized_;
 
   // Set to 1 when playout is active and 0 otherwise.
   volatile int playing_;
 
   // Set to true after successful call to Init(), false otherwise.
   bool initialized_ RTC_GUARDED_BY(thread_checker_);
-
-  // Set to true after successful call to InitRecording() or InitPlayout(),
-  // false otherwise.
-  bool audio_is_initialized_;
 
   // Set to true if audio session is interrupted, false otherwise.
   bool is_interrupted_;

--- a/sdk/objc/native/src/audio/audio_device_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_ios.mm
@@ -197,9 +197,6 @@ int32_t AudioDeviceIOS::InitPlayout() {
       RTC_LOG_F(LS_ERROR) << "InitPlayOrRecord failed for InitPlayout!";
       return -1;
     }
-  } else {
-    // recording is already initialized
-    // RestartAudioUnit(false);
   }
 
   rtc::AtomicOps::ReleaseStore(&playout_is_initialized_, 1);

--- a/sdk/objc/native/src/audio/audio_device_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_ios.mm
@@ -276,14 +276,11 @@ int32_t AudioDeviceIOS::StopPlayout() {
   if (!recording_) {
     ShutdownPlayOrRecord();
 
-    rtc::AtomicOps::ReleaseStore(&playout_is_initialized_, 0);
     rtc::AtomicOps::ReleaseStore(&recording_is_initialized_, 0);
-  } else if (playout_is_initialized_) {
-    // ...
-    rtc::AtomicOps::ReleaseStore(&playout_is_initialized_, 0);
   }
 
   rtc::AtomicOps::ReleaseStore(&playing_, 0);
+  rtc::AtomicOps::ReleaseStore(&playout_is_initialized_, 0);
 
   // Derive average number of calls to OnGetPlayoutData() between detected
   // audio glitches and add the result to a histogram.
@@ -339,14 +336,13 @@ int32_t AudioDeviceIOS::StopRecording() {
     ShutdownPlayOrRecord();
 
     rtc::AtomicOps::ReleaseStore(&playout_is_initialized_, 0);
-    rtc::AtomicOps::ReleaseStore(&recording_is_initialized_, 0);
   } else if (playout_is_initialized_) {
     // restart audio unit with no input
     RestartAudioUnit(false);
-    rtc::AtomicOps::ReleaseStore(&recording_is_initialized_, 0);
   }
 
   rtc::AtomicOps::ReleaseStore(&recording_, 0);
+  rtc::AtomicOps::ReleaseStore(&recording_is_initialized_, 0);
 
   return 0;
 }

--- a/sdk/objc/native/src/audio/audio_session_observer.h
+++ b/sdk/objc/native/src/audio/audio_session_observer.h
@@ -32,8 +32,6 @@ class AudioSessionObserver {
 
   virtual void OnChangedOutputVolume() = 0;
 
-  virtual void OnChangedRecordingEnabled() = 0;
-
  protected:
   virtual ~AudioSessionObserver() {}
 };

--- a/sdk/objc/native/src/audio/voice_processing_audio_unit.h
+++ b/sdk/objc/native/src/audio/voice_processing_audio_unit.h
@@ -75,7 +75,7 @@ class VoiceProcessingAudioUnit {
   VoiceProcessingAudioUnit::State GetState() const;
 
   // Initializes the underlying audio unit with the given sample rate.
-  bool Initialize(Float64 sample_rate);
+  bool Initialize(Float64 sample_rate, bool enable_input);
 
   // Starts the underlying audio unit.
   OSStatus Start();

--- a/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
+++ b/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
@@ -180,7 +180,7 @@ VoiceProcessingAudioUnit::State VoiceProcessingAudioUnit::GetState() const {
   return state_;
 }
 
-bool VoiceProcessingAudioUnit::Initialize(Float64 sample_rate) {
+bool VoiceProcessingAudioUnit::Initialize(Float64 sample_rate, bool enable_input) {
   RTC_DCHECK_GE(state_, kUninitialized);
   RTCLog(@"Initializing audio unit with sample rate: %f", sample_rate);
 
@@ -191,19 +191,11 @@ bool VoiceProcessingAudioUnit::Initialize(Float64 sample_rate) {
   LogStreamDescription(format);
 #endif
 
-  // Enable input on the input scope of the input element.
-  // keep it disabled if audio session is configured for playback only
-  AVAudioSession* session = [AVAudioSession sharedInstance];
-  UInt32 enable_input = 0;
-  if ([session.category isEqualToString: AVAudioSessionCategoryPlayAndRecord] ||
-      [session.category isEqualToString: AVAudioSessionCategoryRecord]) {
-    enable_input = 1;
-  }
-  RTCLog(@"Initializing AudioUnit, category=%@, enable_input=%d", session.category, (int) enable_input);
-  // LOGI() << "Initialize" << session.category << ", enable_input=" << enable_input;
+  UInt32 _enable_input = enable_input ? 1 : 0;
+  RTCLog(@"Initializing AudioUnit, _enable_input=%d", (int) _enable_input);
   result = AudioUnitSetProperty(vpio_unit_, kAudioOutputUnitProperty_EnableIO,
-                                kAudioUnitScope_Input, kInputBus, &enable_input,
-                                sizeof(enable_input));
+                                kAudioUnitScope_Input, kInputBus, &_enable_input,
+                                sizeof(_enable_input));
   if (result != noErr) {
     DisposeAudioUnit();
     RTCLogError(@"Failed to enable input on input scope of input element. "


### PR DESCRIPTION
AudioUnit restart (mic on/off) is not dependent on AVAudioSession category switch.
It is linked with Audio Device Module's `InitRecording()` / `StartRecording()` / `StopRecording()` etc.
Now, category switch not required to change mic on / off.

* Fixes iOS 16 issues

