### PR TITLE
Stop recording on mute (turn off mic indicator)

### DIFF
--- a/audio/audio_send_stream.cc
+++ b/audio/audio_send_stream.cc
@@ -424,6 +424,11 @@ void AudioSendStream::SetMuted(bool muted) {
   channel_send_->SetInputMute(muted);
 }
 
+bool AudioSendStream::GetMuted() {
+  RTC_DCHECK_RUN_ON(&worker_thread_checker_);
+  return channel_send_->InputMute();
+}
+
 webrtc::AudioSendStream::Stats AudioSendStream::GetStats() const {
   return GetStats(true);
 }

--- a/audio/audio_send_stream.h
+++ b/audio/audio_send_stream.h
@@ -93,6 +93,7 @@ class AudioSendStream final : public webrtc::AudioSendStream,
                           int payload_frequency,
                           int event,
                           int duration_ms) override;
+  bool GetMuted() override;
   void SetMuted(bool muted) override;
   webrtc::AudioSendStream::Stats GetStats() const override;
   webrtc::AudioSendStream::Stats GetStats(

--- a/audio/audio_state.cc
+++ b/audio/audio_state.cc
@@ -102,14 +102,14 @@ void AudioState::AddSendingStream(webrtc::AudioSendStream* stream,
     if (!adm->Recording()) {
       if (adm->InitRecording() == 0) {
         if (recording_enabled_) {
-  #if defined(WEBRTC_WIN)
+#if defined(WEBRTC_WIN)
           if (adm->BuiltInAECIsAvailable() && !adm->Playing()) {
             if (!adm->PlayoutIsInitialized()) {
               adm->InitPlayout();
             }
             adm->StartPlayout();
           }
-  #endif
+#endif
           adm->StartRecording();
         }
       } else {

--- a/audio/audio_state.cc
+++ b/audio/audio_state.cc
@@ -102,6 +102,8 @@ void AudioState::AddSendingStream(webrtc::AudioSendStream* stream,
     if (!adm->Recording()) {
       if (adm->InitRecording() == 0) {
         if (recording_enabled_) {
+
+          // TODO: Verify if the following windows only logic is still required.
 #if defined(WEBRTC_WIN)
           if (adm->BuiltInAECIsAvailable() && !adm->Playing()) {
             if (!adm->PlayoutIsInitialized()) {

--- a/audio/audio_state.h
+++ b/audio/audio_state.h
@@ -46,6 +46,8 @@ class AudioState : public webrtc::AudioState {
 
   void SetStereoChannelSwapping(bool enable) override;
 
+  void OnMuteStreamChanged() override;
+
   AudioDeviceModule* audio_device_module() {
     RTC_DCHECK(config_.audio_device_module);
     return config_.audio_device_module.get();
@@ -62,6 +64,8 @@ class AudioState : public webrtc::AudioState {
  private:
   void UpdateAudioTransportWithSendingStreams();
   void UpdateNullAudioPollerState();
+
+  bool ShouldRecord();
 
   SequenceChecker thread_checker_;
   SequenceChecker process_thread_checker_;

--- a/audio/audio_state.h
+++ b/audio/audio_state.h
@@ -65,6 +65,7 @@ class AudioState : public webrtc::AudioState {
   void UpdateAudioTransportWithSendingStreams();
   void UpdateNullAudioPollerState();
 
+  // Returns true when at least 1 stream exists and all streams are not muted.
   bool ShouldRecord();
 
   SequenceChecker thread_checker_;

--- a/audio/channel_send.cc
+++ b/audio/channel_send.cc
@@ -102,6 +102,8 @@ class ChannelSend : public ChannelSendInterface,
   // Muting, Volume and Level.
   void SetInputMute(bool enable) override;
 
+  bool InputMute() const override;
+
   // Stats.
   ANAStats GetANAStatistics() const override;
 
@@ -164,7 +166,6 @@ class ChannelSend : public ChannelSendInterface,
                    int64_t absolute_capture_timestamp_ms) override;
 
   void OnUplinkPacketLossRate(float packet_loss_rate);
-  bool InputMute() const;
 
   int32_t SendRtpAudio(AudioFrameType frameType,
                        uint8_t payloadType,

--- a/audio/channel_send.h
+++ b/audio/channel_send.h
@@ -93,6 +93,8 @@ class ChannelSendInterface {
   virtual bool SendTelephoneEventOutband(int event, int duration_ms) = 0;
   virtual void OnBitrateAllocation(BitrateAllocationUpdate update) = 0;
   virtual int GetTargetBitrate() const = 0;
+
+  virtual bool InputMute() const = 0;
   virtual void SetInputMute(bool muted) = 0;
 
   virtual void ProcessAndEncodeAudio(

--- a/call/audio_send_stream.h
+++ b/call/audio_send_stream.h
@@ -186,6 +186,7 @@ class AudioSendStream : public AudioSender {
                                   int event,
                                   int duration_ms) = 0;
 
+  virtual bool GetMuted() = 0;
   virtual void SetMuted(bool muted) = 0;
 
   virtual Stats GetStats() const = 0;

--- a/call/audio_state.h
+++ b/call/audio_state.h
@@ -59,6 +59,7 @@ class AudioState : public rtc::RefCountInterface {
 
   virtual void SetStereoChannelSwapping(bool enable) = 0;
 
+  // Notify the AudioState that a stream updated it's mute state.
   virtual void OnMuteStreamChanged() = 0;
 
   static rtc::scoped_refptr<AudioState> Create(

--- a/call/audio_state.h
+++ b/call/audio_state.h
@@ -59,6 +59,8 @@ class AudioState : public rtc::RefCountInterface {
 
   virtual void SetStereoChannelSwapping(bool enable) = 0;
 
+  virtual void OnMuteStreamChanged() = 0;
+
   static rtc::scoped_refptr<AudioState> Create(
       const AudioState::Config& config);
 

--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -2263,7 +2263,7 @@ bool WebRtcVoiceMediaChannel::MuteStream(uint32_t ssrc, bool muted) {
     ap->set_output_will_be_muted(all_muted);
   }
 
-  // notfy the AudioState
+  // Notfy the AudioState that the mute state has updated.
   engine_->audio_state()->OnMuteStreamChanged();
 
   return true;

--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -2263,6 +2263,9 @@ bool WebRtcVoiceMediaChannel::MuteStream(uint32_t ssrc, bool muted) {
     ap->set_output_will_be_muted(all_muted);
   }
 
+  // notfy the AudioState
+  engine_->audio_state()->OnMuteStreamChanged();
+
   return true;
 }
 

--- a/media/engine/webrtc_voice_engine.h
+++ b/media/engine/webrtc_voice_engine.h
@@ -87,6 +87,8 @@ class WebRtcVoiceEngine final : public VoiceEngineInterface {
   // Stops AEC dump.
   void StopAecDump() override;
 
+  webrtc::AudioState* audio_state();
+
  private:
   // Every option that is "set" will be applied. Every option not "set" will be
   // ignored. This allows us to selectively turn on and off different options
@@ -100,7 +102,6 @@ class WebRtcVoiceEngine final : public VoiceEngineInterface {
 
   webrtc::AudioDeviceModule* adm();
   webrtc::AudioProcessing* apm() const;
-  webrtc::AudioState* audio_state();
 
   std::vector<AudioCodec> CollectCodecs(
       const std::vector<webrtc::AudioCodecSpec>& specs) const;

--- a/media/engine/webrtc_voice_engine.h
+++ b/media/engine/webrtc_voice_engine.h
@@ -87,6 +87,7 @@ class WebRtcVoiceEngine final : public VoiceEngineInterface {
   // Stops AEC dump.
   void StopAecDump() override;
 
+  // Moved to public so WebRtcVoiceMediaChannel can access it.
   webrtc::AudioState* audio_state();
 
  private:


### PR DESCRIPTION
Now, if all audio tracks are muted(disabled), recording will stop and mic indicator will turn off.
Unmuting(enabling) any audio track will restart audio recording.

This is possible because of https://github.com/webrtc-sdk/webrtc/pull/52
Works(tested) with iOS / macOS.

macOS:
https://user-images.githubusercontent.com/548776/204782648-db38668f-21d6-46ac-876a-728376b716f2.mov
