### PR TITLE
Fix Windows compilation with towupper

### DIFF
--- a/modules/desktop_capture/win/full_screen_win_application_handler.cc
+++ b/modules/desktop_capture/win/full_screen_win_application_handler.cc
@@ -11,6 +11,7 @@
 #include "modules/desktop_capture/win/full_screen_win_application_handler.h"
 
 #include <algorithm>
+#include <cwctype>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Fix missing std::towupper included in [cwctype ](https://en.cppreference.com/w/cpp/string/wide/towupper)