### PR TITLE
Expose Adapter types in PeerConnectionFactory Options for Android

### DIFF
--- a/sdk/android/api/org/webrtc/PeerConnectionFactory.java
+++ b/sdk/android/api/org/webrtc/PeerConnectionFactory.java
@@ -135,13 +135,13 @@ public class PeerConnectionFactory {
     // Keep in sync with webrtc/rtc_base/network.h!
     //
     // These bit fields are defined for `networkIgnoreMask` below.
-    static final int ADAPTER_TYPE_UNKNOWN = 0;
-    static final int ADAPTER_TYPE_ETHERNET = 1 << 0;
-    static final int ADAPTER_TYPE_WIFI = 1 << 1;
-    static final int ADAPTER_TYPE_CELLULAR = 1 << 2;
-    static final int ADAPTER_TYPE_VPN = 1 << 3;
-    static final int ADAPTER_TYPE_LOOPBACK = 1 << 4;
-    static final int ADAPTER_TYPE_ANY = 1 << 5;
+    public static final int ADAPTER_TYPE_UNKNOWN = 0;
+    public static final int ADAPTER_TYPE_ETHERNET = 1 << 0;
+    public static final int ADAPTER_TYPE_WIFI = 1 << 1;
+    public static final int ADAPTER_TYPE_CELLULAR = 1 << 2;
+    public static final int ADAPTER_TYPE_VPN = 1 << 3;
+    public static final int ADAPTER_TYPE_LOOPBACK = 1 << 4;
+    public static final int ADAPTER_TYPE_ANY = 1 << 5;
 
     public int networkIgnoreMask;
     public boolean disableEncryption;


### PR DESCRIPTION
With this change, It is easy to set "networkIgnoreMask" on Android.
It's easy on iOS, so no change needed.
Will resolve https://github.com/webrtc-sdk/webrtc/issues/77.