### PR TITLE
Multitasking Camera Support

### DIFF
--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.h
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.h
@@ -33,6 +33,16 @@ NS_EXTENSION_UNAVAILABLE_IOS("Camera not available in app extensions.")
 // Returns the most efficient supported output pixel format for this capturer.
 - (FourCharCode)preferredOutputPixelFormat;
 
+// A Boolean value that indicates whether the capture session supports using the camera while
+// multitasking.
+// https://developer.apple.com/documentation/avfoundation/avcapturesession/4013228-ismultitaskingcameraaccesssuppor
+@property(readonly, nonatomic) BOOL isMultitaskingAccessSupported;
+
+// A Boolean value that indicates whether the capture session enables access to the camera while
+// multitasking.
+// https://developer.apple.com/documentation/avfoundation/avcapturesession/4013227-ismultitaskingcameraaccessenable
+@property(assign, nonatomic) BOOL isMultitaskingAccessEnabled;
+
 // Starts the capture session asynchronously and notifies callback on completion.
 // The device will capture video in the format given in the `format` parameter. If the pixel format
 // in `format` is supported by the WebRTC pipeline, the same pixel format will be used for the

--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.h
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.h
@@ -40,6 +40,8 @@ NS_EXTENSION_UNAVAILABLE_IOS("Camera not available in app extensions.")
 
 // A Boolean value that indicates whether the capture session enables access to the camera while
 // multitasking.
+// You can enable multitasking camera access by setting this value to true prior to starting the
+// capture session.
 // https://developer.apple.com/documentation/avfoundation/avcapturesession/4013227-ismultitaskingcameraaccessenable
 @property(assign, nonatomic) BOOL isMultitaskingAccessEnabled;
 

--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
@@ -140,6 +140,35 @@ const int64_t kNanosecondsPerSecond = 1000000000;
   return _preferredOutputPixelFormat;
 }
 
+- (BOOL)isMultitaskingAccessSupported {
+// Only iOS 16+
+#if defined(WEBRTC_IOS)
+  if (@available(iOS 16.0, *)) {
+    return [_captureSession isMultitaskingCameraAccessSupported];
+  }
+#endif
+  return NO;
+}
+
+- (BOOL)isMultitaskingAccessEnabled {
+  // Only iOS 16+
+#if defined(WEBRTC_IOS)
+  if (@available(iOS 16.0, *)) {
+    return [_captureSession isMultitaskingCameraAccessEnabled];
+  }
+#endif
+  return NO;
+}
+
+- (void)setIsMultitaskingAccessEnabled:(BOOL)value {
+// Only iOS 16+
+#if defined(WEBRTC_IOS)
+  if (@available(iOS 16.0, *)) {
+    [_captureSession setMultitaskingCameraAccessEnabled:value];
+  }
+#endif
+}
+
 - (void)startCaptureWithDevice:(AVCaptureDevice *)device
                         format:(AVCaptureDeviceFormat *)format
                            fps:(NSInteger)fps {


### PR DESCRIPTION

Apple:
> In iOS 16 and later, you can use the camera in Picture in Picture mode by enabling a capture session’s [isMultitaskingCameraAccessEnabled](https://developer.apple.com/documentation/avfoundation/avcapturesession/4013227-ismultitaskingcameraaccessenable) property. Apps that have a deployment target earlier than iOS 16 require the [com.apple.developer.avfoundation.multitasking-camera-access](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_avfoundation_multitasking-camera-access) entitlement to use the camera in PiP mode.