### PR TITLE
add failure tolerance for framecryptor.

### DIFF
--- a/api/crypto/frame_crypto_transformer.cc
+++ b/api/crypto/frame_crypto_transformer.cc
@@ -136,7 +136,7 @@ uint8_t get_unencrypted_bytes(webrtc::TransformableFrameInterface* frame,
                   << "NonParameterSetNalu::payload_size: " << index.payload_size
                   << ", nalu_type " << nalu_type << ", NaluIndex [" << idx++
                   << "] offset: " << index.payload_start_offset;
-              break;
+              return unencrypted_bytes;
             default:
               break;
           }
@@ -510,7 +510,7 @@ void FrameCryptorTransformer::decryptFrame(
   uint8_t key_index = frame_trailer[1];
 
   if (ivLength != getIvSize()) {
-    RTC_LOG(LS_ERROR) << "FrameCryptorTransformer::decryptFrame() ivLength["
+    RTC_LOG(LS_WARNING) << "FrameCryptorTransformer::decryptFrame() ivLength["
                       << static_cast<int>(ivLength) << "] != getIvSize()["
                       << static_cast<int>(getIvSize()) << "]";
     if (last_dec_error_ != FrameCryptionState::kDecryptionFailed) {
@@ -569,7 +569,7 @@ void FrameCryptorTransformer::decryptFrame(
                         encrypted_payload, &buffer) == Success) {
     decryption_success = true;
   } else {
-    RTC_LOG(LS_ERROR) << "FrameCryptorTransformer::decryptFrame() failed";
+    RTC_LOG(LS_WARNING) << "FrameCryptorTransformer::decryptFrame() failed";
     std::shared_ptr<ParticipantKeyHandler::KeySet> ratcheted_key_set;
     auto currentKeyMaterial = key_set->material;
     if (key_provider_->options().ratchet_window_size > 0) {

--- a/api/crypto/frame_crypto_transformer.cc
+++ b/api/crypto/frame_crypto_transformer.cc
@@ -219,7 +219,7 @@ int AesGcmEncryptDecrypt(EncryptOrDecrypt mode,
   }
 
   if (!ok) {
-    RTC_LOG(LS_ERROR) << "Failed to perform AES-GCM operation.";
+    RTC_LOG(LS_WARNING) << "Failed to perform AES-GCM operation.";
     return OperationError;
   }
 
@@ -593,7 +593,7 @@ void FrameCryptorTransformer::decryptFrame(
           decryption_success = true;
           // success, so we set the new key
           key_handler->SetKeyFromMaterial(new_material, key_index);
-          key_handler->SetHasValidKey(true);
+          key_handler->SetHasValidKey();
           if (last_dec_error_ != FrameCryptionState::kKeyRatcheted) {
             last_dec_error_ = FrameCryptionState::kKeyRatcheted;
             if (observer_)
@@ -622,7 +622,7 @@ void FrameCryptorTransformer::decryptFrame(
   if (!decryption_success) {
     if (last_dec_error_ != FrameCryptionState::kDecryptionFailed) {
       last_dec_error_ = FrameCryptionState::kDecryptionFailed;
-      key_handler->SetHasValidKey(false);
+      key_handler->DecryptionFailure();
       if (observer_)
         observer_->OnFrameCryptionStateChanged(participant_id_,
                                                last_dec_error_);

--- a/api/crypto/frame_crypto_transformer.h
+++ b/api/crypto/frame_crypto_transformer.h
@@ -76,6 +76,8 @@ class KeyProvider : public rtc::RefCountInterface {
   virtual const std::vector<uint8_t> ExportKey(const std::string participant_id,
                                                int key_index) const = 0;
 
+  virtual void SetSifTrailer(const std::vector<uint8_t> trailer) = 0;
+
   virtual KeyProviderOptions& options() = 0;
 
  protected:
@@ -310,6 +312,11 @@ class DefaultKeyProviderImpl : public KeyProvider {
       }
     }
     return std::vector<uint8_t>();
+  }
+
+  void SetSifTrailer(const std::vector<uint8_t> trailer) override {
+    webrtc::MutexLock lock(&mutex_);
+    options_.uncrypted_magic_bytes = trailer;
   }
 
   KeyProviderOptions& options() override { return options_; }

--- a/api/crypto/frame_crypto_transformer.h
+++ b/api/crypto/frame_crypto_transformer.h
@@ -41,12 +41,14 @@ struct KeyProviderOptions {
   std::vector<uint8_t> ratchet_salt;
   std::vector<uint8_t> uncrypted_magic_bytes;
   int ratchet_window_size;
-  KeyProviderOptions() : shared_key(false), ratchet_window_size(0) {}
+  int failure_tolerance;
+  KeyProviderOptions() : shared_key(false), ratchet_window_size(0), failure_tolerance(-1) {}
   KeyProviderOptions(KeyProviderOptions& copy)
       : shared_key(copy.shared_key),
         ratchet_salt(copy.ratchet_salt),
         uncrypted_magic_bytes(copy.uncrypted_magic_bytes),
-        ratchet_window_size(copy.ratchet_window_size) {}
+        ratchet_window_size(copy.ratchet_window_size),
+        failure_tolerance(copy.failure_tolerance) {}
 };
 
 class KeyProvider : public rtc::RefCountInterface {
@@ -116,7 +118,7 @@ class ParticipantKeyHandler {
     }
     SetKeyFromMaterial(new_material,
                        key_index != -1 ? key_index : current_key_index_);
-    SetHasValidKey(true);
+    SetHasValidKey();
     return new_material;
   }
 
@@ -127,7 +129,7 @@ class ParticipantKeyHandler {
 
   virtual void SetKey(std::vector<uint8_t> password, int key_index) {
     SetKeyFromMaterial(password, key_index);
-    SetHasValidKey(true);
+    SetHasValidKey();
   }
 
   std::vector<uint8_t> RatchetKeyMaterial(
@@ -156,9 +158,10 @@ class ParticipantKeyHandler {
     return has_valid_key_;
   }
 
-  void SetHasValidKey(bool has_valid_key) {
+  void SetHasValidKey() {
     webrtc::MutexLock lock(&mutex_);
-    has_valid_key_ = has_valid_key;
+    decryption_failure_count_ = 0;
+    has_valid_key_ = true;
   }
 
   void SetKeyFromMaterial(std::vector<uint8_t> password, int key_index) {
@@ -170,8 +173,21 @@ class ParticipantKeyHandler {
         DeriveKeys(password, key_provider_->options().ratchet_salt, 128);
   }
 
+  void DecryptionFailure() {
+    webrtc::MutexLock lock(&mutex_);
+    if (key_provider_->options().failure_tolerance < 0) {
+      return;
+    }
+    decryption_failure_count_ += 1;
+
+    if (decryption_failure_count_ > key_provider_->options().failure_tolerance) {
+      has_valid_key_ = false;
+    }
+  }
+
  private:
   bool has_valid_key_ = false;
+  int decryption_failure_count_ = 0;
   mutable webrtc::Mutex mutex_;
   int current_key_index_ = 0;
   KeyProvider* key_provider_;

--- a/sdk/android/api/org/webrtc/FrameCryptorFactory.java
+++ b/sdk/android/api/org/webrtc/FrameCryptorFactory.java
@@ -18,8 +18,8 @@ package org.webrtc;
 
 public class FrameCryptorFactory {
   public static FrameCryptorKeyProvider createFrameCryptorKeyProvider(
-      boolean sharedKey, byte[] ratchetSalt, int ratchetWindowSize, byte[] uncryptedMagicBytes) {
-    return nativeCreateFrameCryptorKeyProvider(sharedKey, ratchetSalt, ratchetWindowSize, uncryptedMagicBytes);
+      boolean sharedKey, byte[] ratchetSalt, int ratchetWindowSize, byte[] uncryptedMagicBytes, int failureTolerance) {
+    return nativeCreateFrameCryptorKeyProvider(sharedKey, ratchetSalt, ratchetWindowSize, uncryptedMagicBytes, failureTolerance);
   }
 
   public static FrameCryptor createFrameCryptorForRtpSender(RtpSender rtpSender,
@@ -40,5 +40,5 @@ public class FrameCryptorFactory {
       long rtpReceiver, String participantId, int algorithm, long nativeFrameCryptorKeyProvider);
 
   private static native FrameCryptorKeyProvider nativeCreateFrameCryptorKeyProvider(
-      boolean sharedKey, byte[] ratchetSalt, int ratchetWindowSize, byte[] uncryptedMagicBytes);
+      boolean sharedKey, byte[] ratchetSalt, int ratchetWindowSize, byte[] uncryptedMagicBytes, int failureTolerance);
 }

--- a/sdk/android/api/org/webrtc/FrameCryptorKeyProvider.java
+++ b/sdk/android/api/org/webrtc/FrameCryptorKeyProvider.java
@@ -60,6 +60,11 @@ public class FrameCryptorKeyProvider {
     return nativeExportKey(nativeKeyProvider, participantId, index);
   }
 
+  public void setSifTrailer(byte[] sifTrailer) {
+    checkKeyProviderExists();
+    nativeSetSifTrailer(nativeKeyProvider, sifTrailer);
+  }
+
   public void dispose() {
     checkKeyProviderExists();
     JniCommon.nativeReleaseRef(nativeKeyProvider);
@@ -83,4 +88,6 @@ public class FrameCryptorKeyProvider {
       long keyProviderPointer, String participantId, int index);
   private static native byte[] nativeExportKey(
       long keyProviderPointer, String participantId, int index);
+  private static native void nativeSetSifTrailer(
+      long keyProviderPointer, byte[] sifTrailer);
 }

--- a/sdk/android/src/jni/pc/frame_cryptor.cc
+++ b/sdk/android/src/jni/pc/frame_cryptor.cc
@@ -171,7 +171,8 @@ JNI_FrameCryptorFactory_CreateFrameCryptorKeyProvider(
     jboolean j_shared,
     const base::android::JavaParamRef<jbyteArray>& j_ratchetSalt,
     jint j_ratchetWindowSize,
-    const base::android::JavaParamRef<jbyteArray>& j_uncryptedMagicBytes) {
+    const base::android::JavaParamRef<jbyteArray>& j_uncryptedMagicBytes,
+    jint j_failureTolerance) {
   auto ratchetSalt = JavaToNativeByteArray(env, j_ratchetSalt);
   KeyProviderOptions options;
   options.ratchet_salt =
@@ -182,6 +183,7 @@ JNI_FrameCryptorFactory_CreateFrameCryptorKeyProvider(
   options.uncrypted_magic_bytes =
       std::vector<uint8_t>(uncryptedMagicBytes.begin(), uncryptedMagicBytes.end());
   options.shared_key = j_shared;
+    options.failure_tolerance = j_failureTolerance;
   return NativeToJavaFrameCryptorKeyProvider(
       env, rtc::make_ref_counted<webrtc::DefaultKeyProviderImpl>(options));
 }

--- a/sdk/android/src/jni/pc/frame_cryptor_key_provider.cc
+++ b/sdk/android/src/jni/pc/frame_cryptor_key_provider.cc
@@ -110,5 +110,14 @@ JNI_FrameCryptorKeyProvider_ExportKey(
   return NativeToJavaByteArray(env, rtc::ArrayView<int8_t>(int8tKey));
 }
 
+static void JNI_FrameCryptorKeyProvider_SetSifTrailer(
+    JNIEnv* jni,
+    jlong j_key_provider,
+    const base::android::JavaParamRef<jbyteArray>& j_trailer) {
+  auto trailer = JavaToNativeByteArray(jni, j_trailer);
+  reinterpret_cast<webrtc::DefaultKeyProviderImpl*>(j_key_provider)
+      ->SetSifTrailer(std::vector<uint8_t>(trailer.begin(), trailer.end()));
+}
+
 }  // namespace jni
 }  // namespace webrtc

--- a/sdk/objc/api/peerconnection/RTCFrameCryptorKeyProvider.h
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptorKeyProvider.h
@@ -40,6 +40,12 @@ RTC_OBJC_EXPORT
                       sharedKeyMode:(BOOL)sharedKey
                 uncryptedMagicBytes:(nullable NSData *)uncryptedMagicBytes;
 
+- (instancetype)initWithRatchetSalt:(NSData *)salt
+                  ratchetWindowSize:(int)windowSize
+                      sharedKeyMode:(BOOL)sharedKey
+                uncryptedMagicBytes:(nullable NSData *)uncryptedMagicBytes
+                   failureTolerance:(int)failureTolerance;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sdk/objc/api/peerconnection/RTCFrameCryptorKeyProvider.h
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptorKeyProvider.h
@@ -35,6 +35,8 @@ RTC_OBJC_EXPORT
 
 - (NSData *)exportKey:(NSString *)participantId withIndex:(int)index;
 
+- (void)setSifTrailer:(NSData *)trailer;
+
 - (instancetype)initWithRatchetSalt:(NSData *)salt
                   ratchetWindowSize:(int)windowSize
                       sharedKeyMode:(BOOL)sharedKey

--- a/sdk/objc/api/peerconnection/RTCFrameCryptorKeyProvider.mm
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptorKeyProvider.mm
@@ -95,4 +95,10 @@
   return [NSData dataWithBytes:nativeKey.data() length:nativeKey.size()];
 }
 
+- (void)setSifTrailer:(NSData *)trailer {
+  _nativeKeyProvider->SetSifTrailer(
+      std::vector<uint8_t>((const uint8_t *)trailer.bytes,
+                           ((const uint8_t *)trailer.bytes) + trailer.length));
+}
+
 @end

--- a/sdk/objc/api/peerconnection/RTCFrameCryptorKeyProvider.mm
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptorKeyProvider.mm
@@ -34,12 +34,25 @@
                   ratchetWindowSize:(int)windowSize
                       sharedKeyMode:(BOOL)sharedKey
                 uncryptedMagicBytes:(NSData *)uncryptedMagicBytes {
+  return [self initWithRatchetSalt:salt
+                  ratchetWindowSize:windowSize
+                      sharedKeyMode:sharedKey
+                uncryptedMagicBytes:uncryptedMagicBytes
+                   failureTolerance:-1];
+}
+
+- (instancetype)initWithRatchetSalt:(NSData *)salt
+                  ratchetWindowSize:(int)windowSize
+                      sharedKeyMode:(BOOL)sharedKey
+                uncryptedMagicBytes:(nullable NSData *)uncryptedMagicBytes
+                   failureTolerance:(int)failureTolerance {
   if (self = [super init]) {
     webrtc::KeyProviderOptions options;
     options.ratchet_salt = std::vector<uint8_t>((const uint8_t *)salt.bytes,
                                                 ((const uint8_t *)salt.bytes) + salt.length);
     options.ratchet_window_size = windowSize;
     options.shared_key = sharedKey;
+    options.failure_tolerance = failureTolerance;
     if(uncryptedMagicBytes != nil) {
       options.uncrypted_magic_bytes = std::vector<uint8_t>((const uint8_t *)uncryptedMagicBytes.bytes,
                                                           ((const uint8_t *)uncryptedMagicBytes.bytes) + uncryptedMagicBytes.length);


### PR DESCRIPTION
Changes:
- add `failure-tolerance` into the `KeyProviderOptions`.
- add `SetSifTrailer` into the `KeyProvider`.