### PR TITLE
Fix/send frame cryptor events from signaling thread

### DIFF
--- a/api/crypto/frame_crypto_transformer.cc
+++ b/api/crypto/frame_crypto_transformer.cc
@@ -342,7 +342,7 @@ void FrameCryptorTransformer::encryptFrame(
         << "FrameCryptorTransformer::encryptFrame() sink_callback is NULL";
     if (last_enc_error_ != FrameCryptionState::kInternalError) {
       last_enc_error_ = FrameCryptionState::kInternalError;
-      onFrameCryptionStateChanged(last_dec_error_);
+      onFrameCryptionStateChanged(last_enc_error_);
     }
     return;
   }
@@ -364,7 +364,7 @@ void FrameCryptorTransformer::encryptFrame(
                      << participant_id_;
     if (last_enc_error_ != FrameCryptionState::kMissingKey) {
       last_enc_error_ = FrameCryptionState::kMissingKey;
-      onFrameCryptionStateChanged(last_dec_error_);
+      onFrameCryptionStateChanged(last_enc_error_);
     }
     return;
   }
@@ -414,13 +414,13 @@ void FrameCryptorTransformer::encryptFrame(
                      << " iv=" << to_hex(iv.data(), iv.size());
     if (last_enc_error_ != FrameCryptionState::kOk) {
       last_enc_error_ = FrameCryptionState::kOk;
-      onFrameCryptionStateChanged(last_dec_error_);
+      onFrameCryptionStateChanged(last_enc_error_);
     }
     sink_callback->OnTransformedFrame(std::move(frame));
   } else {
     if (last_enc_error_ != FrameCryptionState::kEncryptionFailed) {
       last_enc_error_ = FrameCryptionState::kEncryptionFailed;
-      onFrameCryptionStateChanged(last_dec_error_);
+      onFrameCryptionStateChanged(last_enc_error_);
     }
     RTC_LOG(LS_ERROR) << "FrameCryptorTransformer::encryptFrame() failed";
   }

--- a/api/crypto/frame_crypto_transformer.cc
+++ b/api/crypto/frame_crypto_transformer.cc
@@ -636,10 +636,12 @@ void FrameCryptorTransformer::decryptFrame(
 }
 
 void FrameCryptorTransformer::onFrameCryptionStateChanged(FrameCryptionState state) {
-  if(signaling_thread_) {
+  webrtc::MutexLock lock(&mutex_);
+  if(observer_) {
+    RTC_DCHECK(signaling_thread_ != nullptr);
     signaling_thread_->PostTask(
-        [observer = observer_, state = state, participant_id = participant_id_]() mutable {
-          observer->OnFrameCryptionStateChanged(participant_id, state);
+          [observer = observer_, state = state, participant_id = participant_id_]() mutable {
+            observer->OnFrameCryptionStateChanged(participant_id, state);
           }
     );
   }

--- a/api/crypto/frame_crypto_transformer.cc
+++ b/api/crypto/frame_crypto_transformer.cc
@@ -570,7 +570,7 @@ void FrameCryptorTransformer::decryptFrame(
     decryption_success = true;
   } else {
     RTC_LOG(LS_WARNING) << "FrameCryptorTransformer::decryptFrame() failed";
-    std::shared_ptr<ParticipantKeyHandler::KeySet> ratcheted_key_set;
+    rtc::scoped_refptr<ParticipantKeyHandler::KeySet> ratcheted_key_set;
     auto currentKeyMaterial = key_set->material;
     if (key_provider_->options().ratchet_window_size > 0) {
       while (ratchet_count < key_provider_->options().ratchet_window_size) {

--- a/api/crypto/frame_crypto_transformer.h
+++ b/api/crypto/frame_crypto_transformer.h
@@ -337,7 +337,7 @@ enum FrameCryptionState {
   kInternalError,
 };
 
-class FrameCryptorTransformerObserver {
+class FrameCryptorTransformerObserver : public rtc::RefCountInterface {
  public:
   virtual void OnFrameCryptionStateChanged(const std::string participant_id,
                                            FrameCryptionState error) = 0;
@@ -364,10 +364,15 @@ class RTC_EXPORT FrameCryptorTransformer
                                    Algorithm algorithm,
                                    rtc::scoped_refptr<KeyProvider> key_provider);
 
-  virtual void SetFrameCryptorTransformerObserver(
-      FrameCryptorTransformerObserver* observer) {
+  virtual void RegisterFrameCryptorTransformerObserver(
+       rtc::scoped_refptr<FrameCryptorTransformerObserver> observer) {
     webrtc::MutexLock lock(&mutex_);
     observer_ = observer;
+  }
+
+    virtual void UnRegisterFrameCryptorTransformerObserver() {
+    webrtc::MutexLock lock(&mutex_);
+    observer_ = nullptr;
   }
 
   virtual void SetKeyIndex(int index) {
@@ -433,10 +438,11 @@ class RTC_EXPORT FrameCryptorTransformer
   int key_index_ = 0;
   std::map<uint32_t, uint32_t> send_counts_;
   rtc::scoped_refptr<KeyProvider> key_provider_;
-  FrameCryptorTransformerObserver* observer_ = nullptr;
+  rtc::scoped_refptr<FrameCryptorTransformerObserver> observer_;
   std::unique_ptr<rtc::Thread> thread_;
   FrameCryptionState last_enc_error_ = FrameCryptionState::kNew;
   FrameCryptionState last_dec_error_ = FrameCryptionState::kNew;
+  
 };
 
 }  // namespace webrtc

--- a/sdk/android/api/org/webrtc/FrameCryptorFactory.java
+++ b/sdk/android/api/org/webrtc/FrameCryptorFactory.java
@@ -24,13 +24,13 @@ public class FrameCryptorFactory {
 
   public static FrameCryptor createFrameCryptorForRtpSender(PeerConnectionFactory factory, RtpSender rtpSender,
       String participantId, FrameCryptorAlgorithm algorithm, FrameCryptorKeyProvider keyProvider) {
-    return nativeCreateFrameCryptorForRtpSender(factory.getNativePeerConnectionFactory(),rtpSender.getNativeRtpSender(), participantId,
+    return nativeCreateFrameCryptorForRtpSender(factory.getNativeOwnedFactoryAndThreads(),rtpSender.getNativeRtpSender(), participantId,
         algorithm.ordinal(), keyProvider.getNativeKeyProvider());
   }
 
   public static FrameCryptor createFrameCryptorForRtpReceiver(PeerConnectionFactory factory, RtpReceiver rtpReceiver,
       String participantId, FrameCryptorAlgorithm algorithm, FrameCryptorKeyProvider keyProvider) {
-    return nativeCreateFrameCryptorForRtpReceiver(factory.getNativePeerConnectionFactory(), rtpReceiver.getNativeRtpReceiver(), participantId,
+    return nativeCreateFrameCryptorForRtpReceiver(factory.getNativeOwnedFactoryAndThreads(), rtpReceiver.getNativeRtpReceiver(), participantId,
         algorithm.ordinal(), keyProvider.getNativeKeyProvider());
   }
 

--- a/sdk/android/api/org/webrtc/FrameCryptorFactory.java
+++ b/sdk/android/api/org/webrtc/FrameCryptorFactory.java
@@ -22,21 +22,21 @@ public class FrameCryptorFactory {
     return nativeCreateFrameCryptorKeyProvider(sharedKey, ratchetSalt, ratchetWindowSize, uncryptedMagicBytes, failureTolerance);
   }
 
-  public static FrameCryptor createFrameCryptorForRtpSender(RtpSender rtpSender,
+  public static FrameCryptor createFrameCryptorForRtpSender(PeerConnectionFactory factory, RtpSender rtpSender,
       String participantId, FrameCryptorAlgorithm algorithm, FrameCryptorKeyProvider keyProvider) {
-    return nativeCreateFrameCryptorForRtpSender(rtpSender.getNativeRtpSender(), participantId,
+    return nativeCreateFrameCryptorForRtpSender(factory.getNativePeerConnectionFactory(),rtpSender.getNativeRtpSender(), participantId,
         algorithm.ordinal(), keyProvider.getNativeKeyProvider());
   }
 
-  public static FrameCryptor createFrameCryptorForRtpReceiver(RtpReceiver rtpReceiver,
+  public static FrameCryptor createFrameCryptorForRtpReceiver(PeerConnectionFactory factory, RtpReceiver rtpReceiver,
       String participantId, FrameCryptorAlgorithm algorithm, FrameCryptorKeyProvider keyProvider) {
-    return nativeCreateFrameCryptorForRtpReceiver(rtpReceiver.getNativeRtpReceiver(), participantId,
+    return nativeCreateFrameCryptorForRtpReceiver(factory.getNativePeerConnectionFactory(), rtpReceiver.getNativeRtpReceiver(), participantId,
         algorithm.ordinal(), keyProvider.getNativeKeyProvider());
   }
 
-  private static native FrameCryptor nativeCreateFrameCryptorForRtpSender(
+  private static native FrameCryptor nativeCreateFrameCryptorForRtpSender(long factory,
       long rtpSender, String participantId, int algorithm, long nativeFrameCryptorKeyProvider);
-  private static native FrameCryptor nativeCreateFrameCryptorForRtpReceiver(
+  private static native FrameCryptor nativeCreateFrameCryptorForRtpReceiver(long factory,
       long rtpReceiver, String participantId, int algorithm, long nativeFrameCryptorKeyProvider);
 
   private static native FrameCryptorKeyProvider nativeCreateFrameCryptorKeyProvider(

--- a/sdk/android/src/jni/pc/frame_cryptor.cc
+++ b/sdk/android/src/jni/pc/frame_cryptor.cc
@@ -88,14 +88,14 @@ static jlong JNI_FrameCryptor_SetObserver(
       rtc::make_ref_counted<FrameCryptorObserverJni>(jni, j_observer);
   observer->AddRef();
   reinterpret_cast<FrameCryptorTransformer*>(j_frame_cryptor_pointer)
-      ->SetFrameCryptorTransformerObserver(observer.get());
+      ->RegisterFrameCryptorTransformerObserver(observer);
   return jlongFromPointer(observer.get());
 }
 
 static void JNI_FrameCryptor_UnSetObserver(JNIEnv* jni,
                                            jlong j_frame_cryptor_pointer) {
   reinterpret_cast<FrameCryptorTransformer*>(j_frame_cryptor_pointer)
-      ->SetFrameCryptorTransformerObserver(nullptr);
+      ->UnRegisterFrameCryptorTransformerObserver();
 }
 
 webrtc::FrameCryptorTransformer::Algorithm AlgorithmFromIndex(int index) {

--- a/sdk/android/src/jni/pc/frame_cryptor.h
+++ b/sdk/android/src/jni/pc/frame_cryptor.h
@@ -29,8 +29,7 @@ ScopedJavaLocalRef<jobject> NativeToJavaFrameCryptor(
     JNIEnv* env,
     rtc::scoped_refptr<FrameCryptorTransformer> cryptor);
 
-class FrameCryptorObserverJni : public FrameCryptorTransformerObserver,
-                                public rtc::RefCountInterface {
+class FrameCryptorObserverJni : public FrameCryptorTransformerObserver {
  public:
   FrameCryptorObserverJni(JNIEnv* jni, const JavaRef<jobject>& j_observer);
   ~FrameCryptorObserverJni() override;

--- a/sdk/objc/api/peerconnection/RTCFrameCryptor.h
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptor.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class RTC_OBJC_TYPE(RTCRtpReceiver);
 @class RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider);
 @class RTC_OBJC_TYPE(RTCFrameCryptor);
+@class RTC_OBJC_TYPE(RTCPeerConnectionFactory);
 
 typedef NS_ENUM(NSUInteger, RTCCyrptorAlgorithm) {
   RTCCyrptorAlgorithmAesGcm = 0,
@@ -60,15 +61,17 @@ RTC_OBJC_EXPORT
 
 @property(nonatomic, weak, nullable) id<RTC_OBJC_TYPE(RTCFrameCryptorDelegate)> delegate;
 
-- (instancetype)initWithRtpSender:(RTC_OBJC_TYPE(RTCRtpSender) *)sender
-                    participantId:(NSString *)participantId
-                        algorithm:(RTCCyrptorAlgorithm)algorithm
-                       keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider;
+- (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
+                      rtpSender:(RTC_OBJC_TYPE(RTCRtpSender) *)sender
+                  participantId:(NSString *)participantId
+                      algorithm:(RTCCyrptorAlgorithm)algorithm
+                    keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider;
 
-- (instancetype)initWithRtpReceiver:(RTC_OBJC_TYPE(RTCRtpReceiver) *)receiver
-                      participantId:(NSString *)participantId
-                          algorithm:(RTCCyrptorAlgorithm)algorithm
-                         keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider;
+- (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
+                    rtpReceiver:(RTC_OBJC_TYPE(RTCRtpReceiver) *)receiver
+                  participantId:(NSString *)participantId
+                      algorithm:(RTCCyrptorAlgorithm)algorithm
+                    keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCFrameCryptor.mm
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptor.mm
@@ -18,6 +18,7 @@
 #import "RTCFrameCryptorKeyProvider+Private.h"
 #import "RTCRtpReceiver+Private.h"
 #import "RTCRtpSender+Private.h"
+#import "RTCPeerConnectionFactory+Private.h"
 
 #include <memory>
 
@@ -111,11 +112,12 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
   }
 }
 
-- (instancetype)initWithRtpSender:(RTC_OBJC_TYPE(RTCRtpSender) *)sender
-                    participantId:(NSString *)participantId
-                        algorithm:(RTCCyrptorAlgorithm)algorithm
-                       keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider {
-  if (self = [super init]) { 
+- (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
+                      rtpSender:(RTC_OBJC_TYPE(RTCRtpSender) *)sender
+                  participantId:(NSString *)participantId
+                      algorithm:(RTCCyrptorAlgorithm)algorithm
+                    keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider {
+  if (self = [super init]) {
     _observer = rtc::make_ref_counted<webrtc::RTCFrameCryptorDelegateAdapter>(self);
     _participantId = participantId;
     auto rtpSender = sender.nativeRtpSender;
@@ -123,7 +125,8 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
         webrtc::FrameCryptorTransformer::MediaType::kAudioFrame :
         webrtc::FrameCryptorTransformer::MediaType::kVideoFrame;
     frame_crypto_transformer_ = rtc::scoped_refptr<webrtc::FrameCryptorTransformer>(
-        new webrtc::FrameCryptorTransformer([participantId stdString],
+        new webrtc::FrameCryptorTransformer(factory.signalingThread,
+                                            [participantId stdString],
                                             mediaType,
                                             [self algorithmFromEnum:algorithm],
                                             keyProvider.nativeKeyProvider));
@@ -135,10 +138,11 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
   return self;
 }
 
-- (instancetype)initWithRtpReceiver:(RTC_OBJC_TYPE(RTCRtpReceiver) *)receiver
-                      participantId:(NSString *)participantId
-                          algorithm:(RTCCyrptorAlgorithm)algorithm
-                         keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider {
+- (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
+                    rtpReceiver:(RTC_OBJC_TYPE(RTCRtpReceiver) *)receiver
+                  participantId:(NSString *)participantId
+                      algorithm:(RTCCyrptorAlgorithm)algorithm
+                    keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider {
   if (self = [super init]) {
     _observer = rtc::make_ref_counted<webrtc::RTCFrameCryptorDelegateAdapter>(self);
     _participantId = participantId;
@@ -147,7 +151,8 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
         webrtc::FrameCryptorTransformer::MediaType::kAudioFrame :
         webrtc::FrameCryptorTransformer::MediaType::kVideoFrame;
     frame_crypto_transformer_ = rtc::scoped_refptr<webrtc::FrameCryptorTransformer>(
-        new webrtc::FrameCryptorTransformer([participantId stdString],
+        new webrtc::FrameCryptorTransformer(factory.signalingThread,
+                                            [participantId stdString],
                                             mediaType,
                                             [self algorithmFromEnum:algorithm],
                                             keyProvider.nativeKeyProvider));


### PR DESCRIPTION
* replace all `std::shared_ptr` to `rtc::scoped_refptr`
* send encryption state events from the `signaling-thread`
* create framecryptor with signaling_thread. (break changes)