### PR TITLE
roll libvpx to include fix for CVE-2023-5217

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -289,7 +289,7 @@ deps = {
   'src/third_party/perfetto':
     'https://android.googlesource.com/platform/external/perfetto.git@20b114cd063623e63ef1b0a31167d60081567e51',
   'src/third_party/libvpx/source/libvpx':
-    'https://chromium.googlesource.com/webm/libvpx.git@27171320f5e36f7b18071bfa1d9616863ca1b4e8',
+    'https://chromium.googlesource.com/webm/libvpx.git@7aaffe2df4c9426ab204a272ca5ca52286ca86d4',
   'src/third_party/libyuv':
     'https://chromium.googlesource.com/libyuv/libyuv.git@77c2121f7e6b8e694d6e908bbbe9be24214097da',
   'src/third_party/lss': {


### PR DESCRIPTION
this rolls these 2 CLs in:
https://chromium-review.googlesource.com/c/webm/libvpx/+/4888549
https://chromium-review.googlesource.com/c/webm/libvpx/+/4888550

vuln described so far just here: https://chromereleases.googleblog.com/2023/09/stable-channel-update-for-desktop_27.html
>[$NA][[1486441](https://crbug.com/1486441)] High CVE-2023-5217: Heap buffer overflow in vp8 encoding in libvpx. Reported by Clément Lecigne of Google's Threat Analysis Group on 2023-09-25

https://nvd.nist.gov/vuln/detail/CVE-2023-5217