### PR TITLE
Fix missing `RTC_OBJC_TYPE` macros

### DIFF
--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -385,7 +385,12 @@ if (is_ios || is_mac) {
           "objc/components/network/RTCNetworkMonitor.mm",
         ]
 
-        configs += [ ":used_from_extension" ]
+        configs += [
+          "..:common_objc",
+          ":used_from_extension",
+        ]
+
+        public_configs = [ ":common_config_objc" ]
 
         frameworks = [ "Network.framework" ]
 

--- a/sdk/objc/api/RTCVideoRendererAdapter+Private.h
+++ b/sdk/objc/api/RTCVideoRendererAdapter+Private.h
@@ -16,7 +16,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RTCVideoRendererAdapter ()
+@interface RTC_OBJC_TYPE(RTCVideoRendererAdapter) ()
 
 /**
  * The Objective-C video renderer passed to this adapter during construction.

--- a/sdk/objc/api/RTCVideoRendererAdapter.h
+++ b/sdk/objc/api/RTCVideoRendererAdapter.h
@@ -10,6 +10,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "RTCMacros.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /*
@@ -18,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
  * adapter adapts calls made to that interface to the RTCVideoRenderer supplied
  * during construction.
  */
-@interface RTCVideoRendererAdapter : NSObject
+@interface RTC_OBJC_TYPE (RTCVideoRendererAdapter): NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/sdk/objc/api/RTCVideoRendererAdapter.mm
+++ b/sdk/objc/api/RTCVideoRendererAdapter.mm
@@ -17,10 +17,9 @@
 
 namespace webrtc {
 
-class VideoRendererAdapter
-    : public rtc::VideoSinkInterface<webrtc::VideoFrame> {
+class VideoRendererAdapter : public rtc::VideoSinkInterface<webrtc::VideoFrame> {
  public:
-  VideoRendererAdapter(RTCVideoRendererAdapter* adapter) {
+  VideoRendererAdapter(RTC_OBJC_TYPE(RTCVideoRendererAdapter) * adapter) {
     adapter_ = adapter;
     size_ = CGSizeZero;
   }
@@ -28,9 +27,9 @@ class VideoRendererAdapter
   void OnFrame(const webrtc::VideoFrame& nativeVideoFrame) override {
     RTC_OBJC_TYPE(RTCVideoFrame)* videoFrame = NativeToObjCVideoFrame(nativeVideoFrame);
 
-    CGSize current_size = (videoFrame.rotation % 180 == 0)
-                              ? CGSizeMake(videoFrame.width, videoFrame.height)
-                              : CGSizeMake(videoFrame.height, videoFrame.width);
+    CGSize current_size = (videoFrame.rotation % 180 == 0) ?
+        CGSizeMake(videoFrame.width, videoFrame.height) :
+        CGSizeMake(videoFrame.height, videoFrame.width);
 
     if (!CGSizeEqualToSize(size_, current_size)) {
       size_ = current_size;
@@ -40,12 +39,12 @@ class VideoRendererAdapter
   }
 
  private:
-  __weak RTCVideoRendererAdapter *adapter_;
+  __weak RTC_OBJC_TYPE(RTCVideoRendererAdapter) * adapter_;
   CGSize size_;
 };
-}
+}  // namespace webrtc
 
-@implementation RTCVideoRendererAdapter {
+@implementation RTC_OBJC_TYPE (RTCVideoRendererAdapter) {
   std::unique_ptr<webrtc::VideoRendererAdapter> _adapter;
 }
 
@@ -60,7 +59,7 @@ class VideoRendererAdapter
   return self;
 }
 
-- (rtc::VideoSinkInterface<webrtc::VideoFrame> *)nativeVideoRenderer {
+- (rtc::VideoSinkInterface<webrtc::VideoFrame>*)nativeVideoRenderer {
   return _adapter.get();
 }
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule+Private.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule+Private.h
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RTCAudioDeviceModule ()
+@interface RTC_OBJC_TYPE(RTCAudioDeviceModule) ()
 
 - (instancetype)initWithNativeModule:(rtc::scoped_refptr<webrtc::AudioDeviceModule> )module
                         workerThread:(rtc::Thread *)workerThread;

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -39,8 +39,8 @@ RTC_OBJC_EXPORT
 // Executes low-level API's in sequence to switch the device
 // Use outputDevice / inputDevice property unless you need to know if setting the device is
 // successful.
-- (BOOL)trySetOutputDevice:(nullable RTCIODevice *)device;
-- (BOOL)trySetInputDevice:(nullable RTCIODevice *)device;
+- (BOOL)trySetOutputDevice:(nullable RTC_OBJC_TYPE(RTCIODevice) *)device;
+- (BOOL)trySetInputDevice:(nullable RTC_OBJC_TYPE(RTCIODevice) *)device;
 
 - (BOOL)setDevicesUpdatedHandler: (nullable RTCOnAudioDevicesDidUpdate) handler;
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -77,7 +77,7 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
   });
 }
 
-- (RTCIODevice *)outputDevice {
+- (RTC_OBJC_TYPE(RTCIODevice) *)outputDevice {
   return _workerThread->BlockingCall([self] {
 
     NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *devices = [self _outputDevices];
@@ -92,11 +92,11 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
   });
 }
 
-- (void)setOutputDevice: (RTCIODevice *)device {
+- (void)setOutputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
   [self trySetOutputDevice: device];
 }
 
-- (BOOL)trySetOutputDevice: (RTCIODevice *)device {
+- (BOOL)trySetOutputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
 
   return _workerThread->BlockingCall([self, device] {
 
@@ -108,7 +108,7 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
     }
 
     if (device != nil) {
-      index = [devices indexOfObjectPassingTest:^BOOL(RTCIODevice *e, NSUInteger i, BOOL *stop) {
+      index = [devices indexOfObjectPassingTest:^BOOL(RTC_OBJC_TYPE(RTCIODevice) *e, NSUInteger i, BOOL *stop) {
         return (*stop = [e.deviceId isEqualToString:device.deviceId]);
       }];
       if (index == NSNotFound) {
@@ -129,7 +129,7 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
   });
 }
 
-- (RTCIODevice *)inputDevice {
+- (RTC_OBJC_TYPE(RTCIODevice) *)inputDevice {
 
   return _workerThread->BlockingCall([self] {
   
@@ -145,11 +145,11 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
   });
 }
 
-- (void)setInputDevice: (RTCIODevice *)device {
+- (void)setInputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
   [self trySetInputDevice: device];
 }
 
-- (BOOL)trySetInputDevice: (RTCIODevice *)device {
+- (BOOL)trySetInputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
 
   return _workerThread->BlockingCall([self, device] {
 
@@ -161,7 +161,7 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
     }
 
     if (device != nil) {
-      index = [devices indexOfObjectPassingTest:^BOOL(RTCIODevice *e, NSUInteger i, BOOL *stop) {
+      index = [devices indexOfObjectPassingTest:^BOOL(RTC_OBJC_TYPE(RTCIODevice) *e, NSUInteger i, BOOL *stop) {
         return (*stop = [e.deviceId isEqualToString:device.deviceId]);
       }];
       if (index == NSNotFound) {
@@ -261,7 +261,7 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
       _native->PlayoutDeviceName(i, name, guid);
       NSString *strGUID = [[NSString alloc] initWithCString:guid encoding:NSUTF8StringEncoding];
       NSString *strName = [[NSString alloc] initWithCString:name encoding:NSUTF8StringEncoding];
-      RTCIODevice *device = [[RTCIODevice alloc] initWithType:RTCIODeviceTypeOutput deviceId:strGUID name:strName];
+      RTC_OBJC_TYPE(RTCIODevice) *device = [[RTC_OBJC_TYPE(RTCIODevice) alloc] initWithType:RTCIODeviceTypeOutput deviceId:strGUID name:strName];
       [result addObject: device];
     }
   }
@@ -283,7 +283,7 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
       _native->RecordingDeviceName(i, name, guid);
       NSString *strGUID = [[NSString alloc] initWithCString:guid encoding:NSUTF8StringEncoding];
       NSString *strName = [[NSString alloc] initWithCString:name encoding:NSUTF8StringEncoding];
-      RTCIODevice *device = [[RTCIODevice alloc] initWithType:RTCIODeviceTypeInput deviceId:strGUID name:strName];
+      RTC_OBJC_TYPE(RTCIODevice) *device = [[RTC_OBJC_TYPE(RTCIODevice) alloc] initWithType:RTCIODeviceTypeInput deviceId:strGUID name:strName];
       [result addObject: device];
     }
   }

--- a/sdk/objc/api/peerconnection/RTCAudioTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioTrack.mm
@@ -28,12 +28,12 @@ namespace webrtc {
 class AudioSinkConverter : public rtc::RefCountInterface, public webrtc::AudioTrackSinkInterface {
  private:
   os_unfair_lock *lock_;
-  __weak RTCAudioTrack *audio_track_;
+  __weak RTC_OBJC_TYPE(RTCAudioTrack) *audio_track_;
   int64_t total_frames_ = 0;
   bool attached_ = false;
 
  public:
-  AudioSinkConverter(RTCAudioTrack *audioTrack, os_unfair_lock *lock) {
+  AudioSinkConverter(RTC_OBJC_TYPE(RTCAudioTrack) *audioTrack, os_unfair_lock *lock) {
     RTC_LOG(LS_INFO) << "RTCAudioTrack.AudioSinkConverter init";
     audio_track_ = audioTrack;
     lock_ = lock;
@@ -274,7 +274,7 @@ class AudioSinkConverter : public rtc::RefCountInterface, public webrtc::AudioTr
   NSArray *renderers = [_renderers allObjects];
   os_unfair_lock_unlock(&_lock);
 
-  for (id<RTCAudioRenderer> renderer in renderers) {
+  for (id<RTC_OBJC_TYPE(RTCAudioRenderer)> renderer in renderers) {
     [renderer renderSampleBuffer:sampleBuffer];
   }
 }

--- a/sdk/objc/api/peerconnection/RTCEncodedImage+Private.mm
+++ b/sdk/objc/api/peerconnection/RTCEncodedImage+Private.mm
@@ -38,7 +38,7 @@ class ObjCEncodedImageBuffer : public webrtc::EncodedImageBufferInterface {
 
 // A simple wrapper around webrtc::EncodedImageBufferInterface to make it usable with associated
 // objects.
-@interface RTCWrappedEncodedImageBuffer : NSObject
+@interface RTC_OBJC_TYPE(RTCWrappedEncodedImageBuffer): NSObject
 @property(nonatomic) rtc::scoped_refptr<webrtc::EncodedImageBufferInterface> buffer;
 - (instancetype)initWithEncodedImageBuffer:
     (rtc::scoped_refptr<webrtc::EncodedImageBufferInterface>)buffer;

--- a/sdk/objc/api/peerconnection/RTCEncodedImage+Private.mm
+++ b/sdk/objc/api/peerconnection/RTCEncodedImage+Private.mm
@@ -34,16 +34,16 @@ class ObjCEncodedImageBuffer : public webrtc::EncodedImageBufferInterface {
 
   NSData *data_;
 };
-}
+}  // namespace
 
 // A simple wrapper around webrtc::EncodedImageBufferInterface to make it usable with associated
 // objects.
-@interface RTC_OBJC_TYPE(RTCWrappedEncodedImageBuffer): NSObject
+@interface RTC_OBJC_TYPE (RTCWrappedEncodedImageBuffer): NSObject
 @property(nonatomic) rtc::scoped_refptr<webrtc::EncodedImageBufferInterface> buffer;
 - (instancetype)initWithEncodedImageBuffer:
     (rtc::scoped_refptr<webrtc::EncodedImageBufferInterface>)buffer;
 @end
-@implementation RTCWrappedEncodedImageBuffer
+@implementation RTC_OBJC_TYPE (RTCWrappedEncodedImageBuffer)
 @synthesize buffer = _buffer;
 - (instancetype)initWithEncodedImageBuffer:
     (rtc::scoped_refptr<webrtc::EncodedImageBufferInterface>)buffer {
@@ -59,7 +59,7 @@ class ObjCEncodedImageBuffer : public webrtc::EncodedImageBufferInterface {
 (Private)
 
     - (rtc::scoped_refptr<webrtc::EncodedImageBufferInterface>)encodedData {
-  RTCWrappedEncodedImageBuffer *wrappedBuffer =
+  RTC_OBJC_TYPE(RTCWrappedEncodedImageBuffer) *wrappedBuffer =
       objc_getAssociatedObject(self, @selector(encodedData));
   return wrappedBuffer.buffer;
 }
@@ -68,7 +68,7 @@ class ObjCEncodedImageBuffer : public webrtc::EncodedImageBufferInterface {
   return objc_setAssociatedObject(
       self,
       @selector(encodedData),
-      [[RTCWrappedEncodedImageBuffer alloc] initWithEncodedImageBuffer:buffer],
+      [[RTC_OBJC_TYPE(RTCWrappedEncodedImageBuffer) alloc] initWithEncodedImageBuffer:buffer],
       OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 

--- a/sdk/objc/api/peerconnection/RTCIODevice+Private.h
+++ b/sdk/objc/api/peerconnection/RTCIODevice+Private.h
@@ -17,7 +17,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RTCIODevice ()
+@interface RTC_OBJC_TYPE(RTCIODevice) ()
 
 - (instancetype)initWithType:(RTCIODeviceType)type
                     deviceId:(NSString *)deviceId

--- a/sdk/objc/api/peerconnection/RTCIODevice.mm
+++ b/sdk/objc/api/peerconnection/RTCIODevice.mm
@@ -19,7 +19,7 @@
 
 NSString *const kDefaultDeviceId = @"default";
 
-@implementation RTCIODevice
+@implementation RTC_OBJC_TYPE(RTCIODevice)
 
 @synthesize type = _type;
 @synthesize deviceId = _deviceId;

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
@@ -66,7 +66,7 @@ RTC_OBJC_EXPORT
             audioProcessingModule:
                 (nullable id<RTC_OBJC_TYPE(RTCAudioProcessingModule)>)audioProcessingModule;
 
-@property(nonatomic, readonly) RTCAudioDeviceModule *audioDeviceModule;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCAudioDeviceModule) *audioDeviceModule;
 
 - (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpSenderCapabilitiesFor:(RTCRtpMediaType)mediaType;
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -65,7 +65,7 @@
   std::unique_ptr<rtc::Thread> _workerThread;
   std::unique_ptr<rtc::Thread> _signalingThread;
   rtc::scoped_refptr<webrtc::AudioDeviceModule> _nativeAudioDeviceModule;
-  RTCDefaultAudioProcessingModule *_defaultAudioProcessingModule;
+  RTC_OBJC_TYPE(RTCDefaultAudioProcessingModule) *_defaultAudioProcessingModule;
 
   BOOL _hasStartedAecDump;
 }
@@ -133,16 +133,16 @@
 
 - (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpSenderCapabilitiesFor:(RTCRtpMediaType)mediaType {
 
-  webrtc::RtpCapabilities capabilities = _nativeFactory->GetRtpSenderCapabilities([RTCRtpReceiver nativeMediaTypeForMediaType: mediaType]);
+  webrtc::RtpCapabilities capabilities = _nativeFactory->GetRtpSenderCapabilities([RTC_OBJC_TYPE(RTCRtpReceiver) nativeMediaTypeForMediaType: mediaType]);
 
-  return [[RTCRtpCapabilities alloc] initWithNativeCapabilities: capabilities];
+  return [[RTC_OBJC_TYPE(RTCRtpCapabilities) alloc] initWithNativeCapabilities: capabilities];
 }
 
 - (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpReceiverCapabilitiesFor:(RTCRtpMediaType)mediaType {
 
-  webrtc::RtpCapabilities capabilities = _nativeFactory->GetRtpReceiverCapabilities([RTCRtpReceiver nativeMediaTypeForMediaType: mediaType]);
+  webrtc::RtpCapabilities capabilities = _nativeFactory->GetRtpReceiverCapabilities([RTC_OBJC_TYPE(RTCRtpReceiver) nativeMediaTypeForMediaType: mediaType]);
 
-  return [[RTCRtpCapabilities alloc] initWithNativeCapabilities: capabilities];
+  return [[RTC_OBJC_TYPE(RTCRtpCapabilities) alloc] initWithNativeCapabilities: capabilities];
 }
 
 - (instancetype)
@@ -164,10 +164,10 @@
   }
   rtc::scoped_refptr<webrtc::AudioDeviceModule> audio_device_module = [self createAudioDeviceModule:bypassVoiceProcessing];
 
-  if ([audioProcessingModule isKindOfClass:[RTCDefaultAudioProcessingModule class]]) {
-    _defaultAudioProcessingModule = (RTCDefaultAudioProcessingModule *)audioProcessingModule;
+  if ([audioProcessingModule isKindOfClass:[RTC_OBJC_TYPE(RTCDefaultAudioProcessingModule) class]]) {
+    _defaultAudioProcessingModule = (RTC_OBJC_TYPE(RTCDefaultAudioProcessingModule) *)audioProcessingModule;
   } else {
-    _defaultAudioProcessingModule = [[RTCDefaultAudioProcessingModule alloc] init];
+    _defaultAudioProcessingModule = [[RTC_OBJC_TYPE(RTCDefaultAudioProcessingModule) alloc] init];
   }
 
   NSLog(@"AudioProcessingModule: %@", _defaultAudioProcessingModule);
@@ -273,8 +273,9 @@
                                                bypassVoiceProcessing == YES);
 	  });
 
-    _audioDeviceModule = [[RTCAudioDeviceModule alloc] initWithNativeModule: _nativeAudioDeviceModule
-                                                       workerThread: _workerThread.get()];
+    _audioDeviceModule =
+        [[RTC_OBJC_TYPE(RTCAudioDeviceModule) alloc] initWithNativeModule:_nativeAudioDeviceModule
+                                                             workerThread:_workerThread.get()];
 
     media_deps.adm = _nativeAudioDeviceModule;
     media_deps.task_queue_factory = dependencies.task_queue_factory.get();

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder+DefaultComponents.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder+DefaultComponents.h
@@ -12,9 +12,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RTCPeerConnectionFactoryBuilder (DefaultComponents)
+@interface RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) (DefaultComponents)
 
-+ (RTCPeerConnectionFactoryBuilder *)defaultBuilder;
++ (RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) *)defaultBuilder;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder+DefaultComponents.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder+DefaultComponents.mm
@@ -22,10 +22,10 @@
 #import "sdk/objc/native/api/audio_device_module.h"
 #endif
 
-@implementation RTCPeerConnectionFactoryBuilder (DefaultComponents)
+@implementation RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) (DefaultComponents)
 
-+ (RTCPeerConnectionFactoryBuilder *)defaultBuilder {
-  RTCPeerConnectionFactoryBuilder *builder = [[RTCPeerConnectionFactoryBuilder alloc] init];
++ (RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) *)defaultBuilder {
+  RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) *builder = [[RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) alloc] init];
   auto audioEncoderFactory = webrtc::CreateBuiltinAudioEncoderFactory();
   [builder setAudioEncoderFactory:audioEncoderFactory];
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.h
@@ -25,7 +25,7 @@ class AudioProcessing;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RTCPeerConnectionFactoryBuilder : NSObject
+@interface RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) : NSObject
 
 + (RTCPeerConnectionFactoryBuilder *)builder;
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) : NSObject
 
-+ (RTCPeerConnectionFactoryBuilder *)builder;
++ (RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) *)builder;
 
 - (RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)createPeerConnectionFactory;
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.mm
@@ -27,8 +27,8 @@
   rtc::scoped_refptr<webrtc::AudioProcessing> _audioProcessingModule;
 }
 
-+ (RTCPeerConnectionFactoryBuilder *)builder {
-  return [[RTCPeerConnectionFactoryBuilder alloc] init];
++ (RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) *)builder {
+  return [[RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) alloc] init];
 }
 
 - (RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)createPeerConnectionFactory {

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.mm
@@ -18,7 +18,7 @@
 #include "modules/audio_device/include/audio_device.h"
 #include "modules/audio_processing/include/audio_processing.h"
 
-@implementation RTCPeerConnectionFactoryBuilder {
+@implementation RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) {
   std::unique_ptr<webrtc::VideoEncoderFactory> _videoEncoderFactory;
   std::unique_ptr<webrtc::VideoDecoderFactory> _videoDecoderFactory;
   rtc::scoped_refptr<webrtc::AudioEncoderFactory> _audioEncoderFactory;

--- a/sdk/objc/api/peerconnection/RTCRtpCapabilities.mm
+++ b/sdk/objc/api/peerconnection/RTCRtpCapabilities.mm
@@ -39,8 +39,8 @@
   NSMutableArray *result = [NSMutableArray array];
 
   for (auto &element : _nativeCapabilities.codecs) {
-    RTCRtpCodecCapability *object =
-        [[RTCRtpCodecCapability alloc] initWithNativeCodecCapability:element];
+    RTC_OBJC_TYPE(RTCRtpCodecCapability) *object =
+        [[RTC_OBJC_TYPE(RTCRtpCodecCapability) alloc] initWithNativeCodecCapability:element];
     [result addObject:object];
   }
 

--- a/sdk/objc/api/peerconnection/RTCRtpCodecCapability.mm
+++ b/sdk/objc/api/peerconnection/RTCRtpCodecCapability.mm
@@ -54,11 +54,11 @@
 }
 
 - (RTCRtpMediaType)kind {
-  return [RTCRtpReceiver mediaTypeForNativeMediaType:_nativeCodecCapability.kind];
+  return [RTC_OBJC_TYPE(RTCRtpReceiver) mediaTypeForNativeMediaType:_nativeCodecCapability.kind];
 }
 
 - (void)setKind:(RTCRtpMediaType)kind {
-  _nativeCodecCapability.kind = [RTCRtpReceiver nativeMediaTypeForMediaType:kind];
+  _nativeCodecCapability.kind = [RTC_OBJC_TYPE(RTCRtpReceiver) nativeMediaTypeForMediaType:kind];
 }
 
 - (NSNumber *)clockRate {

--- a/sdk/objc/api/peerconnection/RTCRtpTransceiver.mm
+++ b/sdk/objc/api/peerconnection/RTCRtpTransceiver.mm
@@ -71,7 +71,7 @@ NSString *const kRTCRtpTransceiverErrorDomain = @"org.webrtc.RTCRtpTranceiver";
 
   std::vector<webrtc::RtpCodecCapability> objects;
 
-  for (RTCRtpCodecCapability *object in codecPreferences) {
+  for (RTC_OBJC_TYPE(RTCRtpCodecCapability) *object in codecPreferences) {
     objects.push_back(object.nativeCodecCapability);
   }
 
@@ -90,7 +90,7 @@ NSString *const kRTCRtpTransceiverErrorDomain = @"org.webrtc.RTCRtpTranceiver";
   std::vector<webrtc::RtpCodecCapability> capabilities = _nativeRtpTransceiver->codec_preferences();
 
   for (auto & element : capabilities) {
-    RTCRtpCodecCapability *object = [[RTCRtpCodecCapability alloc] initWithNativeCodecCapability: element];
+    RTC_OBJC_TYPE(RTCRtpCodecCapability) *object = [[RTC_OBJC_TYPE(RTCRtpCodecCapability) alloc] initWithNativeCodecCapability: element];
     [result addObject: object];
   }
 

--- a/sdk/objc/api/peerconnection/RTCVideoTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCVideoTrack.mm
@@ -53,7 +53,7 @@
 }
 
 - (void)dealloc {
-  for (RTCVideoRendererAdapter *adapter in _adapters) {
+  for (RTC_OBJC_TYPE(RTCVideoRendererAdapter) * adapter in _adapters) {
     self.nativeVideoTrack->RemoveSink(adapter.nativeVideoRenderer);
   }
 }
@@ -85,18 +85,17 @@
   }
 
   // Make sure we don't have this renderer yet.
-  for (RTCVideoRendererAdapter *adapter in _adapters) {
+  for (RTC_OBJC_TYPE(RTCVideoRendererAdapter) * adapter in _adapters) {
     if (adapter.videoRenderer == renderer) {
       RTC_LOG(LS_INFO) << "|renderer| is already attached to this track";
       return;
     }
   }
   // Create a wrapper that provides a native pointer for us.
-  RTCVideoRendererAdapter* adapter =
-      [[RTCVideoRendererAdapter alloc] initWithNativeRenderer:renderer];
+  RTC_OBJC_TYPE(RTCVideoRendererAdapter) *adapter =
+      [[RTC_OBJC_TYPE(RTCVideoRendererAdapter) alloc] initWithNativeRenderer:renderer];
   [_adapters addObject:adapter];
-  self.nativeVideoTrack->AddOrUpdateSink(adapter.nativeVideoRenderer,
-                                         rtc::VideoSinkWants());
+  self.nativeVideoTrack->AddOrUpdateSink(adapter.nativeVideoRenderer, rtc::VideoSinkWants());
 }
 
 - (void)removeRenderer:(id<RTC_OBJC_TYPE(RTCVideoRenderer)>)renderer {
@@ -105,9 +104,8 @@
     return;
   }
   __block NSUInteger indexToRemove = NSNotFound;
-  [_adapters enumerateObjectsUsingBlock:^(RTCVideoRendererAdapter *adapter,
-                                          NSUInteger idx,
-                                          BOOL *stop) {
+  [_adapters enumerateObjectsUsingBlock:^(
+                 RTC_OBJC_TYPE(RTCVideoRendererAdapter) * adapter, NSUInteger idx, BOOL * stop) {
     if (adapter.videoRenderer == renderer) {
       indexToRemove = idx;
       *stop = YES;
@@ -117,8 +115,7 @@
     RTC_LOG(LS_INFO) << "removeRenderer called with a renderer that has not been previously added";
     return;
   }
-  RTCVideoRendererAdapter *adapterToRemove =
-      [_adapters objectAtIndex:indexToRemove];
+  RTC_OBJC_TYPE(RTCVideoRendererAdapter) *adapterToRemove = [_adapters objectAtIndex:indexToRemove];
   self.nativeVideoTrack->RemoveSink(adapterToRemove.nativeVideoRenderer);
   [_adapters removeObjectAtIndex:indexToRemove];
 }

--- a/sdk/objc/base/RTCAudioRenderer.h
+++ b/sdk/objc/base/RTCAudioRenderer.h
@@ -23,11 +23,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
-(RTCAudioRenderer)<NSObject>
+RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE(RTCAudioRenderer)<NSObject>
 
-    - (void)renderSampleBuffer : (CMSampleBufferRef)sampleBuffer
-                                 NS_SWIFT_NAME(render(sampleBuffer:));
+- (void)renderSampleBuffer: (CMSampleBufferRef)sampleBuffer NS_SWIFT_NAME(render(sampleBuffer:));
 
 @end
 

--- a/sdk/objc/base/RTCMacros.h
+++ b/sdk/objc/base/RTCMacros.h
@@ -38,7 +38,7 @@
 //
 // This macro must only be defined here and not on via compiler flag to
 // ensure it has a unique value.
-#define RTC_OBJC_TYPE_PREFIX
+#define RTC_OBJC_TYPE_PREFIX LK_
 
 // RCT_OBJC_TYPE
 //

--- a/sdk/objc/base/RTCMacros.h
+++ b/sdk/objc/base/RTCMacros.h
@@ -38,7 +38,7 @@
 //
 // This macro must only be defined here and not on via compiler flag to
 // ensure it has a unique value.
-#define RTC_OBJC_TYPE_PREFIX LK_
+#define RTC_OBJC_TYPE_PREFIX
 
 // RCT_OBJC_TYPE
 //

--- a/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter+Private.h
+++ b/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter+Private.h
@@ -25,18 +25,18 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RTC_OBJC_TYPE(RTCAudioCustomProcessingAdapter) ()
 
 // Thread safe set/get with os_unfair_lock.
-@property(nonatomic, weak, nullable) id<RTCAudioCustomProcessingDelegate>
+@property(nonatomic, weak, nullable) id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)>
     audioCustomProcessingDelegate;
 
 // Direct read access without lock.
-@property(nonatomic, readonly, weak, nullable) id<RTCAudioCustomProcessingDelegate>
+@property(nonatomic, readonly, weak, nullable) id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)>
     rawAudioCustomProcessingDelegate;
 
 @property(nonatomic, readonly) std::unique_ptr<webrtc::CustomProcessing>
     nativeAudioCustomProcessingModule;
 
 - (instancetype)initWithDelegate:
-    (nullable id<RTCAudioCustomProcessingDelegate>)audioCustomProcessingDelegate;
+    (nullable id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)>)audioCustomProcessingDelegate;
 
 @end
 

--- a/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter+Private.h
+++ b/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter+Private.h
@@ -22,7 +22,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RTCAudioCustomProcessingAdapter ()
+@interface RTC_OBJC_TYPE(RTCAudioCustomProcessingAdapter) ()
 
 // Thread safe set/get with os_unfair_lock.
 @property(nonatomic, weak, nullable) id<RTCAudioCustomProcessingDelegate>

--- a/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter.h
+++ b/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter.h
@@ -19,7 +19,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RTCAudioCustomProcessingAdapter : NSObject
+@interface RTC_OBJC_TYPE(RTCAudioCustomProcessingAdapter) : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter.mm
+++ b/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter.mm
@@ -31,7 +31,7 @@ class AudioCustomProcessingAdapter : public webrtc::CustomProcessing {
   int sample_rate_hz_;
   int num_channels_;
 
-  AudioCustomProcessingAdapter(RTCAudioCustomProcessingAdapter *adapter, os_unfair_lock *lock) {
+  AudioCustomProcessingAdapter(RTC_OBJC_TYPE(RTCAudioCustomProcessingAdapter) *adapter, os_unfair_lock *lock) {
     RTC_LOG(LS_INFO) << "RTCAudioCustomProcessingAdapter.AudioCustomProcessingAdapter init";
 
     adapter_ = adapter;
@@ -79,12 +79,12 @@ class AudioCustomProcessingAdapter : public webrtc::CustomProcessing {
   std::string ToString() const override { return "AudioCustomProcessingAdapter"; }
 
  private:
-  __weak RTCAudioCustomProcessingAdapter *adapter_;
+  __weak RTC_OBJC_TYPE(RTCAudioCustomProcessingAdapter) *adapter_;
   os_unfair_lock *lock_;
 };
 }  // namespace webrtc
 
-@implementation RTCAudioCustomProcessingAdapter {
+@implementation RTC_OBJC_TYPE(RTCAudioCustomProcessingAdapter) {
   webrtc::AudioCustomProcessingAdapter *_adapter;
   os_unfair_lock _lock;
 }

--- a/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter.mm
+++ b/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter.mm
@@ -45,14 +45,14 @@ class AudioCustomProcessingAdapter : public webrtc::CustomProcessing {
     RTC_LOG(LS_INFO) << "RTCAudioCustomProcessingAdapter.AudioCustomProcessingAdapter dealloc";
 
     os_unfair_lock_lock(lock_);
-    id<RTCAudioCustomProcessingDelegate> delegate = adapter_.rawAudioCustomProcessingDelegate;
+    id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)> delegate = adapter_.rawAudioCustomProcessingDelegate;
     [delegate audioProcessingRelease];
     os_unfair_lock_unlock(lock_);
   }
 
   void Initialize(int sample_rate_hz, int num_channels) override {
     os_unfair_lock_lock(lock_);
-    id<RTCAudioCustomProcessingDelegate> delegate = adapter_.rawAudioCustomProcessingDelegate;
+    id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)> delegate = adapter_.rawAudioCustomProcessingDelegate;
     [delegate audioProcessingInitializeWithSampleRate:sample_rate_hz channels:num_channels];
     is_initialized_ = true;
     sample_rate_hz_ = sample_rate_hz;
@@ -68,9 +68,9 @@ class AudioCustomProcessingAdapter : public webrtc::CustomProcessing {
 
       return;
     }
-    id<RTCAudioCustomProcessingDelegate> delegate = adapter_.rawAudioCustomProcessingDelegate;
+    id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)> delegate = adapter_.rawAudioCustomProcessingDelegate;
     if (delegate != nil) {
-      RTCAudioBuffer *audioBuffer = [[RTCAudioBuffer alloc] initWithNativeType:audio_buffer];
+      RTC_OBJC_TYPE(RTCAudioBuffer) *audioBuffer = [[RTC_OBJC_TYPE(RTCAudioBuffer) alloc] initWithNativeType:audio_buffer];
       [delegate audioProcessingProcess:audioBuffer];
     }
     os_unfair_lock_unlock(lock_);
@@ -109,14 +109,14 @@ class AudioCustomProcessingAdapter : public webrtc::CustomProcessing {
 
 #pragma mark - Getter & Setter for audioCustomProcessingDelegate
 
-- (nullable id<RTCAudioCustomProcessingDelegate>)audioCustomProcessingDelegate {
+- (nullable id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)>)audioCustomProcessingDelegate {
   os_unfair_lock_lock(&_lock);
-  id<RTCAudioCustomProcessingDelegate> delegate = _rawAudioCustomProcessingDelegate;
+  id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)> delegate = _rawAudioCustomProcessingDelegate;
   os_unfair_lock_unlock(&_lock);
   return delegate;
 }
 
-- (void)setAudioCustomProcessingDelegate:(nullable id<RTCAudioCustomProcessingDelegate>)delegate {
+- (void)setAudioCustomProcessingDelegate:(nullable id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)>)delegate {
   os_unfair_lock_lock(&_lock);
   if (_rawAudioCustomProcessingDelegate != nil && _adapter->is_initialized_) {
     [_rawAudioCustomProcessingDelegate audioProcessingRelease];

--- a/sdk/objc/components/audio/RTCAudioCustomProcessingDelegate.h
+++ b/sdk/objc/components/audio/RTCAudioCustomProcessingDelegate.h
@@ -36,7 +36,7 @@ RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE (RTCAudioCustomProcessingDelegate)<NSObj
  * RTCAudioBuffer is a simple wrapper for webrtc::AudioBuffer and the valid scope is only inside
  * this method. Do not retain it.
  */
-- (void)audioProcessingProcess:(RTCAudioBuffer *)audioBuffer
+- (void)audioProcessingProcess:(RTC_OBJC_TYPE(RTCAudioBuffer) *)audioBuffer
     NS_SWIFT_NAME(audioProcessingProcess(audioBuffer:));
 
 // TOOD:

--- a/sdk/objc/components/audio/RTCAudioProcessingModule.h
+++ b/sdk/objc/components/audio/RTCAudioProcessingModule.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE (RTCAudioProcessingModule)<NSObject>
 
-- (void)applyConfig: (RTCAudioProcessingConfig *)config;
+- (void)applyConfig: (RTC_OBJC_TYPE(RTCAudioProcessingConfig) *)config;
 
 // TODO: Implement...
 

--- a/sdk/objc/components/audio/RTCDefaultAudioProcessingModule.h
+++ b/sdk/objc/components/audio/RTCDefaultAudioProcessingModule.h
@@ -22,18 +22,17 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class RTC_OBJC_TYPE(RTCAudioProcessingConfig);
-@protocol RTC_OBJC_TYPE
-(RTCAudioCustomProcessingDelegate);
+@protocol RTC_OBJC_TYPE (RTCAudioCustomProcessingDelegate);
 
 RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCDefaultAudioProcessingModule) : NSObject <RTC_OBJC_TYPE(RTCAudioProcessingModule)>
 
-- (instancetype)initWithConfig: (nullable RTCAudioProcessingConfig *)config
+- (instancetype)initWithConfig: (nullable RTC_OBJC_TYPE(RTCAudioProcessingConfig) *)config
  capturePostProcessingDelegate: (nullable id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)>)capturePostProcessingDelegate
    renderPreProcessingDelegate: (nullable id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)>)renderPreProcessingDelegate
    NS_SWIFT_NAME(init(config:capturePostProcessingDelegate:renderPreProcessingDelegate:)) NS_DESIGNATED_INITIALIZER;
 
-- (void)applyConfig:(RTCAudioProcessingConfig *)config;
+- (void)applyConfig:(RTC_OBJC_TYPE(RTCAudioProcessingConfig) *)config;
 
 // Dynamically update delegates at runtime
 

--- a/sdk/objc/components/audio/RTCDefaultAudioProcessingModule.mm
+++ b/sdk/objc/components/audio/RTCDefaultAudioProcessingModule.mm
@@ -33,7 +33,7 @@
         renderPreProcessingDelegate:nil];
 }
 
-- (instancetype)initWithConfig:(nullable RTCAudioProcessingConfig *)config
+- (instancetype)initWithConfig:(nullable RTC_OBJC_TYPE(RTCAudioProcessingConfig) *)config
     capturePostProcessingDelegate:
         (nullable id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)>)capturePostProcessingDelegate
       renderPreProcessingDelegate:(nullable id<RTC_OBJC_TYPE(RTCAudioCustomProcessingDelegate)>)
@@ -83,7 +83,7 @@
 
 #pragma mark - RTCAudioProcessingModule protocol
 
-- (void)applyConfig:(RTCAudioProcessingConfig *)config {
+- (void)applyConfig:(RTC_OBJC_TYPE(RTCAudioProcessingConfig) *)config {
   _nativeAudioProcessingModule->ApplyConfig(config.nativeAudioProcessingConfig);
 }
 

--- a/sdk/objc/components/audio/RTCDefaultAudioProcessingModule.mm
+++ b/sdk/objc/components/audio/RTCDefaultAudioProcessingModule.mm
@@ -23,8 +23,8 @@
 @implementation RTC_OBJC_TYPE (RTCDefaultAudioProcessingModule) {
   rtc::scoped_refptr<webrtc::AudioProcessing> _nativeAudioProcessingModule;
   // Custom processing adapters...
-  RTCAudioCustomProcessingAdapter *_capturePostProcessingAdapter;
-  RTCAudioCustomProcessingAdapter *_renderPreProcessingAdapter;
+  RTC_OBJC_TYPE(RTCAudioCustomProcessingAdapter) *_capturePostProcessingAdapter;
+  RTC_OBJC_TYPE(RTCAudioCustomProcessingAdapter) *_renderPreProcessingAdapter;
 }
 
 - (instancetype)init {
@@ -48,12 +48,12 @@
     }
 
     _capturePostProcessingAdapter =
-        [[RTCAudioCustomProcessingAdapter alloc] initWithDelegate:capturePostProcessingDelegate];
+        [[RTC_OBJC_TYPE(RTCAudioCustomProcessingAdapter) alloc] initWithDelegate:capturePostProcessingDelegate];
     builder.SetCapturePostProcessing(
         _capturePostProcessingAdapter.nativeAudioCustomProcessingModule);
 
     _renderPreProcessingAdapter =
-        [[RTCAudioCustomProcessingAdapter alloc] initWithDelegate:renderPreProcessingDelegate];
+        [[RTC_OBJC_TYPE(RTCAudioCustomProcessingAdapter) alloc] initWithDelegate:renderPreProcessingDelegate];
     builder.SetRenderPreProcessing(_renderPreProcessingAdapter.nativeAudioCustomProcessingModule);
 
     _nativeAudioProcessingModule = builder.Create();

--- a/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.h
+++ b/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.h
@@ -19,7 +19,7 @@ class AudioSessionObserver;
 /** Adapter that forwards RTCAudioSessionDelegate calls to the appropriate
  *  methods on the AudioSessionObserver.
  */
-@interface RTCNativeAudioSessionDelegateAdapter : NSObject <RTC_OBJC_TYPE (RTCAudioSessionDelegate)>
+@interface RTC_OBJC_TYPE(RTCNativeAudioSessionDelegateAdapter) : NSObject <RTC_OBJC_TYPE (RTCAudioSessionDelegate)>
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
+++ b/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
@@ -14,7 +14,7 @@
 
 #import "base/RTCLogging.h"
 
-@implementation RTCNativeAudioSessionDelegateAdapter {
+@implementation RTC_OBJC_TYPE(RTCNativeAudioSessionDelegateAdapter) {
   webrtc::AudioSessionObserver *_observer;
 }
 

--- a/sdk/objc/components/capturer/RTCDesktopCapturer+Private.h
+++ b/sdk/objc/components/capturer/RTCDesktopCapturer+Private.h
@@ -30,7 +30,7 @@ RTC_OBJC_EXPORT
 -(void)didSourceCaptureError;
 @end
 
-@interface RTCDesktopCapturer ()
+@interface RTC_OBJC_TYPE(RTCDesktopCapturer) ()
 
 @property(nonatomic, readonly)std::shared_ptr<webrtc::ObjCDesktopCapturer> nativeCapturer;
 

--- a/sdk/objc/components/capturer/RTCDesktopCapturer.h
+++ b/sdk/objc/components/capturer/RTCDesktopCapturer.h
@@ -23,18 +23,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class RTCDesktopCapturer;
+@class RTC_OBJC_TYPE(RTCDesktopCapturer);
 
 RTC_OBJC_EXPORT
 @protocol RTC_OBJC_TYPE
 (RTCDesktopCapturerDelegate)<NSObject>
--(void)didSourceCaptureStart:(RTCDesktopCapturer *) capturer;
+-(void)didSourceCaptureStart:(RTC_OBJC_TYPE(RTCDesktopCapturer) *) capturer;
 
--(void)didSourceCapturePaused:(RTCDesktopCapturer *) capturer;
+-(void)didSourceCapturePaused:(RTC_OBJC_TYPE(RTCDesktopCapturer) *) capturer;
 
--(void)didSourceCaptureStop:(RTCDesktopCapturer *) capturer;
+-(void)didSourceCaptureStop:(RTC_OBJC_TYPE(RTCDesktopCapturer) *) capturer;
 
--(void)didSourceCaptureError:(RTCDesktopCapturer *) capturer;
+-(void)didSourceCaptureError:(RTC_OBJC_TYPE(RTCDesktopCapturer) *) capturer;
 @end
 
 RTC_OBJC_EXPORT
@@ -42,9 +42,9 @@ RTC_OBJC_EXPORT
 // RTCVideoCapturerDelegate (usually RTCVideoSource).
 @interface RTC_OBJC_TYPE (RTCDesktopCapturer) : RTC_OBJC_TYPE(RTCVideoCapturer)
 
-@property(nonatomic, readonly) RTCDesktopSource *source;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCDesktopSource) *source;
 
-- (instancetype)initWithSource:(RTCDesktopSource*)source delegate:(__weak id<RTC_OBJC_TYPE(RTCDesktopCapturerDelegate)>)delegate captureDelegate:(__weak id<RTC_OBJC_TYPE(RTCVideoCapturerDelegate)>)captureDelegate;
+- (instancetype)initWithSource:(RTC_OBJC_TYPE(RTCDesktopSource) *)source delegate:(__weak id<RTC_OBJC_TYPE(RTCDesktopCapturerDelegate)>)delegate captureDelegate:(__weak id<RTC_OBJC_TYPE(RTCVideoCapturerDelegate)>)captureDelegate;
 
 - (instancetype)initWithDefaultScreen:(__weak id<RTC_OBJC_TYPE(RTCDesktopCapturerDelegate)>)delegate captureDelegate:(__weak id<RTC_OBJC_TYPE(RTCVideoCapturerDelegate)>)captureDelegate;
 

--- a/sdk/objc/components/capturer/RTCDesktopCapturer.mm
+++ b/sdk/objc/components/capturer/RTCDesktopCapturer.mm
@@ -32,7 +32,7 @@
 @synthesize nativeCapturer = _nativeCapturer;
 @synthesize source = _source;
 
-- (instancetype)initWithSource:(RTCDesktopSource*)source delegate:(__weak id<RTC_OBJC_TYPE(RTCDesktopCapturerDelegate)>)delegate captureDelegate:(__weak id<RTC_OBJC_TYPE(RTCVideoCapturerDelegate)>)captureDelegate {
+- (instancetype)initWithSource:(RTC_OBJC_TYPE(RTCDesktopSource) *)source delegate:(__weak id<RTC_OBJC_TYPE(RTCDesktopCapturerDelegate)>)delegate captureDelegate:(__weak id<RTC_OBJC_TYPE(RTCVideoCapturerDelegate)>)captureDelegate {
     if (self = [super initWithDelegate:captureDelegate]) {
       webrtc::DesktopType captureType = webrtc::kScreen;
       if(source.sourceType == RTCDesktopSourceTypeWindow) {

--- a/sdk/objc/components/capturer/RTCDesktopMediaList+Private.h
+++ b/sdk/objc/components/capturer/RTCDesktopMediaList+Private.h
@@ -23,7 +23,7 @@ namespace webrtc {
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RTCDesktopMediaList ()
+@interface RTC_OBJC_TYPE(RTCDesktopMediaList) ()
 
 @property(nonatomic, readonly)std::shared_ptr<webrtc::ObjCDesktopMediaList> nativeMediaList;
 

--- a/sdk/objc/components/capturer/RTCDesktopMediaList.mm
+++ b/sdk/objc/components/capturer/RTCDesktopMediaList.mm
@@ -19,9 +19,9 @@
 #import "RTCDesktopSource+Private.h"
 #import "RTCDesktopMediaList+Private.h"
 
-@implementation RTCDesktopMediaList {
+@implementation RTC_OBJC_TYPE(RTCDesktopMediaList) {
      RTCDesktopSourceType _sourceType;
-     NSMutableArray<RTCDesktopSource *>* _sources;
+     NSMutableArray<RTC_OBJC_TYPE(RTCDesktopSource) *>* _sources;
      __weak id<RTC_OBJC_TYPE(RTCDesktopMediaListDelegate)> _delegate;
 }
 
@@ -45,24 +45,24 @@
     return _nativeMediaList->UpdateSourceList(forceReload, updateThumbnail);
 }
 
--(NSArray<RTCDesktopSource *>*) getSources {
+-(NSArray<RTC_OBJC_TYPE(RTCDesktopSource) *>*) getSources {
     _sources = [NSMutableArray array];
     int sourceCount = _nativeMediaList->GetSourceCount();
     for (int i = 0; i < sourceCount; i++) {
         webrtc::MediaSource *mediaSource = _nativeMediaList->GetSource(i);
-        [_sources addObject:[[RTCDesktopSource alloc] initWithNativeSource:mediaSource sourceType:_sourceType]];
+        [_sources addObject:[[RTC_OBJC_TYPE(RTCDesktopSource) alloc] initWithNativeSource:mediaSource sourceType:_sourceType]];
     }
     return _sources;
 }
 
 -(void)mediaSourceAdded:(webrtc::MediaSource *) source {
-    RTCDesktopSource *desktopSource = [[RTCDesktopSource alloc] initWithNativeSource:source sourceType:_sourceType];
+    RTC_OBJC_TYPE(RTCDesktopSource) *desktopSource = [[RTC_OBJC_TYPE(RTCDesktopSource) alloc] initWithNativeSource:source sourceType:_sourceType];
     [_sources addObject:desktopSource];
     [_delegate didDesktopSourceAdded:desktopSource];
 }
 
 -(void)mediaSourceRemoved:(webrtc::MediaSource *) source {
-    RTCDesktopSource *desktopSource = [self getSourceById:source];
+    RTC_OBJC_TYPE(RTCDesktopSource) *desktopSource = [self getSourceById:source];
     if(desktopSource != nil) {
         [_sources removeObject:desktopSource];
         [_delegate didDesktopSourceRemoved:desktopSource];
@@ -70,7 +70,7 @@
 }
 
 -(void)mediaSourceNameChanged:(webrtc::MediaSource *) source {
-    RTCDesktopSource *desktopSource = [self getSourceById:source];
+    RTC_OBJC_TYPE(RTCDesktopSource) *desktopSource = [self getSourceById:source];
     if(desktopSource != nil) {
         [desktopSource setName:source->name().c_str()];
         [_delegate didDesktopSourceNameChanged:desktopSource];
@@ -78,16 +78,16 @@
 }
 
 -(void)mediaSourceThumbnailChanged:(webrtc::MediaSource *) source {
-    RTCDesktopSource *desktopSource = [self getSourceById:source];
+    RTC_OBJC_TYPE(RTCDesktopSource) *desktopSource = [self getSourceById:source];
     if(desktopSource != nil) {
         [desktopSource setThumbnail:source->thumbnail()];
         [_delegate didDesktopSourceThumbnailChanged:desktopSource];
     }
 }
 
--(RTCDesktopSource *)getSourceById:(webrtc::MediaSource *) source {
+-(RTC_OBJC_TYPE(RTCDesktopSource) *)getSourceById:(webrtc::MediaSource *) source {
     NSEnumerator *enumerator = [_sources objectEnumerator];
-    RTCDesktopSource *object;
+    RTC_OBJC_TYPE(RTCDesktopSource) *object;
     while ((object = enumerator.nextObject) != nil) {
         if(object.nativeMediaSource == source) {
             return object;

--- a/sdk/objc/components/capturer/RTCDesktopSource+Private.h
+++ b/sdk/objc/components/capturer/RTCDesktopSource+Private.h
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RTCDesktopSource ()
+@interface RTC_OBJC_TYPE(RTCDesktopSource) ()
 
 - (instancetype)initWithNativeSource:(webrtc::MediaSource*) nativeSource 
                           sourceType:(RTCDesktopSourceType) sourceType;

--- a/sdk/objc/components/capturer/RTCDesktopSource.mm
+++ b/sdk/objc/components/capturer/RTCDesktopSource.mm
@@ -19,7 +19,7 @@
 #import "RTCDesktopSource.h"
 #import "RTCDesktopSource+Private.h"
 
-@implementation RTCDesktopSource {
+@implementation RTC_OBJC_TYPE(RTCDesktopSource) {
     NSString *_sourceId;
     NSString *_name;
     NSImage *_thumbnail;

--- a/sdk/objc/components/network/RTCNetworkMonitor+Private.h
+++ b/sdk/objc/components/network/RTCNetworkMonitor+Private.h
@@ -9,16 +9,18 @@
  */
 
 #import "RTCNetworkMonitor.h"
+#import "RTCMacros.h"
 
 #include "sdk/objc/native/src/network_monitor_observer.h"
 
-@interface RTCNetworkMonitor ()
+@interface RTC_OBJC_TYPE (RTCNetworkMonitor)
+()
 
-/** `observer` is a raw pointer and should be kept alive
- *  for this object's lifetime.
- */
-- (instancetype)initWithObserver:(webrtc::NetworkMonitorObserver *)observer
-    NS_DESIGNATED_INITIALIZER;
+    /** `observer` is a raw pointer and should be kept alive
+     *  for this object's lifetime.
+     */
+    - (instancetype)initWithObserver
+    : (webrtc::NetworkMonitorObserver *)observer NS_DESIGNATED_INITIALIZER;
 
 /** Stops the receiver from posting updates to `observer`. */
 - (void)stop;

--- a/sdk/objc/components/network/RTCNetworkMonitor.h
+++ b/sdk/objc/components/network/RTCNetworkMonitor.h
@@ -10,12 +10,14 @@
 
 #import <Foundation/Foundation.h>
 
+#import "RTCMacros.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** Listens for NWPathMonitor updates and forwards the results to a C++
  *  observer.
  */
-@interface RTCNetworkMonitor : NSObject
+@interface RTC_OBJC_TYPE (RTCNetworkMonitor): NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/sdk/objc/components/network/RTCNetworkMonitor.mm
+++ b/sdk/objc/components/network/RTCNetworkMonitor.mm
@@ -46,7 +46,7 @@ rtc::AdapterType AdapterTypeFromInterfaceType(nw_interface_type_t interfaceType)
 
 }  // namespace
 
-@implementation RTCNetworkMonitor {
+@implementation RTC_OBJC_TYPE (RTCNetworkMonitor) {
   webrtc::NetworkMonitorObserver *_observer;
   nw_path_monitor_t _pathMonitor;
   dispatch_queue_t _monitorQueue;
@@ -63,12 +63,12 @@ rtc::AdapterType AdapterTypeFromInterfaceType(nw_interface_type_t interfaceType)
         return nil;
       }
       RTCLog(@"NW path monitor created.");
-      __weak RTCNetworkMonitor *weakSelf = self;
+      __weak RTC_OBJC_TYPE(RTCNetworkMonitor) *weakSelf = self;
       nw_path_monitor_set_update_handler(_pathMonitor, ^(nw_path_t path) {
         if (weakSelf == nil) {
           return;
         }
-        RTCNetworkMonitor *strongSelf = weakSelf;
+        RTC_OBJC_TYPE(RTCNetworkMonitor) *strongSelf = weakSelf;
         RTCLog(@"NW path monitor: updated.");
         nw_path_status_t status = nw_path_get_status(path);
         if (status == nw_path_status_invalid) {

--- a/sdk/objc/components/renderer/metal/RTCMTLI420Renderer.h
+++ b/sdk/objc/components/renderer/metal/RTCMTLI420Renderer.h
@@ -13,5 +13,5 @@
 #import "RTCMTLRenderer.h"
 
 NS_AVAILABLE(10_11, 9_0)
-@interface RTCMTLI420Renderer : RTCMTLRenderer
+@interface RTC_OBJC_TYPE(RTCMTLI420Renderer): RTC_OBJC_TYPE(RTCMTLRenderer)
 @end

--- a/sdk/objc/components/renderer/metal/RTCMTLI420Renderer.mm
+++ b/sdk/objc/components/renderer/metal/RTCMTLI420Renderer.mm
@@ -70,7 +70,7 @@ static NSString *const shaderSource = MTL_STRINGIFY(
       return half4(out);
     });
 
-@implementation RTCMTLI420Renderer {
+@implementation RTC_OBJC_TYPE(RTCMTLI420Renderer) {
   // Textures.
   id<MTLTexture> _yTexture;
   id<MTLTexture> _uTexture;

--- a/sdk/objc/components/renderer/metal/RTCMTLNSVideoView.h
+++ b/sdk/objc/components/renderer/metal/RTCMTLNSVideoView.h
@@ -8,5 +8,7 @@
  *  be found in the AUTHORS file in the root of the source tree.
  */
 
+#import "RTCMacros.h"
+
 // Deprecated: Use RTCMTLVideoView instead
-@compatibility_alias RTCMTLNSVideoView RTCMTLVideoView;
+@compatibility_alias RTC_OBJC_TYPE(RTCMTLNSVideoView) RTC_OBJC_TYPE(RTCMTLVideoView);

--- a/sdk/objc/components/renderer/metal/RTCMTLNV12Renderer.h
+++ b/sdk/objc/components/renderer/metal/RTCMTLNV12Renderer.h
@@ -13,6 +13,6 @@
 #import "RTCMTLRenderer.h"
 
 NS_AVAILABLE(10_11, 9_0)
-@interface RTCMTLNV12Renderer : RTCMTLRenderer
+@interface RTC_OBJC_TYPE(RTCMTLNV12Renderer): RTC_OBJC_TYPE(RTCMTLRenderer)
 
 @end

--- a/sdk/objc/components/renderer/metal/RTCMTLNV12Renderer.mm
+++ b/sdk/objc/components/renderer/metal/RTCMTLNV12Renderer.mm
@@ -60,7 +60,7 @@ static NSString *const shaderSource = MTL_STRINGIFY(
       return half4(out);
     });
 
-@implementation RTCMTLNV12Renderer {
+@implementation RTC_OBJC_TYPE(RTCMTLNV12Renderer) {
   // Textures.
   CVMetalTextureCacheRef _textureCache;
   id<MTLTexture> _yTexture;

--- a/sdk/objc/components/renderer/metal/RTCMTLRGBRenderer.h
+++ b/sdk/objc/components/renderer/metal/RTCMTLRGBRenderer.h
@@ -11,12 +11,13 @@
 #import <Foundation/Foundation.h>
 
 #import "RTCMTLRenderer.h"
+#import "RTCMacros.h"
 
 /** @abstract RGB/BGR renderer.
  *  @discussion This renderer handles both kCVPixelFormatType_32BGRA and
  * kCVPixelFormatType_32ARGB.
  */
 NS_AVAILABLE(10_11, 9_0)
-@interface RTCMTLRGBRenderer : RTCMTLRenderer
+@interface RTC_OBJC_TYPE (RTCMTLRGBRenderer): RTCMTLRenderer
 
 @end

--- a/sdk/objc/components/renderer/metal/RTCMTLRGBRenderer.h
+++ b/sdk/objc/components/renderer/metal/RTCMTLRGBRenderer.h
@@ -18,6 +18,6 @@
  * kCVPixelFormatType_32ARGB.
  */
 NS_AVAILABLE(10_11, 9_0)
-@interface RTC_OBJC_TYPE (RTCMTLRGBRenderer): RTCMTLRenderer
+@interface RTC_OBJC_TYPE (RTCMTLRGBRenderer): RTC_OBJC_TYPE(RTCMTLRenderer)
 
 @end

--- a/sdk/objc/components/renderer/metal/RTCMTLRGBRenderer.mm
+++ b/sdk/objc/components/renderer/metal/RTCMTLRGBRenderer.mm
@@ -30,12 +30,12 @@ static NSString *const shaderSource = MTL_STRINGIFY(
     } Vertex;
 
     typedef struct {
-      float4 position[[position]];
+      float4 position [[position]];
       float2 texcoord;
     } VertexIO;
 
-    vertex VertexIO vertexPassthrough(constant Vertex *verticies[[buffer(0)]],
-                                      uint vid[[vertex_id]]) {
+    vertex VertexIO vertexPassthrough(constant Vertex * verticies [[buffer(0)]],
+                                      uint vid [[vertex_id]]) {
       VertexIO out;
       constant Vertex &v = verticies[vid];
       out.position = float4(float2(v.position), 0.0, 1.0);
@@ -43,9 +43,9 @@ static NSString *const shaderSource = MTL_STRINGIFY(
       return out;
     }
 
-    fragment half4 fragmentColorConversion(VertexIO in[[stage_in]],
-                                           texture2d<half, access::sample> texture[[texture(0)]],
-                                           constant bool &isARGB[[buffer(0)]]) {
+    fragment half4 fragmentColorConversion(VertexIO in [[stage_in]],
+                                           texture2d<half, access::sample> texture [[texture(0)]],
+                                           constant bool &isARGB [[buffer(0)]]) {
       constexpr sampler s(address::clamp_to_edge, filter::linear);
 
       half4 out = texture.sample(s, in.texcoord);
@@ -56,7 +56,7 @@ static NSString *const shaderSource = MTL_STRINGIFY(
       return out;
     });
 
-@implementation RTCMTLRGBRenderer {
+@implementation RTC_OBJC_TYPE (RTCMTLRGBRenderer) {
   // Textures.
   CVMetalTextureCacheRef _textureCache;
   id<MTLTexture> _texture;
@@ -73,8 +73,8 @@ static NSString *const shaderSource = MTL_STRINGIFY(
 }
 
 - (BOOL)initializeTextureCache {
-  CVReturn status = CVMetalTextureCacheCreate(kCFAllocatorDefault, nil, [self currentMetalDevice],
-                                              nil, &_textureCache);
+  CVReturn status = CVMetalTextureCacheCreate(
+      kCFAllocatorDefault, nil, [self currentMetalDevice], nil, &_textureCache);
   if (status != kCVReturnSuccess) {
     RTCLogError(@"Metal: Failed to initialize metal texture cache. Return status is %d", status);
     return NO;
@@ -130,9 +130,15 @@ static NSString *const shaderSource = MTL_STRINGIFY(
     return NO;
   }
 
-  CVReturn result = CVMetalTextureCacheCreateTextureFromImage(
-                kCFAllocatorDefault, _textureCache, pixelBuffer, nil, mtlPixelFormat,
-                width, height, 0, &textureOut);
+  CVReturn result = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
+                                                              _textureCache,
+                                                              pixelBuffer,
+                                                              nil,
+                                                              mtlPixelFormat,
+                                                              width,
+                                                              height,
+                                                              0,
+                                                              &textureOut);
   if (result == kCVReturnSuccess) {
     gpuTexture = CVMetalTextureGetTexture(textureOut);
   }

--- a/sdk/objc/components/renderer/metal/RTCMTLRenderer+Private.h
+++ b/sdk/objc/components/renderer/metal/RTCMTLRenderer+Private.h
@@ -16,7 +16,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RTCMTLRenderer (Private)
+@interface RTC_OBJC_TYPE(RTCMTLRenderer) (Private)
 - (nullable id<MTLDevice>)currentMetalDevice;
 - (NSString *)shaderSource;
 - (BOOL)setupTexturesForFrame:(nonnull RTC_OBJC_TYPE(RTCVideoFrame) *)frame;

--- a/sdk/objc/components/renderer/metal/RTCMTLRenderer.h
+++ b/sdk/objc/components/renderer/metal/RTCMTLRenderer.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Implementation of RTCMTLRenderer protocol.
  */
 NS_AVAILABLE(10_11, 9_0)
-@interface RTC_OBJC_TYPE(RTCMTLRenderer) : NSObject <RTCMTLRenderer>
+@interface RTC_OBJC_TYPE(RTCMTLRenderer) : NSObject <RTC_OBJC_TYPE(RTCMTLRenderer)>
 
 /** @abstract   A wrapped RTCVideoRotation, or nil.
     @discussion When not nil, the rotation of the actual frame is ignored when rendering.

--- a/sdk/objc/components/renderer/metal/RTCMTLRenderer.h
+++ b/sdk/objc/components/renderer/metal/RTCMTLRenderer.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Protocol defining ability to render RTCVideoFrame in Metal enabled views.
  */
-@protocol RTCMTLRenderer <NSObject>
+@protocol RTC_OBJC_TYPE(RTCMTLRenderer) <NSObject>
 
 /**
  * Method to be implemented to perform actual rendering of the provided frame.
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Implementation of RTCMTLRenderer protocol.
  */
 NS_AVAILABLE(10_11, 9_0)
-@interface RTCMTLRenderer : NSObject <RTCMTLRenderer>
+@interface RTC_OBJC_TYPE(RTCMTLRenderer) : NSObject <RTCMTLRenderer>
 
 /** @abstract   A wrapped RTCVideoRotation, or nil.
     @discussion When not nil, the rotation of the actual frame is ignored when rendering.

--- a/sdk/objc/components/renderer/metal/RTCMTLRenderer.mm
+++ b/sdk/objc/components/renderer/metal/RTCMTLRenderer.mm
@@ -87,7 +87,7 @@ static inline void getCubeVertexData(int cropX,
 // In future we might use triple buffering method if it improves performance.
 static const NSInteger kMaxInflightBuffers = 1;
 
-@implementation RTCMTLRenderer {
+@implementation RTC_OBJC_TYPE(RTCMTLRenderer) {
   __kindof MTKView *_view;
 
   // Controller.

--- a/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
+++ b/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
@@ -29,9 +29,9 @@
 #define RTCMTLI420RendererClass NSClassFromString(@"RTCMTLI420Renderer")
 #define RTCMTLRGBRendererClass NSClassFromString(@"RTCMTLRGBRenderer")
 
-@interface RTC_OBJC_TYPE (RTCMTLVideoView)
-()<MTKViewDelegate> @property(nonatomic) RTCMTLI420Renderer *rendererI420;
-@property(nonatomic) RTCMTLNV12Renderer *rendererNV12;
+@interface RTC_OBJC_TYPE (RTCMTLVideoView) ()<MTKViewDelegate> 
+@property(nonatomic) RTC_OBJC_TYPE(RTCMTLI420Renderer) *rendererI420;
+@property(nonatomic) RTC_OBJC_TYPE(RTCMTLNV12Renderer) * rendererNV12;
 @property(nonatomic) RTC_OBJC_TYPE(RTCMTLRGBRenderer) * rendererRGB;
 @property(nonatomic) MTKView *metalView;
 @property(atomic) RTC_OBJC_TYPE(RTCVideoFrame) * videoFrame;
@@ -99,11 +99,11 @@
   return [[MTKViewClass alloc] initWithFrame:frame];
 }
 
-+ (RTCMTLNV12Renderer *)createNV12Renderer {
++ (RTC_OBJC_TYPE(RTCMTLNV12Renderer) *)createNV12Renderer {
   return [[RTCMTLNV12RendererClass alloc] init];
 }
 
-+ (RTCMTLI420Renderer *)createI420Renderer {
++ (RTC_OBJC_TYPE(RTCMTLI420Renderer) *)createI420Renderer {
   return [[RTCMTLI420RendererClass alloc] init];
 }
 
@@ -159,7 +159,7 @@
     return;
   }
 
-  RTCMTLRenderer *renderer;
+  RTC_OBJC_TYPE(RTCMTLRenderer) * renderer;
   if ([videoFrame.buffer isKindOfClass:[RTC_OBJC_TYPE(RTCCVPixelBuffer) class]]) {
     RTC_OBJC_TYPE(RTCCVPixelBuffer) *buffer = (RTC_OBJC_TYPE(RTCCVPixelBuffer) *)videoFrame.buffer;
     const OSType pixelFormat = CVPixelBufferGetPixelFormatType(buffer.pixelBuffer);

--- a/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
+++ b/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
@@ -24,13 +24,6 @@
 
 #import "RTCMTLRenderer+Private.h"
 
-// To avoid unreconized symbol linker errors, we're taking advantage of the objc runtime.
-// Linking errors occur when compiling for architectures that don't support Metal.
-#define MTKViewClass NSClassFromString(@"MTKView")
-#define RTCMTLNV12RendererClass NSClassFromString(MTL_STRINGIFY(RTC_OBJC_TYPE(RTCMTLNV12Renderer)))
-#define RTCMTLI420RendererClass NSClassFromString(MTL_STRINGIFY(RTC_OBJC_TYPE(RTCMTLI420Renderer)))
-#define RTCMTLRGBRendererClass NSClassFromString(MTL_STRINGIFY(RTC_OBJC_TYPE(RTCMTLRGBRenderer)))
-
 @interface RTC_OBJC_TYPE (RTCMTLVideoView) ()<MTKViewDelegate> 
 @property(nonatomic) RTC_OBJC_TYPE(RTCMTLI420Renderer) *rendererI420;
 @property(nonatomic) RTC_OBJC_TYPE(RTCMTLNV12Renderer) * rendererNV12;
@@ -98,19 +91,19 @@
 #pragma mark - Private
 
 + (MTKView *)createMetalView:(CGRect)frame {
-  return [[MTKViewClass alloc] initWithFrame:frame];
+  return [[MTKView alloc] initWithFrame:frame];
 }
 
 + (RTC_OBJC_TYPE(RTCMTLNV12Renderer) *)createNV12Renderer {
-  return [[RTCMTLNV12RendererClass alloc] init];
+  return [[RTC_OBJC_TYPE(RTCMTLNV12Renderer) alloc] init];
 }
 
 + (RTC_OBJC_TYPE(RTCMTLI420Renderer) *)createI420Renderer {
-  return [[RTCMTLI420RendererClass alloc] init];
+  return [[RTC_OBJC_TYPE(RTCMTLI420Renderer) alloc] init];
 }
 
 + (RTC_OBJC_TYPE(RTCMTLRGBRenderer) *)createRGBRenderer {
-  return [[RTCMTLRGBRendererClass alloc] init];
+  return [[RTC_OBJC_TYPE(RTCMTLRGBRenderer) alloc] init];
 }
 
 - (void)configure {

--- a/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
+++ b/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
@@ -32,7 +32,7 @@
 @interface RTC_OBJC_TYPE (RTCMTLVideoView)
 ()<MTKViewDelegate> @property(nonatomic) RTCMTLI420Renderer *rendererI420;
 @property(nonatomic) RTCMTLNV12Renderer *rendererNV12;
-@property(nonatomic) RTCMTLRGBRenderer *rendererRGB;
+@property(nonatomic) RTC_OBJC_TYPE(RTCMTLRGBRenderer) * rendererRGB;
 @property(nonatomic) MTKView *metalView;
 @property(atomic) RTC_OBJC_TYPE(RTCVideoFrame) * videoFrame;
 @property(nonatomic) CGSize videoFrameSize;
@@ -107,7 +107,7 @@
   return [[RTCMTLI420RendererClass alloc] init];
 }
 
-+ (RTCMTLRGBRenderer *)createRGBRenderer {
++ (RTC_OBJC_TYPE(RTCMTLRGBRenderer) *)createRGBRenderer {
   return [[RTCMTLRGBRendererClass alloc] init];
 }
 

--- a/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
+++ b/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
@@ -22,12 +22,14 @@
 #import "RTCMTLNV12Renderer.h"
 #import "RTCMTLRGBRenderer.h"
 
+#import "RTCMTLRenderer+Private.h"
+
 // To avoid unreconized symbol linker errors, we're taking advantage of the objc runtime.
 // Linking errors occur when compiling for architectures that don't support Metal.
 #define MTKViewClass NSClassFromString(@"MTKView")
-#define RTCMTLNV12RendererClass NSClassFromString(@"RTCMTLNV12Renderer")
-#define RTCMTLI420RendererClass NSClassFromString(@"RTCMTLI420Renderer")
-#define RTCMTLRGBRendererClass NSClassFromString(@"RTCMTLRGBRenderer")
+#define RTCMTLNV12RendererClass NSClassFromString(MTL_STRINGIFY(RTC_OBJC_TYPE(RTCMTLNV12Renderer)))
+#define RTCMTLI420RendererClass NSClassFromString(MTL_STRINGIFY(RTC_OBJC_TYPE(RTCMTLI420Renderer)))
+#define RTCMTLRGBRendererClass NSClassFromString(MTL_STRINGIFY(RTC_OBJC_TYPE(RTCMTLRGBRenderer)))
 
 @interface RTC_OBJC_TYPE (RTCMTLVideoView) ()<MTKViewDelegate> 
 @property(nonatomic) RTC_OBJC_TYPE(RTCMTLI420Renderer) *rendererI420;

--- a/sdk/objc/components/renderer/opengl/RTCDefaultShader.h
+++ b/sdk/objc/components/renderer/opengl/RTCDefaultShader.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  and RTCEAGLVideoView if no external shader is specified. This shader will render
  *  the video in a rectangle without any color or geometric transformations.
  */
-@interface RTCDefaultShader : NSObject <RTC_OBJC_TYPE (RTCVideoViewShading)>
+@interface RTC_OBJC_TYPE(RTCDefaultShader) : NSObject <RTC_OBJC_TYPE (RTCVideoViewShading)>
 
 @end
 

--- a/sdk/objc/components/renderer/opengl/RTCDefaultShader.mm
+++ b/sdk/objc/components/renderer/opengl/RTCDefaultShader.mm
@@ -69,7 +69,7 @@ static const char kNV12FragmentShaderSource[] =
   "                                     1.0);\n"
   "  }\n";
 
-@implementation RTCDefaultShader {
+@implementation RTC_OBJC_TYPE(RTCDefaultShader) {
   GLuint _vertexBuffer;
   GLuint _vertexArray;
   // Store current rotation and only upload new vertex data when rotation changes.

--- a/sdk/objc/components/renderer/opengl/RTCDisplayLinkTimer.h
+++ b/sdk/objc/components/renderer/opengl/RTCDisplayLinkTimer.h
@@ -10,11 +10,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import "RTCMacros.h"
+
 // RTCDisplayLinkTimer wraps a CADisplayLink and is set to fire every two screen
 // refreshes, which should be 30fps. We wrap the display link in order to avoid
 // a retain cycle since CADisplayLink takes a strong reference onto its target.
 // The timer is paused by default.
-@interface RTCDisplayLinkTimer : NSObject
+@interface RTC_OBJC_TYPE (RTCDisplayLinkTimer): NSObject
 
 @property(nonatomic) BOOL isPaused;
 

--- a/sdk/objc/components/renderer/opengl/RTCDisplayLinkTimer.m
+++ b/sdk/objc/components/renderer/opengl/RTCDisplayLinkTimer.m
@@ -12,7 +12,7 @@
 
 #import <UIKit/UIKit.h>
 
-@implementation RTCDisplayLinkTimer {
+@implementation RTC_OBJC_TYPE (RTCDisplayLinkTimer) {
   CADisplayLink *_displayLink;
   void (^_timerHandler)(void);
 }
@@ -21,17 +21,15 @@
   NSParameterAssert(timerHandler);
   if (self = [super init]) {
     _timerHandler = timerHandler;
-    _displayLink =
-        [CADisplayLink displayLinkWithTarget:self
-                                    selector:@selector(displayLinkDidFire:)];
+    _displayLink = [CADisplayLink displayLinkWithTarget:self
+                                               selector:@selector(displayLinkDidFire:)];
     _displayLink.paused = YES;
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_10_0
     _displayLink.preferredFramesPerSecond = 30;
 #else
     [_displayLink setFrameInterval:2];
 #endif
-    [_displayLink addToRunLoop:[NSRunLoop currentRunLoop]
-                       forMode:NSRunLoopCommonModes];
+    [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
   }
   return self;
 }

--- a/sdk/objc/components/renderer/opengl/RTCEAGLVideoView.m
+++ b/sdk/objc/components/renderer/opengl/RTCEAGLVideoView.m
@@ -48,8 +48,8 @@
   // setNeedsDisplay)
   BOOL _isDirty;
   id<RTC_OBJC_TYPE(RTCVideoViewShading)> _shader;
-  RTCNV12TextureCache *_nv12TextureCache;
-  RTCI420TextureCache *_i420TextureCache;
+  RTC_OBJC_TYPE(RTCNV12TextureCache) *_nv12TextureCache;
+  RTC_OBJC_TYPE(RTCI420TextureCache) *_i420TextureCache;
   // As timestamps should be unique between frames, will store last
   // drawn frame timestamp instead of the whole frame to reduce memory usage.
   int64_t _lastDrawnFrameTimeStampNs;
@@ -61,11 +61,11 @@
 @synthesize rotationOverride = _rotationOverride;
 
 - (instancetype)initWithFrame:(CGRect)frame {
-  return [self initWithFrame:frame shader:[[RTCDefaultShader alloc] init]];
+  return [self initWithFrame:frame shader:[[RTC_OBJC_TYPE(RTCDefaultShader) alloc] init]];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
-  return [self initWithCoder:aDecoder shader:[[RTCDefaultShader alloc] init]];
+  return [self initWithCoder:aDecoder shader:[[RTC_OBJC_TYPE(RTCDefaultShader) alloc] init]];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame shader:(id<RTC_OBJC_TYPE(RTCVideoViewShading)>)shader {
@@ -192,7 +192,7 @@
   glClear(GL_COLOR_BUFFER_BIT);
   if ([frame.buffer isKindOfClass:[RTC_OBJC_TYPE(RTCCVPixelBuffer) class]]) {
     if (!_nv12TextureCache) {
-      _nv12TextureCache = [[RTCNV12TextureCache alloc] initWithContext:_glContext];
+      _nv12TextureCache = [[RTC_OBJC_TYPE(RTCNV12TextureCache) alloc] initWithContext:_glContext];
     }
     if (_nv12TextureCache) {
       [_nv12TextureCache uploadFrameToTextures:frame];
@@ -207,7 +207,7 @@
     }
   } else {
     if (!_i420TextureCache) {
-      _i420TextureCache = [[RTCI420TextureCache alloc] initWithContext:_glContext];
+      _i420TextureCache = [[RTC_OBJC_TYPE(RTCI420TextureCache) alloc] initWithContext:_glContext];
     }
     [_i420TextureCache uploadFrameToTextures:frame];
     [_shader applyShadingForFrameWithWidth:frame.width

--- a/sdk/objc/components/renderer/opengl/RTCEAGLVideoView.m
+++ b/sdk/objc/components/renderer/opengl/RTCEAGLVideoView.m
@@ -42,7 +42,7 @@
 @end
 
 @implementation RTC_OBJC_TYPE (RTCEAGLVideoView) {
-  RTCDisplayLinkTimer *_timer;
+  RTC_OBJC_TYPE(RTCDisplayLinkTimer) * _timer;
   EAGLContext *_glContext;
   // This flag should only be set and read on the main thread (e.g. by
   // setNeedsDisplay)
@@ -90,8 +90,7 @@
 }
 
 - (BOOL)configure {
-  EAGLContext *glContext =
-    [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
+  EAGLContext *glContext = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
   if (!glContext) {
     glContext = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
   }
@@ -102,8 +101,7 @@
   _glContext = glContext;
 
   // GLKView manages a framebuffer for us.
-  _glkView = [[GLKView alloc] initWithFrame:CGRectZero
-                                    context:_glContext];
+  _glkView = [[GLKView alloc] initWithFrame:CGRectZero context:_glContext];
   _glkView.drawableColorFormat = GLKViewDrawableColorFormatRGBA8888;
   _glkView.drawableDepthFormat = GLKViewDrawableDepthFormatNone;
   _glkView.drawableStencilFormat = GLKViewDrawableStencilFormatNone;
@@ -115,8 +113,7 @@
 
   // Listen to application state in order to clean up OpenGL before app goes
   // away.
-  NSNotificationCenter *notificationCenter =
-    [NSNotificationCenter defaultCenter];
+  NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
   [notificationCenter addObserver:self
                          selector:@selector(willResignActive)
                              name:UIApplicationWillResignActiveNotification
@@ -130,7 +127,7 @@
   // using a refresh rate proportional to screen refresh frequency. This
   // occurs on the main thread.
   __weak RTC_OBJC_TYPE(RTCEAGLVideoView) *weakSelf = self;
-  _timer = [[RTCDisplayLinkTimer alloc] initWithTimerHandler:^{
+  _timer = [[RTC_OBJC_TYPE(RTCDisplayLinkTimer) alloc] initWithTimerHandler:^{
     RTC_OBJC_TYPE(RTCEAGLVideoView) *strongSelf = weakSelf;
     [strongSelf displayLinkTimerDidFire];
   }];
@@ -141,14 +138,13 @@
 }
 
 - (void)setMultipleTouchEnabled:(BOOL)multipleTouchEnabled {
-    [super setMultipleTouchEnabled:multipleTouchEnabled];
-    _glkView.multipleTouchEnabled = multipleTouchEnabled;
+  [super setMultipleTouchEnabled:multipleTouchEnabled];
+  _glkView.multipleTouchEnabled = multipleTouchEnabled;
 }
 
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-  UIApplicationState appState =
-      [UIApplication sharedApplication].applicationState;
+  UIApplicationState appState = [UIApplication sharedApplication].applicationState;
   if (appState == UIApplicationStateActive) {
     [self teardownGL];
   }
@@ -189,8 +185,8 @@
     return;
   }
   RTCVideoRotation rotation = frame.rotation;
-  if(_rotationOverride != nil) {
-    [_rotationOverride getValue: &rotation];
+  if (_rotationOverride != nil) {
+    [_rotationOverride getValue:&rotation];
   }
   [self ensureGLContext];
   glClear(GL_COLOR_BUFFER_BIT);

--- a/sdk/objc/components/renderer/opengl/RTCI420TextureCache.h
+++ b/sdk/objc/components/renderer/opengl/RTCI420TextureCache.h
@@ -11,7 +11,7 @@
 #import "RTCOpenGLDefines.h"
 #import "base/RTCVideoFrame.h"
 
-@interface RTCI420TextureCache : NSObject
+@interface RTC_OBJC_TYPE(RTCI420TextureCache) : NSObject
 
 @property(nonatomic, readonly) GLuint yTexture;
 @property(nonatomic, readonly) GLuint uTexture;

--- a/sdk/objc/components/renderer/opengl/RTCI420TextureCache.mm
+++ b/sdk/objc/components/renderer/opengl/RTCI420TextureCache.mm
@@ -28,7 +28,7 @@ static const GLsizei kNumTextureSets = 2;
 static const GLsizei kNumTexturesPerSet = 3;
 static const GLsizei kNumTextures = kNumTexturesPerSet * kNumTextureSets;
 
-@implementation RTCI420TextureCache {
+@implementation RTC_OBJC_TYPE(RTCI420TextureCache) {
   BOOL _hasUnpackRowLength;
   GLint _currentTextureSet;
   // Handles for OpenGL constructs.

--- a/sdk/objc/components/renderer/opengl/RTCNSGLVideoView.m
+++ b/sdk/objc/components/renderer/opengl/RTCNSGLVideoView.m
@@ -29,7 +29,7 @@
     // from the display link callback so atomicity is required.
     @property(atomic, strong) RTC_OBJC_TYPE(RTCVideoFrame) *
     videoFrame;
-@property(atomic, strong) RTCI420TextureCache *i420TextureCache;
+@property(atomic, strong) RTC_OBJC_TYPE(RTCI420TextureCache) *i420TextureCache;
 
 - (void)drawFrame;
 @end
@@ -57,7 +57,7 @@ static CVReturn OnDisplayLinkFired(CVDisplayLinkRef displayLink,
 @synthesize i420TextureCache = _i420TextureCache;
 
 - (instancetype)initWithFrame:(NSRect)frame pixelFormat:(NSOpenGLPixelFormat *)format {
-  return [self initWithFrame:frame pixelFormat:format shader:[[RTCDefaultShader alloc] init]];
+  return [self initWithFrame:frame pixelFormat:format shader:[[RTC_OBJC_TYPE(RTCDefaultShader) alloc] init]];
 }
 
 - (instancetype)initWithFrame:(NSRect)frame
@@ -140,9 +140,9 @@ static CVReturn OnDisplayLinkFired(CVDisplayLinkRef displayLink,
   // TODO(magjed): Add support for NV12 texture cache on OS X.
   frame = [frame newI420VideoFrame];
   if (!self.i420TextureCache) {
-    self.i420TextureCache = [[RTCI420TextureCache alloc] initWithContext:context];
+    self.i420TextureCache = [[RTC_OBJC_TYPE(RTCI420TextureCache) alloc] initWithContext:context];
   }
-  RTCI420TextureCache *i420TextureCache = self.i420TextureCache;
+  RTC_OBJC_TYPE(RTCI420TextureCache) *i420TextureCache = self.i420TextureCache;
   if (i420TextureCache) {
     [i420TextureCache uploadFrameToTextures:frame];
     [_shader applyShadingForFrameWithWidth:frame.width

--- a/sdk/objc/components/renderer/opengl/RTCNV12TextureCache.h
+++ b/sdk/objc/components/renderer/opengl/RTCNV12TextureCache.h
@@ -16,7 +16,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RTCNV12TextureCache : NSObject
+@interface RTC_OBJC_TYPE(RTCNV12TextureCache) : NSObject
 
 @property(nonatomic, readonly) GLuint yTexture;
 @property(nonatomic, readonly) GLuint uvTexture;

--- a/sdk/objc/components/renderer/opengl/RTCNV12TextureCache.m
+++ b/sdk/objc/components/renderer/opengl/RTCNV12TextureCache.m
@@ -14,7 +14,7 @@
 #import "base/RTCVideoFrameBuffer.h"
 #import "components/video_frame_buffer/RTCCVPixelBuffer.h"
 
-@implementation RTCNV12TextureCache {
+@implementation RTC_OBJC_TYPE(RTCNV12TextureCache) {
   CVOpenGLESTextureCacheRef _textureCache;
   CVOpenGLESTextureRef _yTextureRef;
   CVOpenGLESTextureRef _uvTextureRef;

--- a/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m
+++ b/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m
@@ -55,12 +55,12 @@
 
   if ([RTC_OBJC_TYPE(RTCVideoEncoderVP9) isSupported]) {
     [result
-        addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecVp9Name parameters:nil scalabilityModes:[RTCVideoEncoderVP9 scalabilityModes]]];
+        addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecVp9Name parameters:nil scalabilityModes:[RTC_OBJC_TYPE(RTCVideoEncoderVP9) scalabilityModes]]];
   }
 
 #if defined(RTC_USE_LIBAOM_AV1_ENCODER)
   RTC_OBJC_TYPE(RTCVideoCodecInfo) *av1Info =
-    [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecAv1Name parameters:nil scalabilityModes:[RTCVideoEncoderAV1 scalabilityModes]];
+    [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecAv1Name parameters:nil scalabilityModes:[RTC_OBJC_TYPE(RTCVideoEncoderAV1) scalabilityModes]];
   [result addObject:av1Info];
 #endif
 

--- a/sdk/objc/components/video_codec/RTCVideoEncoderFactorySimulcast.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderFactorySimulcast.mm
@@ -28,7 +28,7 @@
 }
 
 - (nullable id<RTC_OBJC_TYPE(RTCVideoEncoder)>)createEncoder: (RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info {
-    return [RTCVideoEncoderSimulcast simulcastEncoderWithPrimary: _primary fallback: _fallback videoCodecInfo: info];
+    return [RTC_OBJC_TYPE(RTCVideoEncoderSimulcast) simulcastEncoderWithPrimary: _primary fallback: _fallback videoCodecInfo: info];
 }
 
 - (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {

--- a/sdk/objc/native/api/video_capturer.mm
+++ b/sdk/objc/native/api/video_capturer.mm
@@ -20,7 +20,7 @@ rtc::scoped_refptr<webrtc::VideoTrackSourceInterface> ObjCToNativeVideoCapturer(
     RTC_OBJC_TYPE(RTCVideoCapturer) * objc_video_capturer,
     rtc::Thread *signaling_thread,
     rtc::Thread *worker_thread) {
-  RTCObjCVideoSourceAdapter *adapter = [[RTCObjCVideoSourceAdapter alloc] init];
+  RTC_OBJC_TYPE(RTCObjCVideoSourceAdapter) *adapter = [[RTC_OBJC_TYPE(RTCObjCVideoSourceAdapter) alloc] init];
   rtc::scoped_refptr<webrtc::ObjCVideoTrackSource> objc_video_track_source =
       rtc::make_ref_counted<webrtc::ObjCVideoTrackSource>(adapter);
   rtc::scoped_refptr<webrtc::VideoTrackSourceInterface> video_source =

--- a/sdk/objc/native/src/audio/audio_device_ios.h
+++ b/sdk/objc/native/src/audio/audio_device_ios.h
@@ -279,7 +279,7 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
   bool is_interrupted_;
 
   // Audio interruption observer instance.
-  RTCNativeAudioSessionDelegateAdapter* audio_session_observer_
+  RTC_OBJC_TYPE(RTCNativeAudioSessionDelegateAdapter)* audio_session_observer_
       RTC_GUARDED_BY(thread_);
 
   // Set to true if we've activated the audio session.

--- a/sdk/objc/native/src/audio/audio_device_ios.h
+++ b/sdk/objc/native/src/audio/audio_device_ios.h
@@ -25,7 +25,7 @@
 #include "sdk/objc/base/RTCMacros.h"
 #include "voice_processing_audio_unit.h"
 
-RTC_FWD_DECL_OBJC_CLASS(RTCNativeAudioSessionDelegateAdapter);
+RTC_FWD_DECL_OBJC_CLASS(RTC_OBJC_TYPE(RTCNativeAudioSessionDelegateAdapter));
 
 namespace webrtc {
 

--- a/sdk/objc/native/src/audio/audio_device_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_ios.mm
@@ -110,7 +110,7 @@ AudioDeviceIOS::AudioDeviceIOS(bool bypass_voice_processing)
   io_thread_checker_.Detach();
   thread_ = rtc::Thread::Current();
 
-  audio_session_observer_ = [[RTCNativeAudioSessionDelegateAdapter alloc] initWithObserver:this];
+  audio_session_observer_ = [[RTC_OBJC_TYPE(RTCNativeAudioSessionDelegateAdapter) alloc] initWithObserver:this];
 }
 
 AudioDeviceIOS::~AudioDeviceIOS() {

--- a/sdk/objc/native/src/objc_audio_device.h
+++ b/sdk/objc/native/src/objc_audio_device.h
@@ -19,7 +19,7 @@
 #include "modules/audio_device/include/audio_device.h"
 #include "rtc_base/thread.h"
 
-@class ObjCAudioDeviceDelegate;
+@class RTC_OBJC_TYPE(ObjCAudioDeviceDelegate);
 
 namespace webrtc {
 
@@ -267,7 +267,7 @@ class ObjCAudioDeviceModule : public AudioDeviceModule {
   rtc::BufferT<int16_t> record_audio_buffer_;
 
   // Delegate object provided to RTCAudioDevice during initialization
-  ObjCAudioDeviceDelegate* audio_device_delegate_;
+  RTC_OBJC_TYPE(ObjCAudioDeviceDelegate)* audio_device_delegate_;
 };
 
 }  // namespace objc_adm

--- a/sdk/objc/native/src/objc_audio_device.mm
+++ b/sdk/objc/native/src/objc_audio_device.mm
@@ -77,7 +77,7 @@ int32_t ObjCAudioDeviceModule::Init() {
 
   if (![audio_device_ isInitialized]) {
     if (audio_device_delegate_ == nil) {
-      audio_device_delegate_ = [[ObjCAudioDeviceDelegate alloc]
+      audio_device_delegate_ = [[RTC_OBJC_TYPE(ObjCAudioDeviceDelegate) alloc]
           initWithAudioDeviceModule:rtc::scoped_refptr<ObjCAudioDeviceModule>(this)
                   audioDeviceThread:thread_];
     }

--- a/sdk/objc/native/src/objc_audio_device_delegate.h
+++ b/sdk/objc/native/src/objc_audio_device_delegate.h
@@ -22,7 +22,7 @@ class ObjCAudioDeviceModule;
 }  // namespace objc_adm
 }  // namespace webrtc
 
-@interface ObjCAudioDeviceDelegate : NSObject <RTC_OBJC_TYPE (RTCAudioDeviceDelegate)>
+@interface RTC_OBJC_TYPE(ObjCAudioDeviceDelegate) : NSObject <RTC_OBJC_TYPE (RTCAudioDeviceDelegate)>
 
 - (instancetype)initWithAudioDeviceModule:
                     (rtc::scoped_refptr<webrtc::objc_adm::ObjCAudioDeviceModule>)audioDeviceModule

--- a/sdk/objc/native/src/objc_audio_device_delegate.mm
+++ b/sdk/objc/native/src/objc_audio_device_delegate.mm
@@ -55,7 +55,7 @@ class AudioDeviceDelegateImpl final : public rtc::RefCountedNonVirtual<AudioDevi
 
 }  // namespace
 
-@implementation ObjCAudioDeviceDelegate {
+@implementation RTC_OBJC_TYPE(ObjCAudioDeviceDelegate) {
   rtc::scoped_refptr<AudioDeviceDelegateImpl> impl_;
 }
 

--- a/sdk/objc/native/src/objc_network_monitor.h
+++ b/sdk/objc/native/src/objc_network_monitor.h
@@ -59,7 +59,7 @@ class ObjCNetworkMonitor : public rtc::NetworkMonitorInterface,
   std::map<std::string, rtc::AdapterType, rtc::AbslStringViewCmp>
       adapter_type_by_name_ RTC_GUARDED_BY(thread_);
   rtc::scoped_refptr<PendingTaskSafetyFlag> safety_flag_;
-  RTCNetworkMonitor* network_monitor_ = nil;
+  RTC_OBJC_TYPE(RTCNetworkMonitor) * network_monitor_ = nil;
 };
 
 }  // namespace webrtc

--- a/sdk/objc/native/src/objc_network_monitor.mm
+++ b/sdk/objc/native/src/objc_network_monitor.mm
@@ -39,7 +39,7 @@ void ObjCNetworkMonitor::Start() {
   thread_ = rtc::Thread::Current();
   RTC_DCHECK_RUN_ON(thread_);
   safety_flag_->SetAlive();
-  network_monitor_ = [[RTCNetworkMonitor alloc] initWithObserver:this];
+  network_monitor_ = [[RTC_OBJC_TYPE(RTCNetworkMonitor) alloc] initWithObserver:this];
   if (network_monitor_ == nil) {
     RTC_LOG(LS_WARNING) << "Failed to create RTCNetworkMonitor; not available on this OS?";
   }

--- a/sdk/objc/native/src/objc_video_track_source.h
+++ b/sdk/objc/native/src/objc_video_track_source.h
@@ -19,7 +19,7 @@
 
 RTC_FWD_DECL_OBJC_CLASS(RTC_OBJC_TYPE(RTCVideoFrame));
 
-@interface RTCObjCVideoSourceAdapter : NSObject <RTC_OBJC_TYPE (RTCVideoCapturerDelegate)>
+@interface RTC_OBJC_TYPE(RTCObjCVideoSourceAdapter) : NSObject <RTC_OBJC_TYPE (RTCVideoCapturerDelegate)>
 @end
 
 namespace webrtc {
@@ -28,7 +28,7 @@ class ObjCVideoTrackSource : public rtc::AdaptedVideoTrackSource {
  public:
   ObjCVideoTrackSource();
   explicit ObjCVideoTrackSource(bool is_screencast);
-  explicit ObjCVideoTrackSource(RTCObjCVideoSourceAdapter* adapter);
+  explicit ObjCVideoTrackSource(RTC_OBJC_TYPE(RTCObjCVideoSourceAdapter)* adapter);
 
   bool is_screencast() const override;
 
@@ -50,7 +50,7 @@ class ObjCVideoTrackSource : public rtc::AdaptedVideoTrackSource {
   rtc::VideoBroadcaster broadcaster_;
   rtc::TimestampAligner timestamp_aligner_;
 
-  RTCObjCVideoSourceAdapter* adapter_;
+  RTC_OBJC_TYPE(RTCObjCVideoSourceAdapter)* adapter_;
   bool is_screencast_;
 };
 

--- a/sdk/objc/native/src/objc_video_track_source.mm
+++ b/sdk/objc/native/src/objc_video_track_source.mm
@@ -17,11 +17,11 @@
 #include "api/video/i420_buffer.h"
 #include "sdk/objc/native/src/objc_frame_buffer.h"
 
-@interface RTCObjCVideoSourceAdapter ()
+@interface RTC_OBJC_TYPE(RTCObjCVideoSourceAdapter) ()
 @property(nonatomic) webrtc::ObjCVideoTrackSource *objCVideoTrackSource;
 @end
 
-@implementation RTCObjCVideoSourceAdapter
+@implementation RTC_OBJC_TYPE(RTCObjCVideoSourceAdapter)
 
 @synthesize objCVideoTrackSource = _objCVideoTrackSource;
 
@@ -40,7 +40,7 @@ ObjCVideoTrackSource::ObjCVideoTrackSource(bool is_screencast)
     : AdaptedVideoTrackSource(/* required resolution alignment */ 2),
       is_screencast_(is_screencast) {}
 
-ObjCVideoTrackSource::ObjCVideoTrackSource(RTCObjCVideoSourceAdapter *adapter) : adapter_(adapter) {
+ObjCVideoTrackSource::ObjCVideoTrackSource(RTC_OBJC_TYPE(RTCObjCVideoSourceAdapter) *adapter) : adapter_(adapter) {
   adapter_.objCVideoTrackSource = this;
 }
 

--- a/sdk/objc/unittests/RTCMTLVideoView_xctest.m
+++ b/sdk/objc/unittests/RTCMTLVideoView_xctest.m
@@ -32,8 +32,8 @@ static size_t kBufferHeight = 200;
 
 + (BOOL)isMetalAvailable;
 + (UIView *)createMetalView:(CGRect)frame;
-+ (id<RTCMTLRenderer>)createNV12Renderer;
-+ (id<RTCMTLRenderer>)createI420Renderer;
++ (id<RTC_OBJC_TYPE(RTCMTLRenderer)>)createNV12Renderer;
++ (id<RTC_OBJC_TYPE(RTCMTLRenderer)>)createI420Renderer;
 - (void)drawInMTKView:(id)view;
 @end
 
@@ -91,7 +91,7 @@ static size_t kBufferHeight = 200;
 }
 
 - (id)rendererMockWithSuccessfulSetup:(BOOL)success {
-  id rendererMock = OCMClassMock([RTCMTLRenderer class]);
+  id rendererMock = OCMClassMock([RTC_OBJC_TYPE(RTCMTLRenderer) class]);
   OCMStub([rendererMock addRenderingDestination:[OCMArg any]]).andReturn(success);
   return rendererMock;
 }

--- a/sdk/objc/unittests/RTCPeerConnectionFactoryBuilderTest.mm
+++ b/sdk/objc/unittests/RTCPeerConnectionFactoryBuilderTest.mm
@@ -46,7 +46,7 @@ extern "C" {
               nativeVideoDecoderFactory:nullptr
                       audioDeviceModule:nullptr
                   audioProcessingModule:nullptr]);
-  RTCPeerConnectionFactoryBuilder* builder = [[RTCPeerConnectionFactoryBuilder alloc] init];
+  RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder)* builder = [[RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) alloc] init];
   RTC_OBJC_TYPE(RTCPeerConnectionFactory)* peerConnectionFactory =
       [builder createPeerConnectionFactory];
   EXPECT_TRUE(peerConnectionFactory != nil);
@@ -63,7 +63,7 @@ extern "C" {
               nativeVideoDecoderFactory:nullptr
                       audioDeviceModule:nullptr
                   audioProcessingModule:nullptr]);
-  RTCPeerConnectionFactoryBuilder* builder = [RTCPeerConnectionFactoryBuilder defaultBuilder];
+  RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder)* builder = [RTC_OBJC_TYPE(RTCPeerConnectionFactoryBuilder) defaultBuilder];
   RTC_OBJC_TYPE(RTCPeerConnectionFactory)* peerConnectionFactory =
       [builder createPeerConnectionFactory];
   EXPECT_TRUE(peerConnectionFactory != nil);


### PR DESCRIPTION
Some symbols are missing `RTC_OBJC_TYPE` macro, this is required for prefixing.
Prefix will be applied by defining `RTC_OBJC_TYPE_PREFIX` in `RTCMacros.h` and compiling.