### PR TITLE
Allow ice gathering on any address ports

### DIFF
--- a/api/peer_connection_interface.h
+++ b/api/peer_connection_interface.h
@@ -691,6 +691,15 @@ class RTC_EXPORT PeerConnectionInterface : public rtc::RefCountInterface {
     // The burst interval of the pacer, see TaskQueuePacedSender constructor.
     absl::optional<TimeDelta> pacer_burst_interval;
 
+    // When this flag is set, ports not bound to any specific network interface
+    // will be used, in addition to normal ports bound to the enumerated
+    // interfaces. Without this flag, these "any address" ports would only be
+    // used when network enumeration fails or is disabled. But under certain
+    // conditions, these ports may succeed where others fail, so they may allow
+    // the application to work in a wider variety of environments, at the expense
+    // of having to allocate additional candidates.
+    bool enable_any_address_ports = false;
+
     //
     // Don't forget to update operator== if adding something.
     //

--- a/pc/peer_connection.cc
+++ b/pc/peer_connection.cc
@@ -345,6 +345,7 @@ bool PeerConnectionInterface::RTCConfiguration::operator==(
     std::vector<rtc::NetworkMask> vpn_list;
     PortAllocatorConfig port_allocator_config;
     absl::optional<TimeDelta> pacer_burst_interval;
+    bool enable_any_address_ports;
   };
   static_assert(sizeof(stuff_being_tested_for_equality) == sizeof(*this),
                 "Did you add something to RTCConfiguration and forget to "
@@ -412,6 +413,7 @@ bool PeerConnectionInterface::RTCConfiguration::operator==(
          port_allocator_config.max_port == o.port_allocator_config.max_port &&
          port_allocator_config.flags == o.port_allocator_config.flags &&
          pacer_burst_interval == o.pacer_burst_interval;
+         enable_any_address_ports == o.enable_any_address_ports;
 }
 
 bool PeerConnectionInterface::RTCConfiguration::operator!=(
@@ -2172,6 +2174,11 @@ PeerConnection::InitializePortAllocator_n(
   if (configuration.disable_link_local_networks) {
     port_allocator_flags |= cricket::PORTALLOCATOR_DISABLE_LINK_LOCAL_NETWORKS;
     RTC_LOG(LS_INFO) << "Disable candidates on link-local network interfaces.";
+  }
+
+  if (configuration.enable_any_address_ports) {
+    port_allocator_flags != cricket::PORTALLOCATOR_ENABLE_ANY_ADDRESS_PORTS;
+    RTC_LOG(LS_INFO) << "Enable gathering on any address ports.";
   }
 
   port_allocator_->set_flags(port_allocator_flags);

--- a/pc/peer_connection.cc
+++ b/pc/peer_connection.cc
@@ -412,7 +412,7 @@ bool PeerConnectionInterface::RTCConfiguration::operator==(
          port_allocator_config.min_port == o.port_allocator_config.min_port &&
          port_allocator_config.max_port == o.port_allocator_config.max_port &&
          port_allocator_config.flags == o.port_allocator_config.flags &&
-         pacer_burst_interval == o.pacer_burst_interval;
+         pacer_burst_interval == o.pacer_burst_interval &&
          enable_any_address_ports == o.enable_any_address_ports;
 }
 
@@ -2177,7 +2177,7 @@ PeerConnection::InitializePortAllocator_n(
   }
 
   if (configuration.enable_any_address_ports) {
-    port_allocator_flags != cricket::PORTALLOCATOR_ENABLE_ANY_ADDRESS_PORTS;
+    port_allocator_flags |= cricket::PORTALLOCATOR_ENABLE_ANY_ADDRESS_PORTS;
     RTC_LOG(LS_INFO) << "Enable gathering on any address ports.";
   }
 

--- a/sdk/android/api/org/webrtc/PeerConnection.java
+++ b/sdk/android/api/org/webrtc/PeerConnection.java
@@ -627,6 +627,7 @@ public class PeerConnection {
       allowCodecSwitching = null;
       enableImplicitRollback = false;
       offerExtmapAllowMixed = true;
+      enableIceGatheringOnAnyAddressPorts = false;
     }
 
     @CalledByNative("RTCConfiguration")

--- a/sdk/android/api/org/webrtc/PeerConnection.java
+++ b/sdk/android/api/org/webrtc/PeerConnection.java
@@ -572,6 +572,17 @@ public class PeerConnection {
      * See: https://www.chromestatus.com/feature/6269234631933952
      */
     public boolean offerExtmapAllowMixed;
+    
+    /**
+     * When this flag is set, ports not bound to any specific network interface
+     * will be used, in addition to normal ports bound to the enumerated
+     * interfaces. Without this flag, these "any address" ports would only be
+     * used when network enumeration fails or is disabled. But under certain
+     * conditions, these ports may succeed where others fail, so they may allow
+     * the application to work in a wider variety of environments, at the expense
+     * of having to allocate additional candidates.
+     */
+    public boolean enableIceGatheringOnAnyAddressPorts;
 
     // TODO(deadbeef): Instead of duplicating the defaults here, we should do
     // something to pick up the defaults from C++. The Objective-C equivalent
@@ -835,6 +846,11 @@ public class PeerConnection {
     @CalledByNative("RTCConfiguration")
     boolean getOfferExtmapAllowMixed() {
       return offerExtmapAllowMixed;
+    }
+
+    @CalledByNative("RTCConfiguration")
+    boolean getEnableIceGatheringOnAnyAddressPorts() {
+      return enableIceGatheringOnAnyAddressPorts;
     }
   };
 

--- a/sdk/android/src/jni/pc/peer_connection.cc
+++ b/sdk/android/src/jni/pc/peer_connection.cc
@@ -278,6 +278,9 @@ void JavaToNativeRTCConfiguration(
   rtc_config->enable_implicit_rollback =
       Java_RTCConfiguration_getEnableImplicitRollback(jni, j_rtc_config);
 
+  rtc_config->enable_any_address_ports =
+      Java_RTCConfiguration_getEnableIceGatheringOnAnyAddressPorts(jni, j_rtc_config);
+
   ScopedJavaLocalRef<jstring> j_turn_logging_id =
       Java_RTCConfiguration_getTurnLoggingId(jni, j_rtc_config);
   if (!IsNull(jni, j_turn_logging_id)) {

--- a/sdk/objc/api/peerconnection/RTCConfiguration.h
+++ b/sdk/objc/api/peerconnection/RTCConfiguration.h
@@ -261,6 +261,17 @@ RTC_OBJC_EXPORT
  */
 @property(nonatomic, copy, nullable) NSNumber *iceInactiveTimeout;
 
+/**
+  * When this flag is set, ports not bound to any specific network interface
+  * will be used, in addition to normal ports bound to the enumerated
+  * interfaces. Without this flag, these "any address" ports would only be
+  * used when network enumeration fails or is disabled. But under certain
+  * conditions, these ports may succeed where others fail, so they may allow
+  * the application to work in a wider variety of environments, at the expense
+  * of having to allocate additional candidates.
+  */
+@property(nonatomic, assign) BOOL enableIceGatheringOnAnyAddressPorts;
+
 - (instancetype)init;
 
 @end

--- a/sdk/objc/api/peerconnection/RTCConfiguration.mm
+++ b/sdk/objc/api/peerconnection/RTCConfiguration.mm
@@ -159,7 +159,7 @@
     _iceInactiveTimeout = config.ice_inactive_timeout.has_value() ?
         [NSNumber numberWithInt:*config.ice_inactive_timeout] :
         nil;
-    _enableIceGatheringOnAnyAddressPorts = config.enableIceGatheringOnAnyAddressPorts;
+    _enableIceGatheringOnAnyAddressPorts = config.enable_any_address_ports;
   }
   return self;
 }

--- a/sdk/objc/api/peerconnection/RTCConfiguration.mm
+++ b/sdk/objc/api/peerconnection/RTCConfiguration.mm
@@ -63,6 +63,7 @@
 @synthesize iceUnwritableTimeout = _iceUnwritableTimeout;
 @synthesize iceUnwritableMinChecks = _iceUnwritableMinChecks;
 @synthesize iceInactiveTimeout = _iceInactiveTimeout;
+@synthesize enableIceGatheringOnAnyAddressPorts = _enableIceGatheringOnAnyAddressPorts;
 
 - (instancetype)init {
   // Copy defaults.
@@ -158,6 +159,7 @@
     _iceInactiveTimeout = config.ice_inactive_timeout.has_value() ?
         [NSNumber numberWithInt:*config.ice_inactive_timeout] :
         nil;
+    _enableIceGatheringOnAnyAddressPorts = config.enableIceGatheringOnAnyAddressPorts;
   }
   return self;
 }
@@ -306,6 +308,7 @@
   if (_iceInactiveTimeout != nil) {
     nativeConfig->ice_inactive_timeout = absl::optional<int>(_iceInactiveTimeout.intValue);
   }
+  nativeConfig->enable_any_address_ports = _enableIceGatheringOnAnyAddressPorts;
   return nativeConfig.release();
 }
 


### PR DESCRIPTION
Some VPNs use 0.0.0.0 mask which will be ignored by the default gathering.
This flag allows those to be picked up as a last resort.

Has implementations for both android and ios.