### PR TITLE
Add NSPrivacyCollectedDataTypes key to xcprivacy file

### DIFF
--- a/sdk/objc/PrivacyInfo.xcprivacy
+++ b/sdk/objc/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Looks like Xcode requires `NSPrivacyCollectedDataTypes` key.

![LiveKitExample (macOS)-PrivacyReport 2024-04-25 18-38-31](https://github.com/webrtc-sdk/webrtc/assets/548776/03b26039-893f-4e69-8358-73863d704ebd)
