### PR TITLE
Set RTCCameraVideoCapturer initial zoom factor

### DIFF
--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
@@ -503,13 +503,10 @@ const int64_t kNanosecondsPerSecond = 1000000000;
   NSAssert([RTC_OBJC_TYPE(RTCDispatcher) isOnQueueForType:RTCDispatcherTypeCaptureSession],
            @"updateZoomFactor must be called on the capture queue.");
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_TV
   double firstSwitchOverZoomFactor =
       _currentDevice.virtualDeviceSwitchOverVideoZoomFactors.firstObject.doubleValue ?: 1.0;
   _currentDevice.videoZoomFactor = firstSwitchOverZoomFactor;
-#else
-  // Fallback code for macOS or other platforms
-  _currentDevice.videoZoomFactor = 1.0;
 #endif
 }
 

--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
@@ -504,8 +504,9 @@ const int64_t kNanosecondsPerSecond = 1000000000;
            @"updateZoomFactor must be called on the capture queue.");
 
 #if TARGET_OS_IOS || TARGET_OS_TV
-  double firstSwitchOverZoomFactor =
-      _currentDevice.virtualDeviceSwitchOverVideoZoomFactors.firstObject.doubleValue ?: 1.0;
+  CGFloat firstSwitchOverZoomFactor = 1.0;
+  NSNumber *first = _currentDevice.virtualDeviceSwitchOverVideoZoomFactors.firstObject;
+  if (first != nil) firstSwitchOverZoomFactor = first.doubleValue;
   _currentDevice.videoZoomFactor = firstSwitchOverZoomFactor;
 #endif
 }

--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
@@ -502,9 +502,15 @@ const int64_t kNanosecondsPerSecond = 1000000000;
 - (void)updateZoomFactor {
   NSAssert([RTC_OBJC_TYPE(RTCDispatcher) isOnQueueForType:RTCDispatcherTypeCaptureSession],
            @"updateZoomFactor must be called on the capture queue.");
+
+#if TARGET_OS_IOS
   double firstSwitchOverZoomFactor =
       _currentDevice.virtualDeviceSwitchOverVideoZoomFactors.firstObject.doubleValue ?: 1.0;
   _currentDevice.videoZoomFactor = firstSwitchOverZoomFactor;
+#else
+  // Fallback code for macOS or other platforms
+  _currentDevice.videoZoomFactor = 1.0;
+#endif
 }
 
 - (void)reconfigureCaptureSessionInput {


### PR DESCRIPTION
Some devices, such as `.builtInTripleCamera`, have a zoom factor of 2.0 for the normal zoom. This adjustment changes it to 2.0 instead of 1.0. Without this adjustment, when using `.builtInTripleCamera`, it will appear zoomed out.