### PR TITLE
Unlock configuration before starting capture session

### DIFF
--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.h
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.h
@@ -30,6 +30,8 @@ NS_EXTENSION_UNAVAILABLE_IOS("Camera not available in app extensions.")
 // Returns list of formats that are supported by this class for this device.
 + (NSArray<AVCaptureDeviceFormat *> *)supportedFormatsForDevice:(AVCaptureDevice *)device;
 
++ (CGFloat)defaultZoomFactorForDeviceType:(AVCaptureDeviceType)deviceType;
+
 // Returns the most efficient supported output pixel format for this capturer.
 - (FourCharCode)preferredOutputPixelFormat;
 

--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
@@ -144,11 +144,13 @@ const int64_t kNanosecondsPerSecond = 1000000000;
   // AVCaptureDeviceTypeBuiltInTelephotoCamera, Physical
   // AVCaptureDeviceTypeBuiltInUltraWideCamera, Physical
 #if TARGET_OS_IOS || TARGET_OS_TV
-  if ([deviceType isEqualToString:AVCaptureDeviceTypeBuiltInTripleCamera] ||
-      [deviceType isEqualToString:AVCaptureDeviceTypeBuiltInDualWideCamera])
-    // For AVCaptureDeviceTypeBuiltInTripleCamera and AVCaptureDeviceTypeBuiltInDualWideCamera,
-    // it will switch over from ultra-wide to wide on 2.0, so to prefer wide by default, return 2.0.
-    return 2.0;
+  if (@available(iOS 13.0, tvOS 17.0, *)) {
+    if ([deviceType isEqualToString:AVCaptureDeviceTypeBuiltInTripleCamera] ||
+        [deviceType isEqualToString:AVCaptureDeviceTypeBuiltInDualWideCamera])
+      // For AVCaptureDeviceTypeBuiltInTripleCamera and AVCaptureDeviceTypeBuiltInDualWideCamera,
+      // it will switch over from ultra-wide to wide on 2.0, so to prefer wide by default.
+      return 2.0;
+  }
 #endif
 
   return 1.0;

--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
@@ -136,6 +136,24 @@ const int64_t kNanosecondsPerSecond = 1000000000;
   return device.formats;
 }
 
++ (CGFloat)defaultZoomFactorForDeviceType:(AVCaptureDeviceType)deviceType {
+  // AVCaptureDeviceTypeBuiltInTripleCamera, Virtual, switchOver: [2, 6], default: 2
+  // AVCaptureDeviceTypeBuiltInDualCamera, Virtual, switchOver: [3], default: 1
+  // AVCaptureDeviceTypeBuiltInDualWideCamera, Virtual, switchOver: [2], default: 2
+  // AVCaptureDeviceTypeBuiltInWideAngleCamera, Physical, General purpose use
+  // AVCaptureDeviceTypeBuiltInTelephotoCamera, Physical
+  // AVCaptureDeviceTypeBuiltInUltraWideCamera, Physical
+#if TARGET_OS_IOS || TARGET_OS_TV
+  if ([deviceType isEqualToString:AVCaptureDeviceTypeBuiltInTripleCamera] ||
+      [deviceType isEqualToString:AVCaptureDeviceTypeBuiltInDualWideCamera])
+    // For AVCaptureDeviceTypeBuiltInTripleCamera and AVCaptureDeviceTypeBuiltInDualWideCamera,
+    // it will switch over from ultra-wide to wide on 2.0, so to prefer wide by default, return 2.0.
+    return 2.0;
+#endif
+
+  return 1.0;
+}
+
 - (FourCharCode)preferredOutputPixelFormat {
   return _preferredOutputPixelFormat;
 }
@@ -187,8 +205,9 @@ const int64_t kNanosecondsPerSecond = 1000000000;
                       [self updateDeviceCaptureFormat:format fps:fps];
                       [self updateVideoDataOutputPixelFormat:format];
                       [self updateZoomFactor];
-                      [self.captureSession startRunning];
                       [self.currentDevice unlockForConfiguration];
+
+                      [self.captureSession startRunning];
                       self.isRunning = YES;
                       if (completionHandler) {
                         completionHandler(nil);
@@ -504,10 +523,8 @@ const int64_t kNanosecondsPerSecond = 1000000000;
            @"updateZoomFactor must be called on the capture queue.");
 
 #if TARGET_OS_IOS || TARGET_OS_TV
-  CGFloat firstSwitchOverZoomFactor = 1.0;
-  NSNumber *first = _currentDevice.virtualDeviceSwitchOverVideoZoomFactors.firstObject;
-  if (first != nil) firstSwitchOverZoomFactor = first.doubleValue;
-  _currentDevice.videoZoomFactor = firstSwitchOverZoomFactor;
+  CGFloat videoZoomFactor = [[self class] defaultZoomFactorForDeviceType:_currentDevice.deviceType];
+  [_currentDevice setVideoZoomFactor:videoZoomFactor];
 #endif
 }
 


### PR DESCRIPTION
`unlockForConfiguration` before `[captureSession startRunning]` to reduce start glitch.
Expose `+defaultZoomFactorForDeviceType:` method.
Initial zoom factor was incorrect for devices such as AVCaptureDeviceTypeBuiltInDualCamera.
