### PR TITLE
Fix webrtc_voice_engine not notifying mute change

### DIFF
--- a/audio/audio_state.cc
+++ b/audio/audio_state.cc
@@ -128,7 +128,9 @@ void AudioState::RemoveSendingStream(webrtc::AudioSendStream* stream) {
   RTC_DCHECK_EQ(1, count);
   UpdateAudioTransportWithSendingStreams();
 
-  if (!ShouldRecord()) {
+  bool should_record = ShouldRecord();
+  RTC_LOG(LS_INFO) << "RemoveSendingStream: should_record = " << should_record;
+  if (!should_record) {
     config_.audio_device_module->StopRecording();
   }
 }
@@ -222,6 +224,7 @@ void AudioState::OnMuteStreamChanged() {
   auto* adm = config_.audio_device_module.get();
   bool should_record = ShouldRecord();
 
+  RTC_LOG(LS_INFO) << "OnMuteStreamChanged: should_record = " << should_record;
   if (should_record && !adm->Recording()) {
     if (adm->InitRecording() == 0) {
       adm->StartRecording();
@@ -232,8 +235,10 @@ void AudioState::OnMuteStreamChanged() {
 }
 
 bool AudioState::ShouldRecord() {
+  RTC_LOG(LS_INFO) << "ShouldRecord";
   // no streams to send
   if (sending_streams_.empty()) {
+    RTC_LOG(LS_INFO) << "ShouldRecord: send stream = empty";
     return false;
   }
 
@@ -246,6 +251,7 @@ bool AudioState::ShouldRecord() {
     }
   }
 
+  RTC_LOG(LS_INFO) << "ShouldRecord: " << muted_count << " muted, " << stream_count << " sending";
   return muted_count != stream_count;
 }
 

--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -1698,6 +1698,9 @@ bool WebRtcVoiceSendChannel::MuteStream(uint32_t ssrc, bool muted) {
     ap->set_output_will_be_muted(all_muted);
   }
 
+  // Notfy the AudioState that the mute state has updated.
+  engine_->audio_state()->OnMuteStreamChanged();
+
   return true;
 }
 


### PR DESCRIPTION
Looks like this line was missed during the m125 update.

https://github.com/webrtc-sdk/webrtc/commit/272127d457ab48e36241e82549870405864851f6#diff-56f5e0c459b287281ef3b0431d3f4129e8e4be4c6955d845bcb22210f08b7ba5R2289

Adding it back in so that mic is properly released when muted.