### PR TITLE
android: Allow for skipping checking the audio playstate if needed

### DIFF
--- a/sdk/android/src/java/org/webrtc/audio/WebRtcAudioTrack.java
+++ b/sdk/android/src/java/org/webrtc/audio/WebRtcAudioTrack.java
@@ -80,6 +80,8 @@ class WebRtcAudioTrack {
   private final @Nullable AudioTrackStateCallback stateCallback;
   private final @Nullable PlaybackSamplesReadyCallback audioSamplesReadyCallback;
 
+  private boolean checkPlayState = true;
+
   /**
    * Audio thread which keeps calling AudioTrack.write() to stream audio.
    * Data is periodically acquired from the native WebRTC layer using the
@@ -99,7 +101,10 @@ class WebRtcAudioTrack {
     public void run() {
       Process.setThreadPriority(Process.THREAD_PRIORITY_URGENT_AUDIO);
       Logging.d(TAG, "AudioTrackThread" + WebRtcAudioUtils.getThreadInfo());
-      assertTrue(audioTrack.getPlayState() == AudioTrack.PLAYSTATE_PLAYING);
+      
+      if (checkPlayState) {
+        assertTrue(audioTrack.getPlayState() == AudioTrack.PLAYSTATE_PLAYING);
+      }
 
       // Audio playout has started and the client is informed about it.
       doAudioTrackStateCallback(AUDIO_TRACK_START);


### PR DESCRIPTION
Pausing/stopping the audio track can lead to a race condition against the AudioTrackThread due to this assert. Normally this is fine since directly pausing/stopping isn't possible, but user is using reflection to workaround another audio issue (muted participants still have a sending audio stream which keeps the audio alive, affecting global sound if in the background).

Not a full fix, as would like to manually control the audio track directly (needs a bigger fix to handle proper synchronization before allowing public access), but this will work through reflection (user takes responsibility for usage).