### PR TITLE
Allow to pass in capture session to RTCCameraVideoCapturer

### DIFF
--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.h
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.h
@@ -32,6 +32,13 @@ NS_EXTENSION_UNAVAILABLE_IOS("Camera not available in app extensions.")
 
 + (CGFloat)defaultZoomFactorForDeviceType:(AVCaptureDeviceType)deviceType;
 
+- (instancetype)initWithDelegate:
+    (nullable __weak id<RTC_OBJC_TYPE(RTCVideoCapturerDelegate)>)delegate;
+
+- (instancetype)initWithDelegate:
+                    (nullable __weak id<RTC_OBJC_TYPE(RTCVideoCapturerDelegate)>)delegate
+                  captureSession:(AVCaptureSession *)captureSession;
+
 // Returns the most efficient supported output pixel format for this capturer.
 - (FourCharCode)preferredOutputPixelFormat;
 


### PR DESCRIPTION
Expose initializers to pass in capture session to RTCCameraVideoCapturer so we can use AVCaptureMultiCamSession etc to capture front and back simultaneously for iOS.