### PR TITLE
Allow software AEC for Simulator

### DIFF
--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -483,20 +483,7 @@ void WebRtcVoiceEngine::ApplyOptions(const AudioOptions& options_in) {
   // Use desktop AEC by default, when not using hardware AEC.
   bool use_mobile_software_aec = false;
 
-#if defined(WEBRTC_IOS)
-  if (options.ios_force_software_aec_HACK &&
-      *options.ios_force_software_aec_HACK) {
-    // EC may be forced on for a device known to have non-functioning platform
-    // AEC.
-    options.echo_cancellation = true;
-    RTC_LOG(LS_WARNING)
-        << "Force software AEC on iOS. May conflict with platform AEC.";
-  } else {
-    // On iOS, VPIO provides built-in EC.
-    options.echo_cancellation = false;
-    RTC_LOG(LS_INFO) << "Always disable AEC on iOS. Use built-in instead.";
-  }
-#elif defined(WEBRTC_ANDROID)
+#if defined(WEBRTC_ANDROID)
   use_mobile_software_aec = true;
 #endif
 

--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -483,7 +483,20 @@ void WebRtcVoiceEngine::ApplyOptions(const AudioOptions& options_in) {
   // Use desktop AEC by default, when not using hardware AEC.
   bool use_mobile_software_aec = false;
 
-#if defined(WEBRTC_ANDROID)
+#if defined(WEBRTC_IOS)
+  if (options.ios_force_software_aec_HACK &&
+      *options.ios_force_software_aec_HACK) {
+    // EC may be forced on for a device known to have non-functioning platform
+    // AEC.
+    options.echo_cancellation = true;
+    RTC_LOG(LS_WARNING)
+        << "Force software AEC on iOS. May conflict with platform AEC.";
+  } else {
+    // On iOS, VPIO provides built-in EC.
+    options.echo_cancellation = false;
+    RTC_LOG(LS_INFO) << "Always disable AEC on iOS. Use built-in instead.";
+  }
+#elif defined(WEBRTC_ANDROID)
   use_mobile_software_aec = true;
 #endif
 

--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -483,7 +483,7 @@ void WebRtcVoiceEngine::ApplyOptions(const AudioOptions& options_in) {
   // Use desktop AEC by default, when not using hardware AEC.
   bool use_mobile_software_aec = false;
 
-#if defined(WEBRTC_IOS)
+#if defined(WEBRTC_IOS) && !TARGET_OS_SIMULATOR
   if (options.ios_force_software_aec_HACK &&
       *options.ios_force_software_aec_HACK) {
     // EC may be forced on for a device known to have non-functioning platform
@@ -501,7 +501,7 @@ void WebRtcVoiceEngine::ApplyOptions(const AudioOptions& options_in) {
 #endif
 
 // Set and adjust gain control options.
-#if defined(WEBRTC_IOS)
+#if defined(WEBRTC_IOS) && !TARGET_OS_SIMULATOR
   // On iOS, VPIO provides built-in AGC.
   options.auto_gain_control = false;
   RTC_LOG(LS_INFO) << "Always disable AGC on iOS. Use built-in instead.";


### PR DESCRIPTION
~Allow to use "googEchoCancellation" constraint for software AEC.
For devices "googEchoCancellation" should be false to use VoiceProcessingIO.~