### PR TITLE
Fixed issue with missing network interfaces on iOS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,6 +33,7 @@ Christophe Dumez <ch.dumez@samsung.com>
 Chris Tserng <tserng@amazon.com>
 Cody Barnes <conceptgenesis@gmail.com>
 Colin Plumb
+Corby Hoback <corby.hoback@gmail.com>
 Cyril Lashkevich <notorca@gmail.com>
 CZ Theng <cz.theng@gmail.com>
 Danail Kirov <dkirovbroadsoft@gmail.com>

--- a/sdk/objc/components/network/RTCNetworkMonitor.mm
+++ b/sdk/objc/components/network/RTCNetworkMonitor.mm
@@ -89,6 +89,7 @@ rtc::AdapterType AdapterTypeFromInterfaceType(nw_interface_type_t interfaceType)
               RTCLog(@"NW path monitor available interface: %s", name);
               rtc::AdapterType adapterType = AdapterTypeFromInterfaceType(interfaceType);
               map->insert(std::pair<std::string, rtc::AdapterType>(name, adapterType));
+              return true;
             });
         @synchronized(strongSelf) {
           webrtc::NetworkMonitorObserver *observer = strongSelf->_observer;


### PR DESCRIPTION
Related issue: https://github.com/webrtc-sdk/webrtc/issues/148
Cherry-pick : https://webrtc.googlesource.com/src/+/fea60ef8e72fb17b4f8a5363aff7e63ab8027b4f

Fixed issue with network interfaces due to a missing return value in the "nw_path_enumerate_interfaces(...)" block. Exposed in iOS 18, RTCNetworkMonitor::initWithObserver will only enumerate the first interface, instead of all device interfaces

Bug: webrtc:359245764
Change-Id: Ifb9f28c33306c0096476a4afb0cdb4d734e87b2c
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/359541
Auto-Submit: Corby <corby.hoback@gmail.com>
Commit-Queue: Jonas Oreland <jonaso@webrtc.org>
Reviewed-by: Kári Helgason <kthelgason@webrtc.org>
Reviewed-by: Jonas Oreland <jonaso@webrtc.org>
Cr-Commit-Position: refs/heads/main@{#42818}