### PR TITLE
Prefix enums with `RTC_OBJC_TYPE` macro

### DIFF
--- a/sdk/objc/api/logging/RTCCallbackLogger.h
+++ b/sdk/objc/api/logging/RTCCallbackLogger.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^RTCCallbackLoggerMessageHandler)(NSString *message);
 typedef void (^RTCCallbackLoggerMessageAndSeverityHandler)(NSString *message,
-                                                           RTCLoggingSeverity severity);
+                                                           RTC_OBJC_TYPE(RTCLoggingSeverity) severity);
 
 // This class intercepts WebRTC logs and forwards them to a registered block.
 // This class is not threadsafe.
@@ -25,7 +25,7 @@ RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCCallbackLogger) : NSObject
 
 // The severity level to capture. The default is kRTCLoggingSeverityInfo.
-@property(nonatomic, assign) RTCLoggingSeverity severity;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCLoggingSeverity) severity;
 
 // The callback handler will be called on the same thread that does the
 // logging, so if the logging callback can be slow it may be a good idea

--- a/sdk/objc/api/logging/RTCCallbackLogger.mm
+++ b/sdk/objc/api/logging/RTCCallbackLogger.mm
@@ -53,24 +53,24 @@ class CallbackWithSeverityLogSink final : public rtc::LogSink {
 
   void OnLogMessage(absl::string_view message, rtc::LoggingSeverity severity) override {
     if (callback_handler_) {
-      RTCLoggingSeverity loggingSeverity = NativeSeverityToObjcSeverity(severity);
+      RTC_OBJC_TYPE(RTCLoggingSeverity) loggingSeverity = NativeSeverityToObjcSeverity(severity);
       callback_handler_([NSString stringForAbslStringView:message], loggingSeverity);
     }
   }
 
  private:
-  static RTCLoggingSeverity NativeSeverityToObjcSeverity(rtc::LoggingSeverity severity) {
+  static RTC_OBJC_TYPE(RTCLoggingSeverity) NativeSeverityToObjcSeverity(rtc::LoggingSeverity severity) {
     switch (severity) {
       case rtc::LS_VERBOSE:
-        return RTCLoggingSeverityVerbose;
+        return RTC_OBJC_TYPE(RTCLoggingSeverityVerbose);
       case rtc::LS_INFO:
-        return RTCLoggingSeverityInfo;
+        return RTC_OBJC_TYPE(RTCLoggingSeverityInfo);
       case rtc::LS_WARNING:
-        return RTCLoggingSeverityWarning;
+        return RTC_OBJC_TYPE(RTCLoggingSeverityWarning);
       case rtc::LS_ERROR:
-        return RTCLoggingSeverityError;
+        return RTC_OBJC_TYPE(RTCLoggingSeverityError);
       case rtc::LS_NONE:
-        return RTCLoggingSeverityNone;
+        return RTC_OBJC_TYPE(RTCLoggingSeverityNone);
     }
   }
 
@@ -89,7 +89,7 @@ class CallbackWithSeverityLogSink final : public rtc::LogSink {
 - (instancetype)init {
   self = [super init];
   if (self != nil) {
-    _severity = RTCLoggingSeverityInfo;
+    _severity = RTC_OBJC_TYPE(RTCLoggingSeverityInfo);
   }
   return self;
 }
@@ -135,15 +135,15 @@ class CallbackWithSeverityLogSink final : public rtc::LogSink {
 
 - (rtc::LoggingSeverity)rtcSeverity {
   switch (_severity) {
-    case RTCLoggingSeverityVerbose:
+    case RTC_OBJC_TYPE(RTCLoggingSeverityVerbose):
       return rtc::LS_VERBOSE;
-    case RTCLoggingSeverityInfo:
+    case RTC_OBJC_TYPE(RTCLoggingSeverityInfo):
       return rtc::LS_INFO;
-    case RTCLoggingSeverityWarning:
+    case RTC_OBJC_TYPE(RTCLoggingSeverityWarning):
       return rtc::LS_WARNING;
-    case RTCLoggingSeverityError:
+    case RTC_OBJC_TYPE(RTCLoggingSeverityError):
       return rtc::LS_ERROR;
-    case RTCLoggingSeverityNone:
+    case RTC_OBJC_TYPE(RTCLoggingSeverityNone):
       return rtc::LS_NONE;
   }
 }

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -14,15 +14,107 @@
  * limitations under the License.
  */
 
+#import <AVFAudio/AVFAudio.h>
 #import <CoreMedia/CoreMedia.h>
 #import <Foundation/Foundation.h>
 
-#import "RTCMacros.h"
 #import "RTCIODevice.h"
+#import "RTCMacros.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^RTCOnAudioDevicesDidUpdate)();
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCAudioDeviceModuleType)) {
+  RTC_OBJC_TYPE(RTCAudioDeviceModuleTypePlatformDefault),
+  RTC_OBJC_TYPE(RTCAudioDeviceModuleTypeAudioEngine),
+};
+
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCSpeechActivityEvent)) {
+  RTC_OBJC_TYPE(RTCSpeechActivityEventStarted),
+  RTC_OBJC_TYPE(RTCSpeechActivityEventEnded),
+  RTC_OBJC_TYPE(RTCSpeechActivityEventNone),
+};
+
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCAudioEngineMuteMode)) {
+  RTC_OBJC_TYPE(RTCAudioEngineMuteModeUnknown) = -1,
+  RTC_OBJC_TYPE(RTCAudioEngineMuteModeAll) = 0,  // Default for iOS
+  RTC_OBJC_TYPE(RTCAudioEngineMuteModeNone) = 1,
+  RTC_OBJC_TYPE(RTCAudioEngineMuteModeInput) = 2,  // Default for Mac
+  RTC_OBJC_TYPE(RTCAudioEngineMuteModeOutput) = 3,
+};
+
+typedef struct {
+  bool outputEnabled;
+  bool outputRunning;
+  bool inputEnabled;
+  bool inputRunning;
+  bool inputMuted;
+  RTC_OBJC_TYPE(RTCAudioEngineMuteMode) muteMode;
+} RTC_OBJC_TYPE(RTCAudioEngineState);
+
+RTC_EXTERN NSString *const kRTCAudioEngineInputMixerNodeKey;
+
+@class RTC_OBJC_TYPE(RTCAudioDeviceModule);
+
+RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
+(RTCAudioDeviceModuleDelegate)<NSObject>
+
+    - (void)audioDeviceModule
+    : (RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule didReceiveSpeechActivityEvent
+    : (RTC_OBJC_TYPE(RTCSpeechActivityEvent))speechActivityEvent NS_SWIFT_NAME(audioDeviceModule(_:didReceiveSpeechActivityEvent:));
+
+// Engine events
+- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+               didCreateEngine:(AVAudioEngine *)engine
+    NS_SWIFT_NAME(audioDeviceModule(_:didCreateEngine:));
+
+- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+              willEnableEngine:(AVAudioEngine *)engine
+              isPlayoutEnabled:(BOOL)isPlayoutEnabled
+            isRecordingEnabled:(BOOL)isRecordingEnabled
+    NS_SWIFT_NAME(audioDeviceModule(_:willEnableEngine:isPlayoutEnabled:isRecordingEnabled:));
+
+- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+               willStartEngine:(AVAudioEngine *)engine
+              isPlayoutEnabled:(BOOL)isPlayoutEnabled
+            isRecordingEnabled:(BOOL)isRecordingEnabled
+    NS_SWIFT_NAME(audioDeviceModule(_:willStartEngine:isPlayoutEnabled:isRecordingEnabled:));
+
+- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+                 didStopEngine:(AVAudioEngine *)engine
+              isPlayoutEnabled:(BOOL)isPlayoutEnabled
+            isRecordingEnabled:(BOOL)isRecordingEnabled
+    NS_SWIFT_NAME(audioDeviceModule(_:didStopEngine:isPlayoutEnabled:isRecordingEnabled:));
+
+- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+              didDisableEngine:(AVAudioEngine *)engine
+              isPlayoutEnabled:(BOOL)isPlayoutEnabled
+            isRecordingEnabled:(BOOL)isRecordingEnabled
+    NS_SWIFT_NAME(audioDeviceModule(_:didDisableEngine:isPlayoutEnabled:isRecordingEnabled:));
+
+- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+             willReleaseEngine:(AVAudioEngine *)engine
+    NS_SWIFT_NAME(audioDeviceModule(_:willReleaseEngine:));
+
+- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+                        engine:(AVAudioEngine *)engine
+      configureInputFromSource:(nullable AVAudioNode *)source
+                 toDestination:(AVAudioNode *)destination
+                    withFormat:(AVAudioFormat *)format
+                       context:(NSDictionary *)context
+    NS_SWIFT_NAME(audioDeviceModule(_:engine:configureInputFromSource:toDestination:format:context:));
+
+- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+                        engine:(AVAudioEngine *)engine
+     configureOutputFromSource:(AVAudioNode *)source
+                 toDestination:(nullable AVAudioNode *)destination
+                    withFormat:(AVAudioFormat *)format
+                       context:(NSDictionary *)context
+    NS_SWIFT_NAME(audioDeviceModule(_:engine:configureOutputFromSource:toDestination:format:context:));
+
+- (void)audioDeviceModuleDidUpdateDevices:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+    NS_SWIFT_NAME(audioDeviceModuleDidUpdateDevices(_:));
+
+@end
 
 RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCAudioDeviceModule) : NSObject
@@ -33,8 +125,8 @@ RTC_OBJC_EXPORT
 @property(nonatomic, readonly) BOOL playing;
 @property(nonatomic, readonly) BOOL recording;
 
-@property(nonatomic, assign) RTC_OBJC_TYPE(RTCIODevice) *outputDevice;
-@property(nonatomic, assign) RTC_OBJC_TYPE(RTCIODevice) *inputDevice;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCIODevice) * outputDevice;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCIODevice) * inputDevice;
 
 // Executes low-level API's in sequence to switch the device
 // Use outputDevice / inputDevice property unless you need to know if setting the device is
@@ -42,14 +134,58 @@ RTC_OBJC_EXPORT
 - (BOOL)trySetOutputDevice:(nullable RTC_OBJC_TYPE(RTCIODevice) *)device;
 - (BOOL)trySetInputDevice:(nullable RTC_OBJC_TYPE(RTCIODevice) *)device;
 
-- (BOOL)setDevicesUpdatedHandler: (nullable RTCOnAudioDevicesDidUpdate) handler;
+- (NSInteger)startPlayout;
+- (NSInteger)stopPlayout;
+- (NSInteger)initPlayout;
+- (NSInteger)startRecording;
+- (NSInteger)stopRecording;
+- (NSInteger)initRecording;
 
-- (BOOL)startPlayout;
-- (BOOL)stopPlayout;
-- (BOOL)initPlayout;
-- (BOOL)startRecording;
-- (BOOL)stopRecording;
-- (BOOL)initRecording;
+- (NSInteger)initAndStartRecording;
+
+// For testing purposes
+@property(nonatomic, readonly) BOOL isPlayoutInitialized;
+@property(nonatomic, readonly) BOOL isRecordingInitialized;
+@property(nonatomic, readonly) BOOL isPlaying;
+@property(nonatomic, readonly) BOOL isRecording;
+@property(nonatomic, readonly) BOOL isEngineRunning;
+@property(nonatomic, readonly) BOOL isMicrophoneMuted;
+- (NSInteger)setMicrophoneMuted:(BOOL)muted;
+
+// Directly get & set engine state.
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCAudioEngineState) engineState;
+
+@property(nonatomic, readonly, getter=isRecordingAlwaysPreparedMode)
+    BOOL recordingAlwaysPreparedMode;
+- (NSInteger)setRecordingAlwaysPreparedMode:(BOOL)enabled;
+
+@property(nonatomic, weak, nullable) id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)> observer;
+
+// Manual rendering.
+@property(nonatomic, readonly, getter=isManualRenderingMode) BOOL manualRenderingMode;
+- (NSInteger)setManualRenderingMode:(BOOL)enabled;
+
+// Advanced other audio ducking.
+@property(nonatomic, assign, getter=isAdvancedDuckingEnabled) BOOL advancedDuckingEnabled;
+
+// Audio ducking level. See `AVAudioVoiceProcessingOtherAudioDuckingLevel` enum for valid values.
+@property(nonatomic, assign) NSInteger duckingLevel;
+
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCAudioEngineMuteMode) muteMode;
+- (NSInteger)setMuteMode:(RTC_OBJC_TYPE(RTCAudioEngineMuteMode))mode;
+
+/// Indicates whether Voice-Processing I/O is enabled. Requires restarting the Audio Engine to
+/// toggle. Defaults to true.
+@property(nonatomic, readonly, getter=isVoiceProcessingEnabled) BOOL voiceProcessingEnabled;
+- (NSInteger)setVoiceProcessingEnabled:(BOOL)enabled;
+
+/// Temporarily bypasses Voice-Processing I/O. Can be toggled at runtime without restarting the
+/// Audio Engine. Defaults to false.
+@property(nonatomic, assign, getter=isVoiceProcessingBypassed) BOOL voiceProcessingBypassed;
+
+/// Indicates whether Automatic Gain Control (AGC) is enabled. Requires Voice-Processing I/O to be
+/// enabled. Enabled by default when VPIO is enabled.
+@property(nonatomic, assign, getter=isVoiceProcessingAGCEnabled) BOOL voiceProcessingAGCEnabled;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -14,107 +14,15 @@
  * limitations under the License.
  */
 
-#import <AVFAudio/AVFAudio.h>
 #import <CoreMedia/CoreMedia.h>
 #import <Foundation/Foundation.h>
 
-#import "RTCIODevice.h"
 #import "RTCMacros.h"
+#import "RTCIODevice.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCAudioDeviceModuleType)) {
-  RTC_OBJC_TYPE(RTCAudioDeviceModuleTypePlatformDefault),
-  RTC_OBJC_TYPE(RTCAudioDeviceModuleTypeAudioEngine),
-};
-
-typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCSpeechActivityEvent)) {
-  RTC_OBJC_TYPE(RTCSpeechActivityEventStarted),
-  RTC_OBJC_TYPE(RTCSpeechActivityEventEnded),
-  RTC_OBJC_TYPE(RTCSpeechActivityEventNone),
-};
-
-typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCAudioEngineMuteMode)) {
-  RTC_OBJC_TYPE(RTCAudioEngineMuteModeUnknown) = -1,
-  RTC_OBJC_TYPE(RTCAudioEngineMuteModeAll) = 0,  // Default for iOS
-  RTC_OBJC_TYPE(RTCAudioEngineMuteModeNone) = 1,
-  RTC_OBJC_TYPE(RTCAudioEngineMuteModeInput) = 2,  // Default for Mac
-  RTC_OBJC_TYPE(RTCAudioEngineMuteModeOutput) = 3,
-};
-
-typedef struct {
-  bool outputEnabled;
-  bool outputRunning;
-  bool inputEnabled;
-  bool inputRunning;
-  bool inputMuted;
-  RTC_OBJC_TYPE(RTCAudioEngineMuteMode) muteMode;
-} RTC_OBJC_TYPE(RTCAudioEngineState);
-
-RTC_EXTERN NSString *const kRTCAudioEngineInputMixerNodeKey;
-
-@class RTC_OBJC_TYPE(RTCAudioDeviceModule);
-
-RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
-(RTCAudioDeviceModuleDelegate)<NSObject>
-
-    - (void)audioDeviceModule
-    : (RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule didReceiveSpeechActivityEvent
-    : (RTC_OBJC_TYPE(RTCSpeechActivityEvent))speechActivityEvent NS_SWIFT_NAME(audioDeviceModule(_:didReceiveSpeechActivityEvent:));
-
-// Engine events
-- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-               didCreateEngine:(AVAudioEngine *)engine
-    NS_SWIFT_NAME(audioDeviceModule(_:didCreateEngine:));
-
-- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-              willEnableEngine:(AVAudioEngine *)engine
-              isPlayoutEnabled:(BOOL)isPlayoutEnabled
-            isRecordingEnabled:(BOOL)isRecordingEnabled
-    NS_SWIFT_NAME(audioDeviceModule(_:willEnableEngine:isPlayoutEnabled:isRecordingEnabled:));
-
-- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-               willStartEngine:(AVAudioEngine *)engine
-              isPlayoutEnabled:(BOOL)isPlayoutEnabled
-            isRecordingEnabled:(BOOL)isRecordingEnabled
-    NS_SWIFT_NAME(audioDeviceModule(_:willStartEngine:isPlayoutEnabled:isRecordingEnabled:));
-
-- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-                 didStopEngine:(AVAudioEngine *)engine
-              isPlayoutEnabled:(BOOL)isPlayoutEnabled
-            isRecordingEnabled:(BOOL)isRecordingEnabled
-    NS_SWIFT_NAME(audioDeviceModule(_:didStopEngine:isPlayoutEnabled:isRecordingEnabled:));
-
-- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-              didDisableEngine:(AVAudioEngine *)engine
-              isPlayoutEnabled:(BOOL)isPlayoutEnabled
-            isRecordingEnabled:(BOOL)isRecordingEnabled
-    NS_SWIFT_NAME(audioDeviceModule(_:didDisableEngine:isPlayoutEnabled:isRecordingEnabled:));
-
-- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-             willReleaseEngine:(AVAudioEngine *)engine
-    NS_SWIFT_NAME(audioDeviceModule(_:willReleaseEngine:));
-
-- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-                        engine:(AVAudioEngine *)engine
-      configureInputFromSource:(nullable AVAudioNode *)source
-                 toDestination:(AVAudioNode *)destination
-                    withFormat:(AVAudioFormat *)format
-                       context:(NSDictionary *)context
-    NS_SWIFT_NAME(audioDeviceModule(_:engine:configureInputFromSource:toDestination:format:context:));
-
-- (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-                        engine:(AVAudioEngine *)engine
-     configureOutputFromSource:(AVAudioNode *)source
-                 toDestination:(nullable AVAudioNode *)destination
-                    withFormat:(AVAudioFormat *)format
-                       context:(NSDictionary *)context
-    NS_SWIFT_NAME(audioDeviceModule(_:engine:configureOutputFromSource:toDestination:format:context:));
-
-- (void)audioDeviceModuleDidUpdateDevices:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-    NS_SWIFT_NAME(audioDeviceModuleDidUpdateDevices(_:));
-
-@end
+typedef void (^RTCOnAudioDevicesDidUpdate)();
 
 RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCAudioDeviceModule) : NSObject
@@ -125,8 +33,8 @@ RTC_OBJC_EXPORT
 @property(nonatomic, readonly) BOOL playing;
 @property(nonatomic, readonly) BOOL recording;
 
-@property(nonatomic, assign) RTC_OBJC_TYPE(RTCIODevice) * outputDevice;
-@property(nonatomic, assign) RTC_OBJC_TYPE(RTCIODevice) * inputDevice;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCIODevice) *outputDevice;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCIODevice) *inputDevice;
 
 // Executes low-level API's in sequence to switch the device
 // Use outputDevice / inputDevice property unless you need to know if setting the device is
@@ -134,58 +42,14 @@ RTC_OBJC_EXPORT
 - (BOOL)trySetOutputDevice:(nullable RTC_OBJC_TYPE(RTCIODevice) *)device;
 - (BOOL)trySetInputDevice:(nullable RTC_OBJC_TYPE(RTCIODevice) *)device;
 
-- (NSInteger)startPlayout;
-- (NSInteger)stopPlayout;
-- (NSInteger)initPlayout;
-- (NSInteger)startRecording;
-- (NSInteger)stopRecording;
-- (NSInteger)initRecording;
+- (BOOL)setDevicesUpdatedHandler: (nullable RTCOnAudioDevicesDidUpdate) handler;
 
-- (NSInteger)initAndStartRecording;
-
-// For testing purposes
-@property(nonatomic, readonly) BOOL isPlayoutInitialized;
-@property(nonatomic, readonly) BOOL isRecordingInitialized;
-@property(nonatomic, readonly) BOOL isPlaying;
-@property(nonatomic, readonly) BOOL isRecording;
-@property(nonatomic, readonly) BOOL isEngineRunning;
-@property(nonatomic, readonly) BOOL isMicrophoneMuted;
-- (NSInteger)setMicrophoneMuted:(BOOL)muted;
-
-// Directly get & set engine state.
-@property(nonatomic, assign) RTC_OBJC_TYPE(RTCAudioEngineState) engineState;
-
-@property(nonatomic, readonly, getter=isRecordingAlwaysPreparedMode)
-    BOOL recordingAlwaysPreparedMode;
-- (NSInteger)setRecordingAlwaysPreparedMode:(BOOL)enabled;
-
-@property(nonatomic, weak, nullable) id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)> observer;
-
-// Manual rendering.
-@property(nonatomic, readonly, getter=isManualRenderingMode) BOOL manualRenderingMode;
-- (NSInteger)setManualRenderingMode:(BOOL)enabled;
-
-// Advanced other audio ducking.
-@property(nonatomic, assign, getter=isAdvancedDuckingEnabled) BOOL advancedDuckingEnabled;
-
-// Audio ducking level. See `AVAudioVoiceProcessingOtherAudioDuckingLevel` enum for valid values.
-@property(nonatomic, assign) NSInteger duckingLevel;
-
-@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCAudioEngineMuteMode) muteMode;
-- (NSInteger)setMuteMode:(RTC_OBJC_TYPE(RTCAudioEngineMuteMode))mode;
-
-/// Indicates whether Voice-Processing I/O is enabled. Requires restarting the Audio Engine to
-/// toggle. Defaults to true.
-@property(nonatomic, readonly, getter=isVoiceProcessingEnabled) BOOL voiceProcessingEnabled;
-- (NSInteger)setVoiceProcessingEnabled:(BOOL)enabled;
-
-/// Temporarily bypasses Voice-Processing I/O. Can be toggled at runtime without restarting the
-/// Audio Engine. Defaults to false.
-@property(nonatomic, assign, getter=isVoiceProcessingBypassed) BOOL voiceProcessingBypassed;
-
-/// Indicates whether Automatic Gain Control (AGC) is enabled. Requires Voice-Processing I/O to be
-/// enabled. Enabled by default when VPIO is enabled.
-@property(nonatomic, assign, getter=isVoiceProcessingAGCEnabled) BOOL voiceProcessingAGCEnabled;
+- (BOOL)startPlayout;
+- (BOOL)stopPlayout;
+- (BOOL)initPlayout;
+- (BOOL)startRecording;
+- (BOOL)stopRecording;
+- (BOOL)initRecording;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -14,72 +14,163 @@
  * limitations under the License.
  */
 
-#include <AudioUnit/AudioUnit.h>
+#include <os/lock.h>
 
-#import "RTCAudioDeviceModule.h"
 #import "RTCAudioDeviceModule+Private.h"
+#import "RTCAudioDeviceModule.h"
 #import "RTCIODevice+Private.h"
 #import "base/RTCLogging.h"
 
+#import "modules/audio_device/audio_engine_device.h"
 #import "sdk/objc/native/api/audio_device_module.h"
 
-class AudioDeviceSink : public webrtc::AudioDeviceSink {
+NSString *const kRTCAudioEngineInputMixerNodeKey = webrtc::kAudioEngineInputMixerNodeKey;
+
+inline webrtc::AudioEngineDevice::MuteMode MuteModeToRTC(RTC_OBJC_TYPE(RTCAudioEngineMuteMode) mode) {
+  return static_cast<webrtc::AudioEngineDevice::MuteMode>(mode);
+}
+
+inline RTC_OBJC_TYPE(RTCAudioEngineMuteMode) MuteModeToObjC(webrtc::AudioEngineDevice::MuteMode mode) {
+  return static_cast<RTC_OBJC_TYPE(RTCAudioEngineMuteMode)>(mode);
+}
+
+class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
  public:
-  AudioDeviceSink() {}
+  AudioDeviceObserver(RTC_OBJC_TYPE(RTCAudioDeviceModule) * adm) { adm_ = adm; }
 
-  void OnDevicesUpdated() override {
+  void OnDevicesUpdated() override { [delegate_ audioDeviceModuleDidUpdateDevices:adm_]; }
 
-    RTCLogInfo(@"AudioDeviceSink OnDevicesUpdated");
-
-    if (callback_handler_) {
-      callback_handler_();
-    }
+  void OnSpeechActivityEvent(webrtc::AudioDeviceModule::SpeechActivityEvent event) override {
+    [delegate_ audioDeviceModule:adm_
+        didReceiveSpeechActivityEvent:ConvertSpeechActivityEvent(event)];
   }
 
- // private:
-  RTCOnAudioDevicesDidUpdate callback_handler_;
+  int32_t OnEngineDidCreate(AVAudioEngine *engine) override {
+    if (delegate_ == nil) return 0;
+    return [delegate_ audioDeviceModule:adm_ didCreateEngine:engine];
+  }
+
+  int32_t OnEngineWillEnable(AVAudioEngine *engine, bool playout_enabled,
+                             bool recording_enabled) override {
+    if (delegate_ == nil) return 0;
+    return [delegate_ audioDeviceModule:adm_
+                       willEnableEngine:engine
+                       isPlayoutEnabled:playout_enabled
+                     isRecordingEnabled:recording_enabled];
+  }
+
+  int32_t OnEngineWillStart(AVAudioEngine *engine, bool playout_enabled,
+                            bool recording_enabled) override {
+    if (delegate_ == nil) return 0;
+    return [delegate_ audioDeviceModule:adm_
+                        willStartEngine:engine
+                       isPlayoutEnabled:playout_enabled
+                     isRecordingEnabled:recording_enabled];
+  }
+
+  int32_t OnEngineDidStop(AVAudioEngine *engine, bool playout_enabled,
+                          bool recording_enabled) override {
+    if (delegate_ == nil) return 0;
+    return [delegate_ audioDeviceModule:adm_
+                          didStopEngine:engine
+                       isPlayoutEnabled:playout_enabled
+                     isRecordingEnabled:recording_enabled];
+  }
+
+  int32_t OnEngineDidDisable(AVAudioEngine *engine, bool playout_enabled,
+                             bool recording_enabled) override {
+    if (delegate_ == nil) return 0;
+    return [delegate_ audioDeviceModule:adm_
+                       didDisableEngine:engine
+                       isPlayoutEnabled:playout_enabled
+                     isRecordingEnabled:recording_enabled];
+  }
+
+  int32_t OnEngineWillRelease(AVAudioEngine *engine) override {
+    if (delegate_ == nil) return 0;
+    return [delegate_ audioDeviceModule:adm_ willReleaseEngine:engine];
+  }
+
+  int32_t OnEngineWillConnectInput(AVAudioEngine *engine, AVAudioNode *src, AVAudioNode *dst,
+                                   AVAudioFormat *format, NSDictionary *context) override {
+    if (delegate_ == nil) return 0;
+    return [delegate_ audioDeviceModule:adm_
+                                 engine:engine
+               configureInputFromSource:src
+                          toDestination:dst
+                             withFormat:format
+                                context:context];
+  }
+
+  int32_t OnEngineWillConnectOutput(AVAudioEngine *engine, AVAudioNode *src, AVAudioNode *dst,
+                                    AVAudioFormat *format, NSDictionary *context) override {
+    if (delegate_ == nil) return 0;
+    return [delegate_ audioDeviceModule:adm_
+                                 engine:engine
+              configureOutputFromSource:src
+                          toDestination:dst
+                             withFormat:format
+                                context:context];
+  }
+
+  __weak id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)> delegate_;
+
+ private:
+  __weak RTC_OBJC_TYPE(RTCAudioDeviceModule) * adm_;
+
+  RTC_OBJC_TYPE(RTCSpeechActivityEvent) ConvertSpeechActivityEvent(
+      webrtc::AudioDeviceModule::SpeechActivityEvent event) {
+    switch (event) {
+      case webrtc::AudioDeviceModule::SpeechActivityEvent::kStarted:
+        return RTC_OBJC_TYPE(RTCSpeechActivityEvent)::RTC_OBJC_TYPE(RTCSpeechActivityEventStarted);
+      case webrtc::AudioDeviceModule::SpeechActivityEvent::kEnded:
+        return RTC_OBJC_TYPE(RTCSpeechActivityEvent)::RTC_OBJC_TYPE(RTCSpeechActivityEventEnded);
+      default:
+        return RTC_OBJC_TYPE(RTCSpeechActivityEvent)::RTC_OBJC_TYPE(RTCSpeechActivityEventEnded);
+    }
+  }
 };
 
 @implementation RTC_OBJC_TYPE (RTCAudioDeviceModule) {
   rtc::Thread *_workerThread;
   rtc::scoped_refptr<webrtc::AudioDeviceModule> _native;
-  AudioDeviceSink *_sink;
+  AudioDeviceObserver *_observer;
 }
 
-- (instancetype)initWithNativeModule:(rtc::scoped_refptr<webrtc::AudioDeviceModule> )module
-                        workerThread:(rtc::Thread * )workerThread {
+- (id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)>)observer {
+  return _workerThread->BlockingCall([self] { return _observer->delegate_; });
+}
 
+- (void)setObserver:(id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)>)observer {
+  _workerThread->BlockingCall([self, observer] {
+    _observer->delegate_ = observer;
+    _native->SetObserver(observer != nil ? _observer : nullptr);
+  });
+}
+
+- (instancetype)initWithNativeModule:(rtc::scoped_refptr<webrtc::AudioDeviceModule>)module
+                        workerThread:(rtc::Thread *)workerThread {
   RTCLogInfo(@"RTCAudioDeviceModule initWithNativeModule:workerThread:");
 
   self = [super init];
   _native = module;
   _workerThread = workerThread;
 
-  _sink = new AudioDeviceSink();
-
-  _workerThread->BlockingCall([self] {
-    _native->SetAudioDeviceSink(_sink);
-  });
+  _observer = new AudioDeviceObserver(self);
 
   return self;
 }
 
 - (NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *)outputDevices {
-
-  return _workerThread->BlockingCall([self] {
-    return [self _outputDevices];
-  });
+  return _workerThread->BlockingCall([self] { return [self _outputDevices]; });
 }
 
 - (NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *)inputDevices {
-  return _workerThread->BlockingCall([self] {
-    return [self _inputDevices];
-  });
+  return _workerThread->BlockingCall([self] { return [self _inputDevices]; });
 }
 
 - (RTC_OBJC_TYPE(RTCIODevice) *)outputDevice {
   return _workerThread->BlockingCall([self] {
-
     NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *devices = [self _outputDevices];
     int16_t devicesCount = (int16_t)([devices count]);
     int16_t index = _native->GetPlayoutDevice();
@@ -92,14 +183,12 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
   });
 }
 
-- (void)setOutputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
-  [self trySetOutputDevice: device];
+- (void)setOutputDevice:(RTC_OBJC_TYPE(RTCIODevice) *)device {
+  [self trySetOutputDevice:device];
 }
 
-- (BOOL)trySetOutputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
-
+- (BOOL)trySetOutputDevice:(RTC_OBJC_TYPE(RTCIODevice) *)device {
   return _workerThread->BlockingCall([self, device] {
-
     NSUInteger index = 0;
     NSArray *devices = [self _outputDevices];
 
@@ -108,7 +197,8 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
     }
 
     if (device != nil) {
-      index = [devices indexOfObjectPassingTest:^BOOL(RTC_OBJC_TYPE(RTCIODevice) *e, NSUInteger i, BOOL *stop) {
+      index = [devices indexOfObjectPassingTest:^BOOL(RTC_OBJC_TYPE(RTCIODevice) * e, NSUInteger i,
+                                                      BOOL * stop) {
         return (*stop = [e.deviceId isEqualToString:device.deviceId]);
       }];
       if (index == NSNotFound) {
@@ -116,13 +206,8 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
       }
     }
 
-    _native->StopPlayout();
-
-    if (_native->SetPlayoutDevice(index) == 0 
-        && _native->InitPlayout() == 0
-        && _native->StartPlayout() == 0) {
-
-        return YES;
+    if (_native->SetPlayoutDevice(index)) {
+      return YES;
     }
 
     return NO;
@@ -130,9 +215,7 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
 }
 
 - (RTC_OBJC_TYPE(RTCIODevice) *)inputDevice {
-
   return _workerThread->BlockingCall([self] {
-  
     NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *devices = [self _inputDevices];
     int16_t devicesCount = (int16_t)([devices count]);
     int16_t index = _native->GetRecordingDevice();
@@ -145,14 +228,12 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
   });
 }
 
-- (void)setInputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
-  [self trySetInputDevice: device];
+- (void)setInputDevice:(RTC_OBJC_TYPE(RTCIODevice) *)device {
+  [self trySetInputDevice:device];
 }
 
-- (BOOL)trySetInputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
-
+- (BOOL)trySetInputDevice:(RTC_OBJC_TYPE(RTCIODevice) *)device {
   return _workerThread->BlockingCall([self, device] {
-
     NSUInteger index = 0;
     NSArray *devices = [self _inputDevices];
 
@@ -161,7 +242,8 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
     }
 
     if (device != nil) {
-      index = [devices indexOfObjectPassingTest:^BOOL(RTC_OBJC_TYPE(RTCIODevice) *e, NSUInteger i, BOOL *stop) {
+      index = [devices indexOfObjectPassingTest:^BOOL(RTC_OBJC_TYPE(RTCIODevice) * e, NSUInteger i,
+                                                      BOOL * stop) {
         return (*stop = [e.deviceId isEqualToString:device.deviceId]);
       }];
       if (index == NSNotFound) {
@@ -169,13 +251,8 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
       }
     }
 
-    _native->StopRecording();
-
-    if (_native->SetRecordingDevice(index) == 0 
-        && _native->InitRecording() == 0
-        && _native->StartRecording() == 0) {
-
-        return YES;
+    if (_native->SetRecordingDevice(index)) {
+      return YES;
     }
 
     return NO;
@@ -183,75 +260,273 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
 }
 
 - (BOOL)playing {
-
-  return _workerThread->BlockingCall([self] {
-    return _native->Playing();
-  });
+  return _workerThread->BlockingCall([self] { return _native->Playing(); });
 }
 
 - (BOOL)recording {
-
-  return _workerThread->BlockingCall([self] {
-    return _native->Recording();
-  });
+  return _workerThread->BlockingCall([self] { return _native->Recording(); });
 }
 
 #pragma mark - Low-level access
 
-- (BOOL)startPlayout {
+- (NSInteger)startPlayout {
+  return _workerThread->BlockingCall([self] { return _native->StartPlayout(); });
+}
 
+- (NSInteger)stopPlayout {
+  return _workerThread->BlockingCall([self] { return _native->StopPlayout(); });
+}
+
+- (NSInteger)initPlayout {
+  return _workerThread->BlockingCall([self] { return _native->InitPlayout(); });
+}
+
+- (NSInteger)startRecording {
+  return _workerThread->BlockingCall([self] { return _native->StartRecording(); });
+}
+
+- (NSInteger)stopRecording {
+  return _workerThread->BlockingCall([self] { return _native->StopRecording(); });
+}
+
+- (NSInteger)initRecording {
+  return _workerThread->BlockingCall([self] { return _native->InitRecording(); });
+}
+
+- (NSInteger)initAndStartRecording {
   return _workerThread->BlockingCall([self] {
-    return _native->StartPlayout() == 0;
+    webrtc::AudioEngineDevice *engine_device =
+        dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+    if (engine_device != nullptr) {
+      return engine_device->InitAndStartRecording();
+    } else {
+      _native->InitRecording();
+      return _native->StartRecording();
+    }
   });
 }
 
-- (BOOL)stopPlayout {
+- (BOOL)isPlayoutInitialized {
+  return _workerThread->BlockingCall([self] { return _native->PlayoutIsInitialized(); });
+}
 
+- (BOOL)isRecordingInitialized {
+  return _workerThread->BlockingCall([self] { return _native->RecordingIsInitialized(); });
+}
+
+- (BOOL)isPlaying {
+  return _workerThread->BlockingCall([self] { return _native->Playing(); });
+}
+
+- (BOOL)isRecording {
+  return _workerThread->BlockingCall([self] { return _native->Recording(); });
+}
+
+- (BOOL)isEngineRunning {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return false;
+
+  return _workerThread->BlockingCall([module] { return module->IsEngineRunning(); });
+}
+
+- (BOOL)isMicrophoneMuted {
   return _workerThread->BlockingCall([self] {
-    return _native->StopPlayout() == 0;
+    bool value = false;
+    return _native->MicrophoneMute(&value) == 0 ? value : NO;
   });
 }
 
-- (BOOL)initPlayout {
+- (NSInteger)setMicrophoneMuted:(BOOL)muted {
+  return _workerThread->BlockingCall([self, muted] { return _native->SetMicrophoneMute(muted); });
+}
 
-  return _workerThread->BlockingCall([self] {
-    return _native->InitPlayout() == 0;
+- (RTC_OBJC_TYPE(RTCAudioEngineState))engineState {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineState){};
+
+  return _workerThread->BlockingCall([module] {
+    webrtc::AudioEngineDevice::EngineState state;
+    if (module->GetEngineState(&state) != 0) return RTC_OBJC_TYPE(RTCAudioEngineState){};
+
+    RTC_OBJC_TYPE(RTCAudioEngineState) result;
+    result.outputEnabled = state.output_enabled;
+    result.outputRunning = state.output_running;
+    result.inputEnabled = state.input_enabled;
+    result.inputRunning = state.input_running;
+    result.inputMuted = state.input_muted;
+    result.muteMode = MuteModeToObjC(state.mute_mode);
+    return result;
   });
 }
 
-- (BOOL)startRecording {
+- (void)setEngineState:(RTC_OBJC_TYPE(RTCAudioEngineState))state {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return;
 
-  return _workerThread->BlockingCall([self] {
-    return _native->StartRecording() == 0;
+  _workerThread->BlockingCall([module, state] {
+    webrtc::AudioEngineDevice::EngineState result;
+    result.output_enabled = state.outputEnabled;
+    result.output_running = state.outputRunning;
+    result.input_enabled = state.inputEnabled;
+    result.input_running = state.inputRunning;
+    result.input_muted = state.inputMuted;
+    result.mute_mode = MuteModeToRTC(state.muteMode);
+
+    module->SetEngineState(result);
   });
 }
 
-- (BOOL)stopRecording {
+#pragma mark - Unique to AudioEngineDevice
 
-  return _workerThread->BlockingCall([self] {
-    return _native->StopRecording() == 0;
+- (BOOL)isRecordingAlwaysPreparedMode {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return NO;
+
+  return _workerThread->BlockingCall([module] {
+    bool value = false;
+    return module->InitRecordingPersistentMode(&value) == 0 ? value : NO;
   });
 }
 
-- (BOOL)initRecording {
+- (NSInteger)setRecordingAlwaysPreparedMode:(BOOL)enabled {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return -1;
 
-  return _workerThread->BlockingCall([self] {
-    return _native->InitRecording() == 0;
+  return _workerThread->BlockingCall(
+      [module, enabled] { return module->SetInitRecordingPersistentMode(enabled); });
+}
+
+- (BOOL)isManualRenderingMode {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return NO;
+
+  return _workerThread->BlockingCall([module] {
+    bool value = false;
+    return module->ManualRenderingMode(&value) == 0 ? value : NO;
   });
 }
 
-- (BOOL)setDevicesUpdatedHandler: (nullable RTCOnAudioDevicesDidUpdate) handler {
-  _sink->callback_handler_ = handler;
-  return YES;
+- (NSInteger)setManualRenderingMode:(BOOL)enabled {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return -1;
+
+  return _workerThread->BlockingCall(
+      [module, enabled] { return module->SetManualRenderingMode(enabled); });
+}
+
+- (BOOL)isAdvancedDuckingEnabled {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return NO;
+
+  return _workerThread->BlockingCall([module] {
+    bool value = false;
+    return module->AdvancedDucking(&value) == 0 ? value : NO;
+  });
+}
+
+- (void)setAdvancedDuckingEnabled:(BOOL)enabled {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return;
+
+  _workerThread->BlockingCall(
+      [module, enabled] { return module->SetAdvancedDucking(enabled) == 0; });
+}
+
+- (NSInteger)duckingLevel {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return 0;
+
+  return _workerThread->BlockingCall([module] {
+    long value = false;
+    return module->DuckingLevel(&value) == 0 ? value : 0;
+  });
+}
+
+- (void)setDuckingLevel:(NSInteger)value {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return;
+
+  _workerThread->BlockingCall([module, value] { return module->SetDuckingLevel(value) == 0; });
+}
+
+- (RTC_OBJC_TYPE(RTCAudioEngineMuteMode))muteMode {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineMuteModeUnknown);
+
+  return _workerThread->BlockingCall([module] {
+    webrtc::AudioEngineDevice::MuteMode mode;
+    return module->GetMuteMode(&mode) == 0 ? MuteModeToObjC(mode) : RTC_OBJC_TYPE(RTCAudioEngineMuteModeUnknown);
+  });
+}
+
+- (NSInteger)setMuteMode:(RTC_OBJC_TYPE(RTCAudioEngineMuteMode))mode {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return -1;
+
+  return _workerThread->BlockingCall(
+      [module, mode] { return module->SetMuteMode(MuteModeToRTC(mode)); });
+}
+
+- (BOOL)isVoiceProcessingEnabled {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return NO;
+
+  return _workerThread->BlockingCall([module] {
+    bool value = false;
+    return module->VoiceProcessingEnabled(&value) == 0 ? value : NO;
+  });
+}
+
+- (NSInteger)setVoiceProcessingEnabled:(BOOL)enabled {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return -1;
+
+  return _workerThread->BlockingCall(
+      [module, enabled] { return module->SetVoiceProcessingEnabled(enabled); });
+}
+
+- (BOOL)isVoiceProcessingBypassed {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return NO;
+
+  return _workerThread->BlockingCall([module] {
+    bool value = false;
+    return module->VoiceProcessingBypassed(&value) == 0 ? value : NO;
+  });
+}
+
+- (void)setVoiceProcessingBypassed:(BOOL)enabled {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return;
+
+  _workerThread->BlockingCall(
+      [module, enabled] { return module->SetVoiceProcessingBypassed(enabled) == 0; });
+}
+
+- (BOOL)isVoiceProcessingAGCEnabled {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return NO;
+
+  return _workerThread->BlockingCall([module] {
+    bool value = false;
+    return module->VoiceProcessingAGCEnabled(&value) == 0 ? value : NO;
+  });
+}
+
+- (void)setVoiceProcessingAGCEnabled:(BOOL)enabled {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return;
+
+  _workerThread->BlockingCall(
+      [module, enabled] { return module->SetVoiceProcessingAGCEnabled(enabled) == 0; });
 }
 
 #pragma mark - Private
 
 - (NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *)_outputDevices {
-
   char guid[webrtc::kAdmMaxGuidSize + 1] = {0};
   char name[webrtc::kAdmMaxDeviceNameSize + 1] = {0};
-  
+
   NSMutableArray *result = [NSMutableArray array];
 
   int16_t count = _native->PlayoutDevices();
@@ -261,8 +536,11 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
       _native->PlayoutDeviceName(i, name, guid);
       NSString *strGUID = [[NSString alloc] initWithCString:guid encoding:NSUTF8StringEncoding];
       NSString *strName = [[NSString alloc] initWithCString:name encoding:NSUTF8StringEncoding];
-      RTC_OBJC_TYPE(RTCIODevice) *device = [[RTC_OBJC_TYPE(RTCIODevice) alloc] initWithType:RTCIODeviceTypeOutput deviceId:strGUID name:strName];
-      [result addObject: device];
+      RTC_OBJC_TYPE(RTCIODevice) *device =
+          [[RTC_OBJC_TYPE(RTCIODevice) alloc] initWithType:RTC_OBJC_TYPE(RTCIODeviceTypeOutput)
+                                                  deviceId:strGUID
+                                                      name:strName];
+      [result addObject:device];
     }
   }
 
@@ -270,10 +548,9 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
 }
 
 - (NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *)_inputDevices {
-  
   char guid[webrtc::kAdmMaxGuidSize + 1] = {0};
   char name[webrtc::kAdmMaxDeviceNameSize + 1] = {0};
-  
+
   NSMutableArray *result = [NSMutableArray array];
 
   int16_t count = _native->RecordingDevices();
@@ -283,8 +560,11 @@ class AudioDeviceSink : public webrtc::AudioDeviceSink {
       _native->RecordingDeviceName(i, name, guid);
       NSString *strGUID = [[NSString alloc] initWithCString:guid encoding:NSUTF8StringEncoding];
       NSString *strName = [[NSString alloc] initWithCString:name encoding:NSUTF8StringEncoding];
-      RTC_OBJC_TYPE(RTCIODevice) *device = [[RTC_OBJC_TYPE(RTCIODevice) alloc] initWithType:RTCIODeviceTypeInput deviceId:strGUID name:strName];
-      [result addObject: device];
+      RTC_OBJC_TYPE(RTCIODevice) *device =
+          [[RTC_OBJC_TYPE(RTCIODevice) alloc] initWithType:RTC_OBJC_TYPE(RTCIODeviceTypeInput)
+                                                  deviceId:strGUID
+                                                      name:strName];
+      [result addObject:device];
     }
   }
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -14,163 +14,72 @@
  * limitations under the License.
  */
 
-#include <os/lock.h>
+#include <AudioUnit/AudioUnit.h>
 
-#import "RTCAudioDeviceModule+Private.h"
 #import "RTCAudioDeviceModule.h"
+#import "RTCAudioDeviceModule+Private.h"
 #import "RTCIODevice+Private.h"
 #import "base/RTCLogging.h"
 
-#import "modules/audio_device/audio_engine_device.h"
 #import "sdk/objc/native/api/audio_device_module.h"
 
-NSString *const kRTCAudioEngineInputMixerNodeKey = webrtc::kAudioEngineInputMixerNodeKey;
-
-inline webrtc::AudioEngineDevice::MuteMode MuteModeToRTC(RTC_OBJC_TYPE(RTCAudioEngineMuteMode) mode) {
-  return static_cast<webrtc::AudioEngineDevice::MuteMode>(mode);
-}
-
-inline RTC_OBJC_TYPE(RTCAudioEngineMuteMode) MuteModeToObjC(webrtc::AudioEngineDevice::MuteMode mode) {
-  return static_cast<RTC_OBJC_TYPE(RTCAudioEngineMuteMode)>(mode);
-}
-
-class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
+class AudioDeviceSink : public webrtc::AudioDeviceSink {
  public:
-  AudioDeviceObserver(RTC_OBJC_TYPE(RTCAudioDeviceModule) * adm) { adm_ = adm; }
+  AudioDeviceSink() {}
 
-  void OnDevicesUpdated() override { [delegate_ audioDeviceModuleDidUpdateDevices:adm_]; }
+  void OnDevicesUpdated() override {
 
-  void OnSpeechActivityEvent(webrtc::AudioDeviceModule::SpeechActivityEvent event) override {
-    [delegate_ audioDeviceModule:adm_
-        didReceiveSpeechActivityEvent:ConvertSpeechActivityEvent(event)];
-  }
+    RTCLogInfo(@"AudioDeviceSink OnDevicesUpdated");
 
-  int32_t OnEngineDidCreate(AVAudioEngine *engine) override {
-    if (delegate_ == nil) return 0;
-    return [delegate_ audioDeviceModule:adm_ didCreateEngine:engine];
-  }
-
-  int32_t OnEngineWillEnable(AVAudioEngine *engine, bool playout_enabled,
-                             bool recording_enabled) override {
-    if (delegate_ == nil) return 0;
-    return [delegate_ audioDeviceModule:adm_
-                       willEnableEngine:engine
-                       isPlayoutEnabled:playout_enabled
-                     isRecordingEnabled:recording_enabled];
-  }
-
-  int32_t OnEngineWillStart(AVAudioEngine *engine, bool playout_enabled,
-                            bool recording_enabled) override {
-    if (delegate_ == nil) return 0;
-    return [delegate_ audioDeviceModule:adm_
-                        willStartEngine:engine
-                       isPlayoutEnabled:playout_enabled
-                     isRecordingEnabled:recording_enabled];
-  }
-
-  int32_t OnEngineDidStop(AVAudioEngine *engine, bool playout_enabled,
-                          bool recording_enabled) override {
-    if (delegate_ == nil) return 0;
-    return [delegate_ audioDeviceModule:adm_
-                          didStopEngine:engine
-                       isPlayoutEnabled:playout_enabled
-                     isRecordingEnabled:recording_enabled];
-  }
-
-  int32_t OnEngineDidDisable(AVAudioEngine *engine, bool playout_enabled,
-                             bool recording_enabled) override {
-    if (delegate_ == nil) return 0;
-    return [delegate_ audioDeviceModule:adm_
-                       didDisableEngine:engine
-                       isPlayoutEnabled:playout_enabled
-                     isRecordingEnabled:recording_enabled];
-  }
-
-  int32_t OnEngineWillRelease(AVAudioEngine *engine) override {
-    if (delegate_ == nil) return 0;
-    return [delegate_ audioDeviceModule:adm_ willReleaseEngine:engine];
-  }
-
-  int32_t OnEngineWillConnectInput(AVAudioEngine *engine, AVAudioNode *src, AVAudioNode *dst,
-                                   AVAudioFormat *format, NSDictionary *context) override {
-    if (delegate_ == nil) return 0;
-    return [delegate_ audioDeviceModule:adm_
-                                 engine:engine
-               configureInputFromSource:src
-                          toDestination:dst
-                             withFormat:format
-                                context:context];
-  }
-
-  int32_t OnEngineWillConnectOutput(AVAudioEngine *engine, AVAudioNode *src, AVAudioNode *dst,
-                                    AVAudioFormat *format, NSDictionary *context) override {
-    if (delegate_ == nil) return 0;
-    return [delegate_ audioDeviceModule:adm_
-                                 engine:engine
-              configureOutputFromSource:src
-                          toDestination:dst
-                             withFormat:format
-                                context:context];
-  }
-
-  __weak id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)> delegate_;
-
- private:
-  __weak RTC_OBJC_TYPE(RTCAudioDeviceModule) * adm_;
-
-  RTC_OBJC_TYPE(RTCSpeechActivityEvent) ConvertSpeechActivityEvent(
-      webrtc::AudioDeviceModule::SpeechActivityEvent event) {
-    switch (event) {
-      case webrtc::AudioDeviceModule::SpeechActivityEvent::kStarted:
-        return RTC_OBJC_TYPE(RTCSpeechActivityEvent)::RTC_OBJC_TYPE(RTCSpeechActivityEventStarted);
-      case webrtc::AudioDeviceModule::SpeechActivityEvent::kEnded:
-        return RTC_OBJC_TYPE(RTCSpeechActivityEvent)::RTC_OBJC_TYPE(RTCSpeechActivityEventEnded);
-      default:
-        return RTC_OBJC_TYPE(RTCSpeechActivityEvent)::RTC_OBJC_TYPE(RTCSpeechActivityEventEnded);
+    if (callback_handler_) {
+      callback_handler_();
     }
   }
+
+ // private:
+  RTCOnAudioDevicesDidUpdate callback_handler_;
 };
 
 @implementation RTC_OBJC_TYPE (RTCAudioDeviceModule) {
   rtc::Thread *_workerThread;
   rtc::scoped_refptr<webrtc::AudioDeviceModule> _native;
-  AudioDeviceObserver *_observer;
+  AudioDeviceSink *_sink;
 }
 
-- (id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)>)observer {
-  return _workerThread->BlockingCall([self] { return _observer->delegate_; });
-}
+- (instancetype)initWithNativeModule:(rtc::scoped_refptr<webrtc::AudioDeviceModule> )module
+                        workerThread:(rtc::Thread * )workerThread {
 
-- (void)setObserver:(id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)>)observer {
-  _workerThread->BlockingCall([self, observer] {
-    _observer->delegate_ = observer;
-    _native->SetObserver(observer != nil ? _observer : nullptr);
-  });
-}
-
-- (instancetype)initWithNativeModule:(rtc::scoped_refptr<webrtc::AudioDeviceModule>)module
-                        workerThread:(rtc::Thread *)workerThread {
   RTCLogInfo(@"RTCAudioDeviceModule initWithNativeModule:workerThread:");
 
   self = [super init];
   _native = module;
   _workerThread = workerThread;
 
-  _observer = new AudioDeviceObserver(self);
+  _sink = new AudioDeviceSink();
+
+  _workerThread->BlockingCall([self] {
+    _native->SetAudioDeviceSink(_sink);
+  });
 
   return self;
 }
 
 - (NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *)outputDevices {
-  return _workerThread->BlockingCall([self] { return [self _outputDevices]; });
+
+  return _workerThread->BlockingCall([self] {
+    return [self _outputDevices];
+  });
 }
 
 - (NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *)inputDevices {
-  return _workerThread->BlockingCall([self] { return [self _inputDevices]; });
+  return _workerThread->BlockingCall([self] {
+    return [self _inputDevices];
+  });
 }
 
 - (RTC_OBJC_TYPE(RTCIODevice) *)outputDevice {
   return _workerThread->BlockingCall([self] {
+
     NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *devices = [self _outputDevices];
     int16_t devicesCount = (int16_t)([devices count]);
     int16_t index = _native->GetPlayoutDevice();
@@ -183,12 +92,14 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   });
 }
 
-- (void)setOutputDevice:(RTC_OBJC_TYPE(RTCIODevice) *)device {
-  [self trySetOutputDevice:device];
+- (void)setOutputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
+  [self trySetOutputDevice: device];
 }
 
-- (BOOL)trySetOutputDevice:(RTC_OBJC_TYPE(RTCIODevice) *)device {
+- (BOOL)trySetOutputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
+
   return _workerThread->BlockingCall([self, device] {
+
     NSUInteger index = 0;
     NSArray *devices = [self _outputDevices];
 
@@ -197,8 +108,7 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
     }
 
     if (device != nil) {
-      index = [devices indexOfObjectPassingTest:^BOOL(RTC_OBJC_TYPE(RTCIODevice) * e, NSUInteger i,
-                                                      BOOL * stop) {
+      index = [devices indexOfObjectPassingTest:^BOOL(RTC_OBJC_TYPE(RTCIODevice) *e, NSUInteger i, BOOL *stop) {
         return (*stop = [e.deviceId isEqualToString:device.deviceId]);
       }];
       if (index == NSNotFound) {
@@ -206,8 +116,13 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
       }
     }
 
-    if (_native->SetPlayoutDevice(index)) {
-      return YES;
+    _native->StopPlayout();
+
+    if (_native->SetPlayoutDevice(index) == 0 
+        && _native->InitPlayout() == 0
+        && _native->StartPlayout() == 0) {
+
+        return YES;
     }
 
     return NO;
@@ -215,7 +130,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (RTC_OBJC_TYPE(RTCIODevice) *)inputDevice {
+
   return _workerThread->BlockingCall([self] {
+  
     NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *devices = [self _inputDevices];
     int16_t devicesCount = (int16_t)([devices count]);
     int16_t index = _native->GetRecordingDevice();
@@ -228,12 +145,14 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   });
 }
 
-- (void)setInputDevice:(RTC_OBJC_TYPE(RTCIODevice) *)device {
-  [self trySetInputDevice:device];
+- (void)setInputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
+  [self trySetInputDevice: device];
 }
 
-- (BOOL)trySetInputDevice:(RTC_OBJC_TYPE(RTCIODevice) *)device {
+- (BOOL)trySetInputDevice: (RTC_OBJC_TYPE(RTCIODevice) *)device {
+
   return _workerThread->BlockingCall([self, device] {
+
     NSUInteger index = 0;
     NSArray *devices = [self _inputDevices];
 
@@ -242,8 +161,7 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
     }
 
     if (device != nil) {
-      index = [devices indexOfObjectPassingTest:^BOOL(RTC_OBJC_TYPE(RTCIODevice) * e, NSUInteger i,
-                                                      BOOL * stop) {
+      index = [devices indexOfObjectPassingTest:^BOOL(RTC_OBJC_TYPE(RTCIODevice) *e, NSUInteger i, BOOL *stop) {
         return (*stop = [e.deviceId isEqualToString:device.deviceId]);
       }];
       if (index == NSNotFound) {
@@ -251,8 +169,13 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
       }
     }
 
-    if (_native->SetRecordingDevice(index)) {
-      return YES;
+    _native->StopRecording();
+
+    if (_native->SetRecordingDevice(index) == 0 
+        && _native->InitRecording() == 0
+        && _native->StartRecording() == 0) {
+
+        return YES;
     }
 
     return NO;
@@ -260,273 +183,75 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)playing {
-  return _workerThread->BlockingCall([self] { return _native->Playing(); });
+
+  return _workerThread->BlockingCall([self] {
+    return _native->Playing();
+  });
 }
 
 - (BOOL)recording {
-  return _workerThread->BlockingCall([self] { return _native->Recording(); });
+
+  return _workerThread->BlockingCall([self] {
+    return _native->Recording();
+  });
 }
 
 #pragma mark - Low-level access
 
-- (NSInteger)startPlayout {
-  return _workerThread->BlockingCall([self] { return _native->StartPlayout(); });
-}
+- (BOOL)startPlayout {
 
-- (NSInteger)stopPlayout {
-  return _workerThread->BlockingCall([self] { return _native->StopPlayout(); });
-}
-
-- (NSInteger)initPlayout {
-  return _workerThread->BlockingCall([self] { return _native->InitPlayout(); });
-}
-
-- (NSInteger)startRecording {
-  return _workerThread->BlockingCall([self] { return _native->StartRecording(); });
-}
-
-- (NSInteger)stopRecording {
-  return _workerThread->BlockingCall([self] { return _native->StopRecording(); });
-}
-
-- (NSInteger)initRecording {
-  return _workerThread->BlockingCall([self] { return _native->InitRecording(); });
-}
-
-- (NSInteger)initAndStartRecording {
   return _workerThread->BlockingCall([self] {
-    webrtc::AudioEngineDevice *engine_device =
-        dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-    if (engine_device != nullptr) {
-      return engine_device->InitAndStartRecording();
-    } else {
-      _native->InitRecording();
-      return _native->StartRecording();
-    }
+    return _native->StartPlayout() == 0;
   });
 }
 
-- (BOOL)isPlayoutInitialized {
-  return _workerThread->BlockingCall([self] { return _native->PlayoutIsInitialized(); });
-}
+- (BOOL)stopPlayout {
 
-- (BOOL)isRecordingInitialized {
-  return _workerThread->BlockingCall([self] { return _native->RecordingIsInitialized(); });
-}
-
-- (BOOL)isPlaying {
-  return _workerThread->BlockingCall([self] { return _native->Playing(); });
-}
-
-- (BOOL)isRecording {
-  return _workerThread->BlockingCall([self] { return _native->Recording(); });
-}
-
-- (BOOL)isEngineRunning {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return false;
-
-  return _workerThread->BlockingCall([module] { return module->IsEngineRunning(); });
-}
-
-- (BOOL)isMicrophoneMuted {
   return _workerThread->BlockingCall([self] {
-    bool value = false;
-    return _native->MicrophoneMute(&value) == 0 ? value : NO;
+    return _native->StopPlayout() == 0;
   });
 }
 
-- (NSInteger)setMicrophoneMuted:(BOOL)muted {
-  return _workerThread->BlockingCall([self, muted] { return _native->SetMicrophoneMute(muted); });
-}
+- (BOOL)initPlayout {
 
-- (RTC_OBJC_TYPE(RTCAudioEngineState))engineState {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineState){};
-
-  return _workerThread->BlockingCall([module] {
-    webrtc::AudioEngineDevice::EngineState state;
-    if (module->GetEngineState(&state) != 0) return RTC_OBJC_TYPE(RTCAudioEngineState){};
-
-    RTC_OBJC_TYPE(RTCAudioEngineState) result;
-    result.outputEnabled = state.output_enabled;
-    result.outputRunning = state.output_running;
-    result.inputEnabled = state.input_enabled;
-    result.inputRunning = state.input_running;
-    result.inputMuted = state.input_muted;
-    result.muteMode = MuteModeToObjC(state.mute_mode);
-    return result;
+  return _workerThread->BlockingCall([self] {
+    return _native->InitPlayout() == 0;
   });
 }
 
-- (void)setEngineState:(RTC_OBJC_TYPE(RTCAudioEngineState))state {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return;
+- (BOOL)startRecording {
 
-  _workerThread->BlockingCall([module, state] {
-    webrtc::AudioEngineDevice::EngineState result;
-    result.output_enabled = state.outputEnabled;
-    result.output_running = state.outputRunning;
-    result.input_enabled = state.inputEnabled;
-    result.input_running = state.inputRunning;
-    result.input_muted = state.inputMuted;
-    result.mute_mode = MuteModeToRTC(state.muteMode);
-
-    module->SetEngineState(result);
+  return _workerThread->BlockingCall([self] {
+    return _native->StartRecording() == 0;
   });
 }
 
-#pragma mark - Unique to AudioEngineDevice
+- (BOOL)stopRecording {
 
-- (BOOL)isRecordingAlwaysPreparedMode {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return NO;
-
-  return _workerThread->BlockingCall([module] {
-    bool value = false;
-    return module->InitRecordingPersistentMode(&value) == 0 ? value : NO;
+  return _workerThread->BlockingCall([self] {
+    return _native->StopRecording() == 0;
   });
 }
 
-- (NSInteger)setRecordingAlwaysPreparedMode:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return -1;
+- (BOOL)initRecording {
 
-  return _workerThread->BlockingCall(
-      [module, enabled] { return module->SetInitRecordingPersistentMode(enabled); });
-}
-
-- (BOOL)isManualRenderingMode {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return NO;
-
-  return _workerThread->BlockingCall([module] {
-    bool value = false;
-    return module->ManualRenderingMode(&value) == 0 ? value : NO;
+  return _workerThread->BlockingCall([self] {
+    return _native->InitRecording() == 0;
   });
 }
 
-- (NSInteger)setManualRenderingMode:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return -1;
-
-  return _workerThread->BlockingCall(
-      [module, enabled] { return module->SetManualRenderingMode(enabled); });
-}
-
-- (BOOL)isAdvancedDuckingEnabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return NO;
-
-  return _workerThread->BlockingCall([module] {
-    bool value = false;
-    return module->AdvancedDucking(&value) == 0 ? value : NO;
-  });
-}
-
-- (void)setAdvancedDuckingEnabled:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return;
-
-  _workerThread->BlockingCall(
-      [module, enabled] { return module->SetAdvancedDucking(enabled) == 0; });
-}
-
-- (NSInteger)duckingLevel {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return 0;
-
-  return _workerThread->BlockingCall([module] {
-    long value = false;
-    return module->DuckingLevel(&value) == 0 ? value : 0;
-  });
-}
-
-- (void)setDuckingLevel:(NSInteger)value {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return;
-
-  _workerThread->BlockingCall([module, value] { return module->SetDuckingLevel(value) == 0; });
-}
-
-- (RTC_OBJC_TYPE(RTCAudioEngineMuteMode))muteMode {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineMuteModeUnknown);
-
-  return _workerThread->BlockingCall([module] {
-    webrtc::AudioEngineDevice::MuteMode mode;
-    return module->GetMuteMode(&mode) == 0 ? MuteModeToObjC(mode) : RTC_OBJC_TYPE(RTCAudioEngineMuteModeUnknown);
-  });
-}
-
-- (NSInteger)setMuteMode:(RTC_OBJC_TYPE(RTCAudioEngineMuteMode))mode {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return -1;
-
-  return _workerThread->BlockingCall(
-      [module, mode] { return module->SetMuteMode(MuteModeToRTC(mode)); });
-}
-
-- (BOOL)isVoiceProcessingEnabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return NO;
-
-  return _workerThread->BlockingCall([module] {
-    bool value = false;
-    return module->VoiceProcessingEnabled(&value) == 0 ? value : NO;
-  });
-}
-
-- (NSInteger)setVoiceProcessingEnabled:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return -1;
-
-  return _workerThread->BlockingCall(
-      [module, enabled] { return module->SetVoiceProcessingEnabled(enabled); });
-}
-
-- (BOOL)isVoiceProcessingBypassed {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return NO;
-
-  return _workerThread->BlockingCall([module] {
-    bool value = false;
-    return module->VoiceProcessingBypassed(&value) == 0 ? value : NO;
-  });
-}
-
-- (void)setVoiceProcessingBypassed:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return;
-
-  _workerThread->BlockingCall(
-      [module, enabled] { return module->SetVoiceProcessingBypassed(enabled) == 0; });
-}
-
-- (BOOL)isVoiceProcessingAGCEnabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return NO;
-
-  return _workerThread->BlockingCall([module] {
-    bool value = false;
-    return module->VoiceProcessingAGCEnabled(&value) == 0 ? value : NO;
-  });
-}
-
-- (void)setVoiceProcessingAGCEnabled:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return;
-
-  _workerThread->BlockingCall(
-      [module, enabled] { return module->SetVoiceProcessingAGCEnabled(enabled) == 0; });
+- (BOOL)setDevicesUpdatedHandler: (nullable RTCOnAudioDevicesDidUpdate) handler {
+  _sink->callback_handler_ = handler;
+  return YES;
 }
 
 #pragma mark - Private
 
 - (NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *)_outputDevices {
+
   char guid[webrtc::kAdmMaxGuidSize + 1] = {0};
   char name[webrtc::kAdmMaxDeviceNameSize + 1] = {0};
-
+  
   NSMutableArray *result = [NSMutableArray array];
 
   int16_t count = _native->PlayoutDevices();
@@ -536,11 +261,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
       _native->PlayoutDeviceName(i, name, guid);
       NSString *strGUID = [[NSString alloc] initWithCString:guid encoding:NSUTF8StringEncoding];
       NSString *strName = [[NSString alloc] initWithCString:name encoding:NSUTF8StringEncoding];
-      RTC_OBJC_TYPE(RTCIODevice) *device =
-          [[RTC_OBJC_TYPE(RTCIODevice) alloc] initWithType:RTC_OBJC_TYPE(RTCIODeviceTypeOutput)
-                                                  deviceId:strGUID
-                                                      name:strName];
-      [result addObject:device];
+      RTC_OBJC_TYPE(RTCIODevice) *device = [[RTC_OBJC_TYPE(RTCIODevice) alloc] initWithType:RTCIODeviceTypeOutput deviceId:strGUID name:strName];
+      [result addObject: device];
     }
   }
 
@@ -548,9 +270,10 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *)_inputDevices {
+  
   char guid[webrtc::kAdmMaxGuidSize + 1] = {0};
   char name[webrtc::kAdmMaxDeviceNameSize + 1] = {0};
-
+  
   NSMutableArray *result = [NSMutableArray array];
 
   int16_t count = _native->RecordingDevices();
@@ -560,11 +283,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
       _native->RecordingDeviceName(i, name, guid);
       NSString *strGUID = [[NSString alloc] initWithCString:guid encoding:NSUTF8StringEncoding];
       NSString *strName = [[NSString alloc] initWithCString:name encoding:NSUTF8StringEncoding];
-      RTC_OBJC_TYPE(RTCIODevice) *device =
-          [[RTC_OBJC_TYPE(RTCIODevice) alloc] initWithType:RTC_OBJC_TYPE(RTCIODeviceTypeInput)
-                                                  deviceId:strGUID
-                                                      name:strName];
-      [result addObject:device];
+      RTC_OBJC_TYPE(RTCIODevice) *device = [[RTC_OBJC_TYPE(RTCIODevice) alloc] initWithType:RTCIODeviceTypeInput deviceId:strGUID name:strName];
+      [result addObject: device];
     }
   }
 

--- a/sdk/objc/api/peerconnection/RTCAudioSource+Private.h
+++ b/sdk/objc/api/peerconnection/RTCAudioSource+Private.h
@@ -29,6 +29,6 @@
 
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
               nativeMediaSource:(rtc::scoped_refptr<webrtc::MediaSourceInterface>)nativeMediaSource
-                           type:(RTCMediaSourceType)type NS_UNAVAILABLE;
+                           type:(RTC_OBJC_TYPE(RTCMediaSourceType))type NS_UNAVAILABLE;
 
 @end

--- a/sdk/objc/api/peerconnection/RTCAudioSource.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioSource.mm
@@ -23,10 +23,9 @@
                   (rtc::scoped_refptr<webrtc::AudioSourceInterface>)nativeAudioSource {
   RTC_DCHECK(factory);
   RTC_DCHECK(nativeAudioSource);
-
   if (self = [super initWithFactory:factory
                   nativeMediaSource:nativeAudioSource
-                               type:RTCMediaSourceTypeAudio]) {
+                               type:RTC_OBJC_TYPE(RTCMediaSourceTypeAudio)]) {
     _nativeAudioSource = nativeAudioSource;
   }
   return self;
@@ -34,7 +33,7 @@
 
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
               nativeMediaSource:(rtc::scoped_refptr<webrtc::MediaSourceInterface>)nativeMediaSource
-                           type:(RTCMediaSourceType)type {
+                           type:(RTC_OBJC_TYPE(RTCMediaSourceType))type {
   RTC_DCHECK_NOTREACHED();
   return nil;
 }

--- a/sdk/objc/api/peerconnection/RTCAudioSource.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioSource.mm
@@ -23,6 +23,7 @@
                   (rtc::scoped_refptr<webrtc::AudioSourceInterface>)nativeAudioSource {
   RTC_DCHECK(factory);
   RTC_DCHECK(nativeAudioSource);
+
   if (self = [super initWithFactory:factory
                   nativeMediaSource:nativeAudioSource
                                type:RTC_OBJC_TYPE(RTCMediaSourceTypeAudio)]) {

--- a/sdk/objc/api/peerconnection/RTCAudioTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioTrack.mm
@@ -39,7 +39,7 @@
   std::string nativeId = [NSString stdStringForString:trackId];
   rtc::scoped_refptr<webrtc::AudioTrackInterface> track =
       factory.nativeFactory->CreateAudioTrack(nativeId, source.nativeAudioSource.get());
-  if (self = [self initWithFactory:factory nativeTrack:track type:RTCMediaStreamTrackTypeAudio]) {
+  if (self = [self initWithFactory:factory nativeTrack:track type:RTC_OBJC_TYPE(RTCMediaStreamTrackTypeAudio)]) {
     _source = source;
   }
 
@@ -48,10 +48,10 @@
 
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
                     nativeTrack:(rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>)nativeTrack
-                           type:(RTCMediaStreamTrackType)type {
+                           type:(RTC_OBJC_TYPE(RTCMediaStreamTrackType))type {
   NSParameterAssert(factory);
   NSParameterAssert(nativeTrack);
-  NSParameterAssert(type == RTCMediaStreamTrackTypeAudio);
+  NSParameterAssert(type == RTC_OBJC_TYPE(RTCMediaStreamTrackTypeAudio));
   if (self = [super initWithFactory:factory nativeTrack:nativeTrack type:type]) {
     _adapters = [NSMutableArray array];
     _signalingThread = factory.signalingThread;

--- a/sdk/objc/api/peerconnection/RTCConfiguration+Private.h
+++ b/sdk/objc/api/peerconnection/RTCConfiguration+Private.h
@@ -18,52 +18,52 @@ NS_ASSUME_NONNULL_BEGIN
 ()
 
     + (webrtc::PeerConnectionInterface::IceTransportsType)nativeTransportsTypeForTransportPolicy
-    : (RTCIceTransportPolicy)policy;
+    : (RTC_OBJC_TYPE(RTCIceTransportPolicy))policy;
 
-+ (RTCIceTransportPolicy)transportPolicyForTransportsType:
++ (RTC_OBJC_TYPE(RTCIceTransportPolicy))transportPolicyForTransportsType:
     (webrtc::PeerConnectionInterface::IceTransportsType)nativeType;
 
-+ (NSString *)stringForTransportPolicy:(RTCIceTransportPolicy)policy;
++ (NSString *)stringForTransportPolicy:(RTC_OBJC_TYPE(RTCIceTransportPolicy))policy;
 
 + (webrtc::PeerConnectionInterface::BundlePolicy)nativeBundlePolicyForPolicy:
-    (RTCBundlePolicy)policy;
+    (RTC_OBJC_TYPE(RTCBundlePolicy))policy;
 
-+ (RTCBundlePolicy)bundlePolicyForNativePolicy:
++ (RTC_OBJC_TYPE(RTCBundlePolicy))bundlePolicyForNativePolicy:
     (webrtc::PeerConnectionInterface::BundlePolicy)nativePolicy;
 
-+ (NSString *)stringForBundlePolicy:(RTCBundlePolicy)policy;
++ (NSString *)stringForBundlePolicy:(RTC_OBJC_TYPE(RTCBundlePolicy))policy;
 
 + (webrtc::PeerConnectionInterface::RtcpMuxPolicy)nativeRtcpMuxPolicyForPolicy:
-    (RTCRtcpMuxPolicy)policy;
+    (RTC_OBJC_TYPE(RTCRtcpMuxPolicy))policy;
 
-+ (RTCRtcpMuxPolicy)rtcpMuxPolicyForNativePolicy:
++ (RTC_OBJC_TYPE(RTCRtcpMuxPolicy))rtcpMuxPolicyForNativePolicy:
     (webrtc::PeerConnectionInterface::RtcpMuxPolicy)nativePolicy;
 
-+ (NSString *)stringForRtcpMuxPolicy:(RTCRtcpMuxPolicy)policy;
++ (NSString *)stringForRtcpMuxPolicy:(RTC_OBJC_TYPE(RTCRtcpMuxPolicy))policy;
 
 + (webrtc::PeerConnectionInterface::TcpCandidatePolicy)nativeTcpCandidatePolicyForPolicy:
-    (RTCTcpCandidatePolicy)policy;
+    (RTC_OBJC_TYPE(RTCTcpCandidatePolicy))policy;
 
-+ (RTCTcpCandidatePolicy)tcpCandidatePolicyForNativePolicy:
++ (RTC_OBJC_TYPE(RTCTcpCandidatePolicy))tcpCandidatePolicyForNativePolicy:
     (webrtc::PeerConnectionInterface::TcpCandidatePolicy)nativePolicy;
 
-+ (NSString *)stringForTcpCandidatePolicy:(RTCTcpCandidatePolicy)policy;
++ (NSString *)stringForTcpCandidatePolicy:(RTC_OBJC_TYPE(RTCTcpCandidatePolicy))policy;
 
 + (webrtc::PeerConnectionInterface::CandidateNetworkPolicy)nativeCandidateNetworkPolicyForPolicy:
-    (RTCCandidateNetworkPolicy)policy;
+    (RTC_OBJC_TYPE(RTCCandidateNetworkPolicy))policy;
 
-+ (RTCCandidateNetworkPolicy)candidateNetworkPolicyForNativePolicy:
++ (RTC_OBJC_TYPE(RTCCandidateNetworkPolicy))candidateNetworkPolicyForNativePolicy:
     (webrtc::PeerConnectionInterface::CandidateNetworkPolicy)nativePolicy;
 
-+ (NSString *)stringForCandidateNetworkPolicy:(RTCCandidateNetworkPolicy)policy;
++ (NSString *)stringForCandidateNetworkPolicy:(RTC_OBJC_TYPE(RTCCandidateNetworkPolicy))policy;
 
-+ (rtc::KeyType)nativeEncryptionKeyTypeForKeyType:(RTCEncryptionKeyType)keyType;
++ (rtc::KeyType)nativeEncryptionKeyTypeForKeyType:(RTC_OBJC_TYPE(RTCEncryptionKeyType))keyType;
 
-+ (webrtc::SdpSemantics)nativeSdpSemanticsForSdpSemantics:(RTCSdpSemantics)sdpSemantics;
++ (webrtc::SdpSemantics)nativeSdpSemanticsForSdpSemantics:(RTC_OBJC_TYPE(RTCSdpSemantics))sdpSemantics;
 
-+ (RTCSdpSemantics)sdpSemanticsForNativeSdpSemantics:(webrtc::SdpSemantics)sdpSemantics;
++ (RTC_OBJC_TYPE(RTCSdpSemantics))sdpSemanticsForNativeSdpSemantics:(webrtc::SdpSemantics)sdpSemantics;
 
-+ (NSString *)stringForSdpSemantics:(RTCSdpSemantics)sdpSemantics;
++ (NSString *)stringForSdpSemantics:(RTC_OBJC_TYPE(RTCSdpSemantics))sdpSemantics;
 
 /**
  * RTCConfiguration struct representation of this RTCConfiguration.

--- a/sdk/objc/api/peerconnection/RTCConfiguration.h
+++ b/sdk/objc/api/peerconnection/RTCConfiguration.h
@@ -20,7 +20,7 @@
  * Represents the ice transport policy. This exposes the same states in C++,
  * which include one more state than what exists in the W3C spec.
  */
-typedef NS_ENUM(NSInteger, RTCIceTransportPolicy) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCIceTransportPolicy)) {
   RTCIceTransportPolicyNone,
   RTCIceTransportPolicyRelay,
   RTCIceTransportPolicyNoHost,
@@ -28,41 +28,41 @@ typedef NS_ENUM(NSInteger, RTCIceTransportPolicy) {
 };
 
 /** Represents the bundle policy. */
-typedef NS_ENUM(NSInteger, RTCBundlePolicy) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCBundlePolicy)) {
   RTCBundlePolicyBalanced,
   RTCBundlePolicyMaxCompat,
   RTCBundlePolicyMaxBundle
 };
 
 /** Represents the rtcp mux policy. */
-typedef NS_ENUM(NSInteger, RTCRtcpMuxPolicy) { RTCRtcpMuxPolicyNegotiate, RTCRtcpMuxPolicyRequire };
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtcpMuxPolicy)) { RTCRtcpMuxPolicyNegotiate, RTCRtcpMuxPolicyRequire };
 
 /** Represents the tcp candidate policy. */
-typedef NS_ENUM(NSInteger, RTCTcpCandidatePolicy) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCTcpCandidatePolicy)) {
   RTCTcpCandidatePolicyEnabled,
   RTCTcpCandidatePolicyDisabled
 };
 
 /** Represents the candidate network policy. */
-typedef NS_ENUM(NSInteger, RTCCandidateNetworkPolicy) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCCandidateNetworkPolicy)) {
   RTCCandidateNetworkPolicyAll,
   RTCCandidateNetworkPolicyLowCost
 };
 
 /** Represents the continual gathering policy. */
-typedef NS_ENUM(NSInteger, RTCContinualGatheringPolicy) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCContinualGatheringPolicy)) {
   RTCContinualGatheringPolicyGatherOnce,
   RTCContinualGatheringPolicyGatherContinually
 };
 
 /** Represents the encryption key type. */
-typedef NS_ENUM(NSInteger, RTCEncryptionKeyType) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCEncryptionKeyType)) {
   RTCEncryptionKeyTypeRSA,
   RTCEncryptionKeyTypeECDSA,
 };
 
 /** Represents the chosen SDP semantics for the RTCPeerConnection. */
-typedef NS_ENUM(NSInteger, RTCSdpSemantics) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCSdpSemantics)) {
   // TODO(https://crbug.com/webrtc/13528): Remove support for Plan B.
   RTCSdpSemanticsPlanB,
   RTCSdpSemanticsUnifiedPlan,
@@ -86,16 +86,16 @@ RTC_OBJC_EXPORT
 
 /** Which candidates the ICE agent is allowed to use. The W3C calls it
  * `iceTransportPolicy`, while in C++ it is called `type`. */
-@property(nonatomic, assign) RTCIceTransportPolicy iceTransportPolicy;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCIceTransportPolicy) iceTransportPolicy;
 
 /** The media-bundling policy to use when gathering ICE candidates. */
-@property(nonatomic, assign) RTCBundlePolicy bundlePolicy;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCBundlePolicy) bundlePolicy;
 
 /** The rtcp-mux policy to use when gathering ICE candidates. */
-@property(nonatomic, assign) RTCRtcpMuxPolicy rtcpMuxPolicy;
-@property(nonatomic, assign) RTCTcpCandidatePolicy tcpCandidatePolicy;
-@property(nonatomic, assign) RTCCandidateNetworkPolicy candidateNetworkPolicy;
-@property(nonatomic, assign) RTCContinualGatheringPolicy continualGatheringPolicy;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCRtcpMuxPolicy) rtcpMuxPolicy;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCTcpCandidatePolicy) tcpCandidatePolicy;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCCandidateNetworkPolicy) candidateNetworkPolicy;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCContinualGatheringPolicy) continualGatheringPolicy;
 
 /** If set to YES, don't gather IPv6 ICE candidates on Wi-Fi.
  *  Only intended to be used on specific devices. Certain phones disable IPv6
@@ -125,7 +125,7 @@ RTC_OBJC_EXPORT
 @property(nonatomic, assign) int iceBackupCandidatePairPingInterval;
 
 /** Key type used to generate SSL identity. Default is ECDSA. */
-@property(nonatomic, assign) RTCEncryptionKeyType keyType;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCEncryptionKeyType) keyType;
 
 /** ICE candidate pool size as defined in JSEP. Default is 0. */
 @property(nonatomic, assign) int iceCandidatePoolSize;
@@ -176,7 +176,7 @@ RTC_OBJC_EXPORT
  * the section. This will also cause RTCPeerConnection to ignore all but the
  * first m= section of the same media type.
  */
-@property(nonatomic, assign) RTCSdpSemantics sdpSemantics;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCSdpSemantics) sdpSemantics;
 
 /** Actively reset the SRTP parameters when the DTLS transports underneath are
  *  changed after offer/answer negotiation. This is only intended to be a

--- a/sdk/objc/api/peerconnection/RTCConfiguration.h
+++ b/sdk/objc/api/peerconnection/RTCConfiguration.h
@@ -21,51 +21,54 @@
  * which include one more state than what exists in the W3C spec.
  */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCIceTransportPolicy)) {
-  RTCIceTransportPolicyNone,
-  RTCIceTransportPolicyRelay,
-  RTCIceTransportPolicyNoHost,
-  RTCIceTransportPolicyAll
+  RTC_OBJC_TYPE(RTCIceTransportPolicyNone),
+  RTC_OBJC_TYPE(RTCIceTransportPolicyRelay),
+  RTC_OBJC_TYPE(RTCIceTransportPolicyNoHost),
+  RTC_OBJC_TYPE(RTCIceTransportPolicyAll)
 };
 
 /** Represents the bundle policy. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCBundlePolicy)) {
-  RTCBundlePolicyBalanced,
-  RTCBundlePolicyMaxCompat,
-  RTCBundlePolicyMaxBundle
+  RTC_OBJC_TYPE(RTCBundlePolicyBalanced),
+  RTC_OBJC_TYPE(RTCBundlePolicyMaxCompat),
+  RTC_OBJC_TYPE(RTCBundlePolicyMaxBundle)
 };
 
 /** Represents the rtcp mux policy. */
-typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtcpMuxPolicy)) { RTCRtcpMuxPolicyNegotiate, RTCRtcpMuxPolicyRequire };
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtcpMuxPolicy)) {
+  RTC_OBJC_TYPE(RTCRtcpMuxPolicyNegotiate),
+  RTC_OBJC_TYPE(RTCRtcpMuxPolicyRequire)
+};
 
 /** Represents the tcp candidate policy. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCTcpCandidatePolicy)) {
-  RTCTcpCandidatePolicyEnabled,
-  RTCTcpCandidatePolicyDisabled
+  RTC_OBJC_TYPE(RTCTcpCandidatePolicyEnabled),
+  RTC_OBJC_TYPE(RTCTcpCandidatePolicyDisabled)
 };
 
 /** Represents the candidate network policy. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCCandidateNetworkPolicy)) {
-  RTCCandidateNetworkPolicyAll,
-  RTCCandidateNetworkPolicyLowCost
+  RTC_OBJC_TYPE(RTCCandidateNetworkPolicyAll),
+  RTC_OBJC_TYPE(RTCCandidateNetworkPolicyLowCost)
 };
 
 /** Represents the continual gathering policy. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCContinualGatheringPolicy)) {
-  RTCContinualGatheringPolicyGatherOnce,
-  RTCContinualGatheringPolicyGatherContinually
+  RTC_OBJC_TYPE(RTCContinualGatheringPolicyGatherOnce),
+  RTC_OBJC_TYPE(RTCContinualGatheringPolicyGatherContinually)
 };
 
 /** Represents the encryption key type. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCEncryptionKeyType)) {
-  RTCEncryptionKeyTypeRSA,
-  RTCEncryptionKeyTypeECDSA,
+  RTC_OBJC_TYPE(RTCEncryptionKeyTypeRSA),
+  RTC_OBJC_TYPE(RTCEncryptionKeyTypeECDSA),
 };
 
 /** Represents the chosen SDP semantics for the RTCPeerConnection. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCSdpSemantics)) {
   // TODO(https://crbug.com/webrtc/13528): Remove support for Plan B.
-  RTCSdpSemanticsPlanB,
-  RTCSdpSemanticsUnifiedPlan,
+  RTC_OBJC_TYPE(RTCSdpSemanticsPlanB),
+  RTC_OBJC_TYPE(RTCSdpSemanticsUnifiedPlan),
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/sdk/objc/api/peerconnection/RTCConfiguration.mm
+++ b/sdk/objc/api/peerconnection/RTCConfiguration.mm
@@ -111,7 +111,7 @@
     _iceConnectionReceivingTimeout = config.ice_connection_receiving_timeout;
     _iceBackupCandidatePairPingInterval =
         config.ice_backup_candidate_pair_ping_interval;
-    _keyType = RTCEncryptionKeyTypeECDSA;
+    _keyType = RTC_OBJC_TYPE(RTCEncryptionKeyTypeECDSA);
     _iceCandidatePoolSize = config.ice_candidate_pool_size;
     _shouldPruneTurnPorts = config.prune_turn_ports;
     _shouldPresumeWritableWhenFullyRelayed =
@@ -310,233 +310,231 @@
 }
 
 + (webrtc::PeerConnectionInterface::IceTransportsType)
-    nativeTransportsTypeForTransportPolicy:(RTCIceTransportPolicy)policy {
+    nativeTransportsTypeForTransportPolicy:(RTC_OBJC_TYPE(RTCIceTransportPolicy))policy {
   switch (policy) {
-    case RTCIceTransportPolicyNone:
+    case RTC_OBJC_TYPE(RTCIceTransportPolicyNone):
       return webrtc::PeerConnectionInterface::kNone;
-    case RTCIceTransportPolicyRelay:
+    case RTC_OBJC_TYPE(RTCIceTransportPolicyRelay):
       return webrtc::PeerConnectionInterface::kRelay;
-    case RTCIceTransportPolicyNoHost:
+    case RTC_OBJC_TYPE(RTCIceTransportPolicyNoHost):
       return webrtc::PeerConnectionInterface::kNoHost;
-    case RTCIceTransportPolicyAll:
+    case RTC_OBJC_TYPE(RTCIceTransportPolicyAll):
       return webrtc::PeerConnectionInterface::kAll;
   }
 }
 
-+ (RTCIceTransportPolicy)transportPolicyForTransportsType:
++ (RTC_OBJC_TYPE(RTCIceTransportPolicy))transportPolicyForTransportsType:
     (webrtc::PeerConnectionInterface::IceTransportsType)nativeType {
   switch (nativeType) {
     case webrtc::PeerConnectionInterface::kNone:
-      return RTCIceTransportPolicyNone;
+      return RTC_OBJC_TYPE(RTCIceTransportPolicyNone);
     case webrtc::PeerConnectionInterface::kRelay:
-      return RTCIceTransportPolicyRelay;
+      return RTC_OBJC_TYPE(RTCIceTransportPolicyRelay);
     case webrtc::PeerConnectionInterface::kNoHost:
-      return RTCIceTransportPolicyNoHost;
+      return RTC_OBJC_TYPE(RTCIceTransportPolicyNoHost);
     case webrtc::PeerConnectionInterface::kAll:
-      return RTCIceTransportPolicyAll;
+      return RTC_OBJC_TYPE(RTCIceTransportPolicyAll);
   }
 }
 
-+ (NSString *)stringForTransportPolicy:(RTCIceTransportPolicy)policy {
++ (NSString *)stringForTransportPolicy:(RTC_OBJC_TYPE(RTCIceTransportPolicy))policy {
   switch (policy) {
-    case RTCIceTransportPolicyNone:
+    case RTC_OBJC_TYPE(RTCIceTransportPolicyNone):
       return @"NONE";
-    case RTCIceTransportPolicyRelay:
+    case RTC_OBJC_TYPE(RTCIceTransportPolicyRelay):
       return @"RELAY";
-    case RTCIceTransportPolicyNoHost:
+    case RTC_OBJC_TYPE(RTCIceTransportPolicyNoHost):
       return @"NO_HOST";
-    case RTCIceTransportPolicyAll:
+    case RTC_OBJC_TYPE(RTCIceTransportPolicyAll):
       return @"ALL";
   }
 }
 
 + (webrtc::PeerConnectionInterface::BundlePolicy)nativeBundlePolicyForPolicy:
-    (RTCBundlePolicy)policy {
+    (RTC_OBJC_TYPE(RTCBundlePolicy))policy {
   switch (policy) {
-    case RTCBundlePolicyBalanced:
+    case RTC_OBJC_TYPE(RTCBundlePolicyBalanced):
       return webrtc::PeerConnectionInterface::kBundlePolicyBalanced;
-    case RTCBundlePolicyMaxCompat:
-      return webrtc::PeerConnectionInterface::kBundlePolicyMaxCompat;
-    case RTCBundlePolicyMaxBundle:
+    case RTC_OBJC_TYPE(RTCBundlePolicyMaxBundle):
       return webrtc::PeerConnectionInterface::kBundlePolicyMaxBundle;
+    case RTC_OBJC_TYPE(RTCBundlePolicyMaxCompat):
+      return webrtc::PeerConnectionInterface::kBundlePolicyMaxCompat;
   }
 }
 
-+ (RTCBundlePolicy)bundlePolicyForNativePolicy:
++ (RTC_OBJC_TYPE(RTCBundlePolicy))bundlePolicyForNativePolicy:
     (webrtc::PeerConnectionInterface::BundlePolicy)nativePolicy {
   switch (nativePolicy) {
     case webrtc::PeerConnectionInterface::kBundlePolicyBalanced:
-      return RTCBundlePolicyBalanced;
-    case webrtc::PeerConnectionInterface::kBundlePolicyMaxCompat:
-      return RTCBundlePolicyMaxCompat;
+      return RTC_OBJC_TYPE(RTCBundlePolicyBalanced);
     case webrtc::PeerConnectionInterface::kBundlePolicyMaxBundle:
-      return RTCBundlePolicyMaxBundle;
+      return RTC_OBJC_TYPE(RTCBundlePolicyMaxBundle);
+    case webrtc::PeerConnectionInterface::kBundlePolicyMaxCompat:
+      return RTC_OBJC_TYPE(RTCBundlePolicyMaxCompat);
   }
 }
 
-+ (NSString *)stringForBundlePolicy:(RTCBundlePolicy)policy {
++ (NSString *)stringForBundlePolicy:(RTC_OBJC_TYPE(RTCBundlePolicy))policy {
   switch (policy) {
-    case RTCBundlePolicyBalanced:
+    case RTC_OBJC_TYPE(RTCBundlePolicyBalanced):
       return @"BALANCED";
-    case RTCBundlePolicyMaxCompat:
+    case RTC_OBJC_TYPE(RTCBundlePolicyMaxCompat):
       return @"MAX_COMPAT";
-    case RTCBundlePolicyMaxBundle:
+    case RTC_OBJC_TYPE(RTCBundlePolicyMaxBundle):
       return @"MAX_BUNDLE";
   }
 }
 
 + (webrtc::PeerConnectionInterface::RtcpMuxPolicy)nativeRtcpMuxPolicyForPolicy:
-    (RTCRtcpMuxPolicy)policy {
+    (RTC_OBJC_TYPE(RTCRtcpMuxPolicy))policy {
   switch (policy) {
-    case RTCRtcpMuxPolicyNegotiate:
+    case RTC_OBJC_TYPE(RTCRtcpMuxPolicyNegotiate):
       return webrtc::PeerConnectionInterface::kRtcpMuxPolicyNegotiate;
-    case RTCRtcpMuxPolicyRequire:
+    case RTC_OBJC_TYPE(RTCRtcpMuxPolicyRequire):
       return webrtc::PeerConnectionInterface::kRtcpMuxPolicyRequire;
   }
 }
 
-+ (RTCRtcpMuxPolicy)rtcpMuxPolicyForNativePolicy:
++ (RTC_OBJC_TYPE(RTCRtcpMuxPolicy))rtcpMuxPolicyForNativePolicy:
     (webrtc::PeerConnectionInterface::RtcpMuxPolicy)nativePolicy {
   switch (nativePolicy) {
     case webrtc::PeerConnectionInterface::kRtcpMuxPolicyNegotiate:
-      return RTCRtcpMuxPolicyNegotiate;
+      return RTC_OBJC_TYPE(RTCRtcpMuxPolicyNegotiate);
     case webrtc::PeerConnectionInterface::kRtcpMuxPolicyRequire:
-      return RTCRtcpMuxPolicyRequire;
+      return RTC_OBJC_TYPE(RTCRtcpMuxPolicyRequire);
   }
 }
 
-+ (NSString *)stringForRtcpMuxPolicy:(RTCRtcpMuxPolicy)policy {
++ (NSString *)stringForRtcpMuxPolicy:(RTC_OBJC_TYPE(RTCRtcpMuxPolicy))policy {
   switch (policy) {
-    case RTCRtcpMuxPolicyNegotiate:
+    case RTC_OBJC_TYPE(RTCRtcpMuxPolicyNegotiate):
       return @"NEGOTIATE";
-    case RTCRtcpMuxPolicyRequire:
+    case RTC_OBJC_TYPE(RTCRtcpMuxPolicyRequire):
       return @"REQUIRE";
   }
 }
 
-+ (webrtc::PeerConnectionInterface::TcpCandidatePolicy)
-    nativeTcpCandidatePolicyForPolicy:(RTCTcpCandidatePolicy)policy {
++ (webrtc::PeerConnectionInterface::TcpCandidatePolicy)nativeTcpCandidatePolicyForPolicy:
+    (RTC_OBJC_TYPE(RTCTcpCandidatePolicy))policy {
   switch (policy) {
-    case RTCTcpCandidatePolicyEnabled:
+    case RTC_OBJC_TYPE(RTCTcpCandidatePolicyEnabled):
       return webrtc::PeerConnectionInterface::kTcpCandidatePolicyEnabled;
-    case RTCTcpCandidatePolicyDisabled:
+    case RTC_OBJC_TYPE(RTCTcpCandidatePolicyDisabled):
       return webrtc::PeerConnectionInterface::kTcpCandidatePolicyDisabled;
   }
 }
 
-+ (webrtc::PeerConnectionInterface::CandidateNetworkPolicy)
-    nativeCandidateNetworkPolicyForPolicy:(RTCCandidateNetworkPolicy)policy {
++ (webrtc::PeerConnectionInterface::CandidateNetworkPolicy)nativeCandidateNetworkPolicyForPolicy:
+    (RTC_OBJC_TYPE(RTCCandidateNetworkPolicy))policy {
   switch (policy) {
-    case RTCCandidateNetworkPolicyAll:
+    case RTC_OBJC_TYPE(RTCCandidateNetworkPolicyAll):
       return webrtc::PeerConnectionInterface::kCandidateNetworkPolicyAll;
-    case RTCCandidateNetworkPolicyLowCost:
+    case RTC_OBJC_TYPE(RTCCandidateNetworkPolicyLowCost):
       return webrtc::PeerConnectionInterface::kCandidateNetworkPolicyLowCost;
   }
 }
 
-+ (RTCTcpCandidatePolicy)tcpCandidatePolicyForNativePolicy:
++ (RTC_OBJC_TYPE(RTCTcpCandidatePolicy))tcpCandidatePolicyForNativePolicy:
     (webrtc::PeerConnectionInterface::TcpCandidatePolicy)nativePolicy {
   switch (nativePolicy) {
     case webrtc::PeerConnectionInterface::kTcpCandidatePolicyEnabled:
-      return RTCTcpCandidatePolicyEnabled;
+      return RTC_OBJC_TYPE(RTCTcpCandidatePolicyEnabled);
     case webrtc::PeerConnectionInterface::kTcpCandidatePolicyDisabled:
-      return RTCTcpCandidatePolicyDisabled;
+      return RTC_OBJC_TYPE(RTCTcpCandidatePolicyDisabled);
   }
 }
 
-+ (NSString *)stringForTcpCandidatePolicy:(RTCTcpCandidatePolicy)policy {
++ (NSString *)stringForTcpCandidatePolicy:(RTC_OBJC_TYPE(RTCTcpCandidatePolicy))policy {
   switch (policy) {
-    case RTCTcpCandidatePolicyEnabled:
+    case RTC_OBJC_TYPE(RTCTcpCandidatePolicyEnabled):
       return @"TCP_ENABLED";
-    case RTCTcpCandidatePolicyDisabled:
+    case RTC_OBJC_TYPE(RTCTcpCandidatePolicyDisabled):
       return @"TCP_DISABLED";
   }
 }
 
-+ (RTCCandidateNetworkPolicy)candidateNetworkPolicyForNativePolicy:
++ (RTC_OBJC_TYPE(RTCCandidateNetworkPolicy))candidateNetworkPolicyForNativePolicy:
     (webrtc::PeerConnectionInterface::CandidateNetworkPolicy)nativePolicy {
   switch (nativePolicy) {
     case webrtc::PeerConnectionInterface::kCandidateNetworkPolicyAll:
-      return RTCCandidateNetworkPolicyAll;
+      return RTC_OBJC_TYPE(RTCCandidateNetworkPolicyAll);
     case webrtc::PeerConnectionInterface::kCandidateNetworkPolicyLowCost:
-      return RTCCandidateNetworkPolicyLowCost;
+      return RTC_OBJC_TYPE(RTCCandidateNetworkPolicyLowCost);
   }
 }
 
-+ (NSString *)stringForCandidateNetworkPolicy:
-    (RTCCandidateNetworkPolicy)policy {
++ (NSString *)stringForCandidateNetworkPolicy:(RTC_OBJC_TYPE(RTCCandidateNetworkPolicy))policy {
   switch (policy) {
-    case RTCCandidateNetworkPolicyAll:
+    case RTC_OBJC_TYPE(RTCCandidateNetworkPolicyAll):
       return @"CANDIDATE_ALL_NETWORKS";
-    case RTCCandidateNetworkPolicyLowCost:
+    case RTC_OBJC_TYPE(RTCCandidateNetworkPolicyLowCost):
       return @"CANDIDATE_LOW_COST_NETWORKS";
   }
 }
 
 + (webrtc::PeerConnectionInterface::ContinualGatheringPolicy)
     nativeContinualGatheringPolicyForPolicy:
-        (RTCContinualGatheringPolicy)policy {
+        (RTC_OBJC_TYPE(RTCContinualGatheringPolicy))policy {
   switch (policy) {
-    case RTCContinualGatheringPolicyGatherOnce:
+    case RTC_OBJC_TYPE(RTCContinualGatheringPolicyGatherOnce):
       return webrtc::PeerConnectionInterface::GATHER_ONCE;
-    case RTCContinualGatheringPolicyGatherContinually:
+    case RTC_OBJC_TYPE(RTCContinualGatheringPolicyGatherContinually):
       return webrtc::PeerConnectionInterface::GATHER_CONTINUALLY;
   }
 }
 
-+ (RTCContinualGatheringPolicy)continualGatheringPolicyForNativePolicy:
++ (RTC_OBJC_TYPE(RTCContinualGatheringPolicy))continualGatheringPolicyForNativePolicy:
     (webrtc::PeerConnectionInterface::ContinualGatheringPolicy)nativePolicy {
   switch (nativePolicy) {
     case webrtc::PeerConnectionInterface::GATHER_ONCE:
-      return RTCContinualGatheringPolicyGatherOnce;
+      return RTC_OBJC_TYPE(RTCContinualGatheringPolicyGatherOnce);
     case webrtc::PeerConnectionInterface::GATHER_CONTINUALLY:
-      return RTCContinualGatheringPolicyGatherContinually;
+      return RTC_OBJC_TYPE(RTCContinualGatheringPolicyGatherContinually);
   }
 }
 
 + (NSString *)stringForContinualGatheringPolicy:
-    (RTCContinualGatheringPolicy)policy {
+    (RTC_OBJC_TYPE(RTCContinualGatheringPolicy))policy {
   switch (policy) {
-    case RTCContinualGatheringPolicyGatherOnce:
+    case RTC_OBJC_TYPE(RTCContinualGatheringPolicyGatherOnce):
       return @"GATHER_ONCE";
-    case RTCContinualGatheringPolicyGatherContinually:
+    case RTC_OBJC_TYPE(RTCContinualGatheringPolicyGatherContinually):
       return @"GATHER_CONTINUALLY";
   }
 }
 
-+ (rtc::KeyType)nativeEncryptionKeyTypeForKeyType:
-    (RTCEncryptionKeyType)keyType {
++ (rtc::KeyType)nativeEncryptionKeyTypeForKeyType:(RTC_OBJC_TYPE(RTCEncryptionKeyType))keyType {
   switch (keyType) {
-    case RTCEncryptionKeyTypeRSA:
+    case RTC_OBJC_TYPE(RTCEncryptionKeyTypeRSA):
       return rtc::KT_RSA;
-    case RTCEncryptionKeyTypeECDSA:
+    case RTC_OBJC_TYPE(RTCEncryptionKeyTypeECDSA):
       return rtc::KT_ECDSA;
   }
 }
 
-+ (webrtc::SdpSemantics)nativeSdpSemanticsForSdpSemantics:(RTCSdpSemantics)sdpSemantics {
++ (webrtc::SdpSemantics)nativeSdpSemanticsForSdpSemantics:(RTC_OBJC_TYPE(RTCSdpSemantics))sdpSemantics {
   switch (sdpSemantics) {
-    case RTCSdpSemanticsPlanB:
+    case RTC_OBJC_TYPE(RTCSdpSemanticsPlanB):
       return webrtc::SdpSemantics::kPlanB_DEPRECATED;
-    case RTCSdpSemanticsUnifiedPlan:
+    case RTC_OBJC_TYPE(RTCSdpSemanticsUnifiedPlan):
       return webrtc::SdpSemantics::kUnifiedPlan;
   }
 }
 
-+ (RTCSdpSemantics)sdpSemanticsForNativeSdpSemantics:(webrtc::SdpSemantics)sdpSemantics {
++ (RTC_OBJC_TYPE(RTCSdpSemantics))sdpSemanticsForNativeSdpSemantics:(webrtc::SdpSemantics)sdpSemantics {
   switch (sdpSemantics) {
     case webrtc::SdpSemantics::kPlanB_DEPRECATED:
-      return RTCSdpSemanticsPlanB;
+      return RTC_OBJC_TYPE(RTCSdpSemanticsPlanB);
     case webrtc::SdpSemantics::kUnifiedPlan:
-      return RTCSdpSemanticsUnifiedPlan;
+      return RTC_OBJC_TYPE(RTCSdpSemanticsUnifiedPlan);
   }
 }
 
-+ (NSString *)stringForSdpSemantics:(RTCSdpSemantics)sdpSemantics {
++ (NSString *)stringForSdpSemantics:(RTC_OBJC_TYPE(RTCSdpSemantics))sdpSemantics {
   switch (sdpSemantics) {
-    case RTCSdpSemanticsPlanB:
+    case RTC_OBJC_TYPE(RTCSdpSemanticsPlanB):
       return @"PLAN_B";
-    case RTCSdpSemanticsUnifiedPlan:
+    case RTC_OBJC_TYPE(RTCSdpSemanticsUnifiedPlan):
       return @"UNIFIED_PLAN";
   }
 }

--- a/sdk/objc/api/peerconnection/RTCConfiguration.mm
+++ b/sdk/objc/api/peerconnection/RTCConfiguration.mm
@@ -355,10 +355,10 @@
   switch (policy) {
     case RTC_OBJC_TYPE(RTCBundlePolicyBalanced):
       return webrtc::PeerConnectionInterface::kBundlePolicyBalanced;
-    case RTC_OBJC_TYPE(RTCBundlePolicyMaxBundle):
-      return webrtc::PeerConnectionInterface::kBundlePolicyMaxBundle;
     case RTC_OBJC_TYPE(RTCBundlePolicyMaxCompat):
       return webrtc::PeerConnectionInterface::kBundlePolicyMaxCompat;
+    case RTC_OBJC_TYPE(RTCBundlePolicyMaxBundle):
+      return webrtc::PeerConnectionInterface::kBundlePolicyMaxBundle;
   }
 }
 
@@ -367,10 +367,10 @@
   switch (nativePolicy) {
     case webrtc::PeerConnectionInterface::kBundlePolicyBalanced:
       return RTC_OBJC_TYPE(RTCBundlePolicyBalanced);
-    case webrtc::PeerConnectionInterface::kBundlePolicyMaxBundle:
-      return RTC_OBJC_TYPE(RTCBundlePolicyMaxBundle);
     case webrtc::PeerConnectionInterface::kBundlePolicyMaxCompat:
       return RTC_OBJC_TYPE(RTCBundlePolicyMaxCompat);
+    case webrtc::PeerConnectionInterface::kBundlePolicyMaxBundle:
+      return RTC_OBJC_TYPE(RTCBundlePolicyMaxBundle);
   }
 }
 

--- a/sdk/objc/api/peerconnection/RTCDataChannel+Private.h
+++ b/sdk/objc/api/peerconnection/RTCDataChannel+Private.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RTC_OBJC_TYPE(RTCPeerConnectionFactory);
 
-@interface RTC_OBJC_TYPE (RTCDataBuffer)
+@interface RTC_OBJC_TYPE(RTCDataBuffer)
 ()
 
     /**
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface RTC_OBJC_TYPE (RTCDataChannel)
+@interface RTC_OBJC_TYPE(RTCDataChannel)
 ()
 
     /** Initialize an RTCDataChannel from a native DataChannelInterface. */
@@ -40,12 +40,12 @@ NS_ASSUME_NONNULL_BEGIN
     : (rtc::scoped_refptr<webrtc::DataChannelInterface>)nativeDataChannel NS_DESIGNATED_INITIALIZER;
 
 + (webrtc::DataChannelInterface::DataState)nativeDataChannelStateForState:
-    (RTCDataChannelState)state;
+    (RTC_OBJC_TYPE(RTCDataChannelState))state;
 
-+ (RTCDataChannelState)dataChannelStateForNativeState:
++ (RTC_OBJC_TYPE(RTCDataChannelState))dataChannelStateForNativeState:
     (webrtc::DataChannelInterface::DataState)nativeState;
 
-+ (NSString *)stringForState:(RTCDataChannelState)state;
++ (NSString *)stringForState:(RTC_OBJC_TYPE(RTCDataChannelState))state;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCDataChannel.h
+++ b/sdk/objc/api/peerconnection/RTCDataChannel.h
@@ -54,7 +54,7 @@ RTC_OBJC_EXPORT
 @end
 
 /** Represents the state of the data channel. */
-typedef NS_ENUM(NSInteger, RTCDataChannelState) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCDataChannelState)) {
   RTCDataChannelStateConnecting,
   RTCDataChannelStateOpen,
   RTCDataChannelStateClosing,
@@ -108,7 +108,7 @@ RTC_OBJC_EXPORT
 @property(nonatomic, readonly) int channelId;
 
 /** The state of the data channel. */
-@property(nonatomic, readonly) RTCDataChannelState readyState;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCDataChannelState) readyState;
 
 /**
  * The number of bytes of application data that have been queued using

--- a/sdk/objc/api/peerconnection/RTCDataChannel.h
+++ b/sdk/objc/api/peerconnection/RTCDataChannel.h
@@ -55,10 +55,10 @@ RTC_OBJC_EXPORT
 
 /** Represents the state of the data channel. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCDataChannelState)) {
-  RTCDataChannelStateConnecting,
-  RTCDataChannelStateOpen,
-  RTCDataChannelStateClosing,
-  RTCDataChannelStateClosed,
+  RTC_OBJC_TYPE(RTCDataChannelStateConnecting),
+  RTC_OBJC_TYPE(RTCDataChannelStateOpen),
+  RTC_OBJC_TYPE(RTCDataChannelStateClosing),
+  RTC_OBJC_TYPE(RTCDataChannelStateClosed),
 };
 
 RTC_OBJC_EXPORT

--- a/sdk/objc/api/peerconnection/RTCDataChannel.mm
+++ b/sdk/objc/api/peerconnection/RTCDataChannel.mm
@@ -137,7 +137,7 @@ class DataChannelDelegateAdapter : public DataChannelObserver {
   return _nativeDataChannel->id();
 }
 
-- (RTCDataChannelState)readyState {
+- (RTC_OBJC_TYPE(RTCDataChannelState))readyState {
   return [[self class] dataChannelStateForNativeState:
       _nativeDataChannel->state()];
 }
@@ -177,42 +177,42 @@ class DataChannelDelegateAdapter : public DataChannelObserver {
 }
 
 + (webrtc::DataChannelInterface::DataState)
-    nativeDataChannelStateForState:(RTCDataChannelState)state {
+    nativeDataChannelStateForState:(RTC_OBJC_TYPE(RTCDataChannelState))state {
   switch (state) {
-    case RTCDataChannelStateConnecting:
+    case RTC_OBJC_TYPE(RTCDataChannelStateConnecting):
       return webrtc::DataChannelInterface::DataState::kConnecting;
-    case RTCDataChannelStateOpen:
+    case RTC_OBJC_TYPE(RTCDataChannelStateOpen):
       return webrtc::DataChannelInterface::DataState::kOpen;
-    case RTCDataChannelStateClosing:
+    case RTC_OBJC_TYPE(RTCDataChannelStateClosing):
       return webrtc::DataChannelInterface::DataState::kClosing;
-    case RTCDataChannelStateClosed:
+    case RTC_OBJC_TYPE(RTCDataChannelStateClosed):
       return webrtc::DataChannelInterface::DataState::kClosed;
   }
 }
 
-+ (RTCDataChannelState)dataChannelStateForNativeState:
++ (RTC_OBJC_TYPE(RTCDataChannelState))dataChannelStateForNativeState:
     (webrtc::DataChannelInterface::DataState)nativeState {
   switch (nativeState) {
     case webrtc::DataChannelInterface::DataState::kConnecting:
-      return RTCDataChannelStateConnecting;
+      return RTC_OBJC_TYPE(RTCDataChannelStateConnecting);
     case webrtc::DataChannelInterface::DataState::kOpen:
-      return RTCDataChannelStateOpen;
+      return RTC_OBJC_TYPE(RTCDataChannelStateOpen);
     case webrtc::DataChannelInterface::DataState::kClosing:
-      return RTCDataChannelStateClosing;
+      return RTC_OBJC_TYPE(RTCDataChannelStateClosing);
     case webrtc::DataChannelInterface::DataState::kClosed:
-      return RTCDataChannelStateClosed;
+      return RTC_OBJC_TYPE(RTCDataChannelStateClosed);
   }
 }
 
-+ (NSString *)stringForState:(RTCDataChannelState)state {
++ (NSString *)stringForState:(RTC_OBJC_TYPE(RTCDataChannelState))state {
   switch (state) {
-    case RTCDataChannelStateConnecting:
+    case RTC_OBJC_TYPE(RTCDataChannelStateConnecting):
       return @"Connecting";
-    case RTCDataChannelStateOpen:
+    case RTC_OBJC_TYPE(RTCDataChannelStateOpen):
       return @"Open";
-    case RTCDataChannelStateClosing:
+    case RTC_OBJC_TYPE(RTCDataChannelStateClosing):
       return @"Closing";
-    case RTCDataChannelStateClosed:
+    case RTC_OBJC_TYPE(RTCDataChannelStateClosed):
       return @"Closed";
   }
 }

--- a/sdk/objc/api/peerconnection/RTCEncodedImage+Private.mm
+++ b/sdk/objc/api/peerconnection/RTCEncodedImage+Private.mm
@@ -89,12 +89,12 @@ class ObjCEncodedImageBuffer : public webrtc::EncodedImageBufferInterface {
     self.flags = encodedImage.timing_.flags;
     self.encodeStartMs = encodedImage.timing_.encode_start_ms;
     self.encodeFinishMs = encodedImage.timing_.encode_finish_ms;
-    self.frameType = static_cast<RTCFrameType>(encodedImage._frameType);
-    self.rotation = static_cast<RTCVideoRotation>(encodedImage.rotation_);
+    self.frameType = static_cast<RTC_OBJC_TYPE(RTCFrameType)>(encodedImage._frameType);
+    self.rotation = static_cast<RTC_OBJC_TYPE(RTCVideoRotation)>(encodedImage.rotation_);
     self.qp = @(encodedImage.qp_);
     self.contentType = (encodedImage.content_type_ == webrtc::VideoContentType::SCREENSHARE) ?
-        RTCVideoContentTypeScreenshare :
-        RTCVideoContentTypeUnspecified;
+        RTC_OBJC_TYPE(RTCVideoContentTypeScreenshare) :
+        RTC_OBJC_TYPE(RTCVideoContentTypeUnspecified);
   }
 
   return self;
@@ -120,7 +120,7 @@ class ObjCEncodedImageBuffer : public webrtc::EncodedImageBufferInterface {
   encodedImage._frameType = webrtc::VideoFrameType(self.frameType);
   encodedImage.rotation_ = webrtc::VideoRotation(self.rotation);
   encodedImage.qp_ = self.qp ? self.qp.intValue : -1;
-  encodedImage.content_type_ = (self.contentType == RTCVideoContentTypeScreenshare) ?
+  encodedImage.content_type_ = (self.contentType == RTC_OBJC_TYPE(RTCVideoContentTypeScreenshare)) ?
       webrtc::VideoContentType::SCREENSHARE :
       webrtc::VideoContentType::UNSPECIFIED;
 

--- a/sdk/objc/api/peerconnection/RTCFieldTrials.h
+++ b/sdk/objc/api/peerconnection/RTCFieldTrials.h
@@ -13,18 +13,18 @@
 #import "RTCMacros.h"
 
 /** The only valid value for the following if set is kRTCFieldTrialEnabledValue. */
-RTC_EXTERN NSString *const kRTCFieldTrialAudioForceABWENoTWCCKey;
-RTC_EXTERN NSString *const kRTCFieldTrialFlexFec03AdvertisedKey;
-RTC_EXTERN NSString *const kRTCFieldTrialFlexFec03Key;
-RTC_EXTERN NSString *const kRTCFieldTrialH264HighProfileKey;
-RTC_EXTERN NSString *const kRTCFieldTrialMinimizeResamplingOnMobileKey;
-RTC_EXTERN NSString *const kRTCFieldTrialUseNWPathMonitor;
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialAudioForceABWENoTWCCKey);
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialFlexFec03AdvertisedKey);
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialFlexFec03Key);
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialH264HighProfileKey);
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialMinimizeResamplingOnMobileKey);
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialUseNWPathMonitor);
 
 /** The valid value for field trials above. */
-RTC_EXTERN NSString *const kRTCFieldTrialEnabledValue;
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialEnabledValue);
 
 /** Initialize field trials using a dictionary mapping field trial keys to their
  * values. See above for valid keys and values. Must be called before any other
  * call into WebRTC. See: webrtc/system_wrappers/include/field_trial.h
  */
-RTC_EXTERN void RTCInitFieldTrialDictionary(NSDictionary<NSString *, NSString *> *fieldTrials);
+RTC_EXTERN void RTC_OBJC_TYPE(RTCInitFieldTrialDictionary)(NSDictionary<NSString *, NSString *> *fieldTrials);

--- a/sdk/objc/api/peerconnection/RTCFieldTrials.mm
+++ b/sdk/objc/api/peerconnection/RTCFieldTrials.mm
@@ -16,21 +16,21 @@
 
 #include "system_wrappers/include/field_trial.h"
 
-NSString *const kRTCFieldTrialAudioForceABWENoTWCCKey = @"WebRTC-Audio-ABWENoTWCC";
-NSString *const kRTCFieldTrialFlexFec03AdvertisedKey = @"WebRTC-FlexFEC-03-Advertised";
-NSString *const kRTCFieldTrialFlexFec03Key = @"WebRTC-FlexFEC-03";
-NSString *const kRTCFieldTrialH264HighProfileKey = @"WebRTC-H264HighProfile";
-NSString *const kRTCFieldTrialMinimizeResamplingOnMobileKey =
+NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialAudioForceABWENoTWCCKey) = @"WebRTC-Audio-ABWENoTWCC";
+NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialFlexFec03AdvertisedKey) = @"WebRTC-FlexFEC-03-Advertised";
+NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialFlexFec03Key) = @"WebRTC-FlexFEC-03";
+NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialH264HighProfileKey) = @"WebRTC-H264HighProfile";
+NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialMinimizeResamplingOnMobileKey) =
     @"WebRTC-Audio-MinimizeResamplingOnMobile";
-NSString *const kRTCFieldTrialUseNWPathMonitor = @"WebRTC-Network-UseNWPathMonitor";
-NSString *const kRTCFieldTrialEnabledValue = @"Enabled";
+NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialUseNWPathMonitor) = @"WebRTC-Network-UseNWPathMonitor";
+NSString *const RTC_CONSTANT_TYPE(RTCFieldTrialEnabledValue) = @"Enabled";
 
 // InitFieldTrialsFromString stores the char*, so the char array must outlive
 // the application.
 static char *gFieldTrialInitString = nullptr;
 static os_unfair_lock fieldTrialLock = OS_UNFAIR_LOCK_INIT;
 
-void RTCInitFieldTrialDictionary(NSDictionary<NSString *, NSString *> *fieldTrials) {
+void RTC_OBJC_TYPE(RTCInitFieldTrialDictionary)(NSDictionary<NSString *, NSString *> *fieldTrials) {
   if (!fieldTrials) {
     RTCLogWarning(@"No fieldTrials provided.");
     return;

--- a/sdk/objc/api/peerconnection/RTCFileLogger.h
+++ b/sdk/objc/api/peerconnection/RTCFileLogger.h
@@ -12,14 +12,14 @@
 
 #import "RTCMacros.h"
 
-typedef NS_ENUM(NSUInteger, RTCFileLoggerSeverity) {
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCFileLoggerSeverity)) {
   RTCFileLoggerSeverityVerbose,
   RTCFileLoggerSeverityInfo,
   RTCFileLoggerSeverityWarning,
   RTCFileLoggerSeverityError
 };
 
-typedef NS_ENUM(NSUInteger, RTCFileLoggerRotationType) {
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCFileLoggerRotationType)) {
   RTCFileLoggerTypeCall,
   RTCFileLoggerTypeApp,
 };
@@ -37,11 +37,11 @@ RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCFileLogger) : NSObject
 
 // The severity level to capture. The default is kRTCFileLoggerSeverityInfo.
-@property(nonatomic, assign) RTCFileLoggerSeverity severity;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCFileLoggerSeverity) severity;
 
 // The rotation type for this file logger. The default is
 // kRTCFileLoggerTypeCall.
-@property(nonatomic, readonly) RTCFileLoggerRotationType rotationType;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCFileLoggerRotationType) rotationType;
 
 // Disables buffering disk writes. Should be set before `start`. Buffering
 // is enabled by default for performance.
@@ -56,7 +56,7 @@ RTC_OBJC_EXPORT
 
 - (instancetype)initWithDirPath:(NSString *)dirPath
                     maxFileSize:(NSUInteger)maxFileSize
-                   rotationType:(RTCFileLoggerRotationType)rotationType NS_DESIGNATED_INITIALIZER;
+                   rotationType:(RTC_OBJC_TYPE(RTCFileLoggerRotationType))rotationType NS_DESIGNATED_INITIALIZER;
 
 // Starts writing WebRTC logs to disk if not already started. Overwrites any
 // existing file(s).

--- a/sdk/objc/api/peerconnection/RTCFileLogger.h
+++ b/sdk/objc/api/peerconnection/RTCFileLogger.h
@@ -13,15 +13,15 @@
 #import "RTCMacros.h"
 
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCFileLoggerSeverity)) {
-  RTCFileLoggerSeverityVerbose,
-  RTCFileLoggerSeverityInfo,
-  RTCFileLoggerSeverityWarning,
-  RTCFileLoggerSeverityError
+  RTC_OBJC_TYPE(RTCFileLoggerSeverityVerbose),
+  RTC_OBJC_TYPE(RTCFileLoggerSeverityInfo),
+  RTC_OBJC_TYPE(RTCFileLoggerSeverityWarning),
+  RTC_OBJC_TYPE(RTCFileLoggerSeverityError)
 };
 
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCFileLoggerRotationType)) {
-  RTCFileLoggerTypeCall,
-  RTCFileLoggerTypeApp,
+  RTC_OBJC_TYPE(RTCFileLoggerTypeCall),
+  RTC_OBJC_TYPE(RTCFileLoggerTypeApp),
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/sdk/objc/api/peerconnection/RTCFileLogger.mm
+++ b/sdk/objc/api/peerconnection/RTCFileLogger.mm
@@ -46,12 +46,12 @@ const char *kRTCFileLoggerRotatingLogPrefix = "rotating_log";
                     maxFileSize:(NSUInteger)maxFileSize {
   return [self initWithDirPath:dirPath
                    maxFileSize:maxFileSize
-                  rotationType:RTCFileLoggerTypeCall];
+                  rotationType:RTC_OBJC_TYPE(RTCFileLoggerTypeCall)];
 }
 
 - (instancetype)initWithDirPath:(NSString *)dirPath
                     maxFileSize:(NSUInteger)maxFileSize
-                   rotationType:(RTCFileLoggerRotationType)rotationType {
+                   rotationType:(RTC_OBJC_TYPE(RTCFileLoggerRotationType))rotationType {
   NSParameterAssert(dirPath.length);
   NSParameterAssert(maxFileSize);
   if (self = [super init]) {
@@ -73,7 +73,7 @@ const char *kRTCFileLoggerRotatingLogPrefix = "rotating_log";
     }
     _dirPath = dirPath;
     _maxFileSize = maxFileSize;
-    _severity = RTCFileLoggerSeverityInfo;
+    _severity = RTC_OBJC_TYPE(RTCFileLoggerSeverityInfo);
   }
   return self;
 }
@@ -87,14 +87,14 @@ const char *kRTCFileLoggerRotatingLogPrefix = "rotating_log";
     return;
   }
   switch (_rotationType) {
-    case RTCFileLoggerTypeApp:
+    case RTC_OBJC_TYPE(RTCFileLoggerTypeApp):
       _logSink.reset(
           new rtc::FileRotatingLogSink(_dirPath.UTF8String,
                                        kRTCFileLoggerRotatingLogPrefix,
                                        _maxFileSize,
                                        _maxFileSize / 10));
       break;
-    case RTCFileLoggerTypeCall:
+    case RTC_OBJC_TYPE(RTCFileLoggerTypeCall):
       _logSink.reset(
           new rtc::CallSessionFileRotatingLogSink(_dirPath.UTF8String,
                                                   _maxFileSize));
@@ -131,11 +131,11 @@ const char *kRTCFileLoggerRotatingLogPrefix = "rotating_log";
   NSMutableData* logData = [NSMutableData data];
   std::unique_ptr<rtc::FileRotatingStreamReader> stream;
   switch(_rotationType) {
-    case RTCFileLoggerTypeApp:
+    case RTC_OBJC_TYPE(RTCFileLoggerTypeApp):
       stream = std::make_unique<rtc::FileRotatingStreamReader>(_dirPath.UTF8String,
                                                                kRTCFileLoggerRotatingLogPrefix);
       break;
-    case RTCFileLoggerTypeCall:
+    case RTC_OBJC_TYPE(RTCFileLoggerTypeCall):
       stream = std::make_unique<rtc::CallSessionFileRotatingStreamReader>(_dirPath.UTF8String);
       break;
   }
@@ -156,13 +156,13 @@ const char *kRTCFileLoggerRotatingLogPrefix = "rotating_log";
 
 - (rtc::LoggingSeverity)rtcSeverity {
   switch (_severity) {
-    case RTCFileLoggerSeverityVerbose:
+    case RTC_OBJC_TYPE(RTCFileLoggerSeverityVerbose):
       return rtc::LS_VERBOSE;
-    case RTCFileLoggerSeverityInfo:
+    case RTC_OBJC_TYPE(RTCFileLoggerSeverityInfo):
       return rtc::LS_INFO;
-    case RTCFileLoggerSeverityWarning:
+    case RTC_OBJC_TYPE(RTCFileLoggerSeverityWarning):
       return rtc::LS_WARNING;
-    case RTCFileLoggerSeverityError:
+    case RTC_OBJC_TYPE(RTCFileLoggerSeverityError):
       return rtc::LS_ERROR;
   }
 }

--- a/sdk/objc/api/peerconnection/RTCFileLogger.mm
+++ b/sdk/objc/api/peerconnection/RTCFileLogger.mm
@@ -19,7 +19,7 @@
 
 NSString *const kDefaultLogDirName = @"webrtc_logs";
 NSUInteger const kDefaultMaxFileSize = 10 * 1024 * 1024; // 10MB.
-const char *kRTCFileLoggerRotatingLogPrefix = "rotating_log";
+const char * RTC_CONSTANT_TYPE(RTCFileLoggerRotatingLogPrefix) = "rotating_log";
 
 @implementation RTC_OBJC_TYPE (RTCFileLogger) {
   BOOL _hasStarted;
@@ -90,7 +90,7 @@ const char *kRTCFileLoggerRotatingLogPrefix = "rotating_log";
     case RTC_OBJC_TYPE(RTCFileLoggerTypeApp):
       _logSink.reset(
           new rtc::FileRotatingLogSink(_dirPath.UTF8String,
-                                       kRTCFileLoggerRotatingLogPrefix,
+                                       RTC_CONSTANT_TYPE(RTCFileLoggerRotatingLogPrefix),
                                        _maxFileSize,
                                        _maxFileSize / 10));
       break;
@@ -133,7 +133,7 @@ const char *kRTCFileLoggerRotatingLogPrefix = "rotating_log";
   switch(_rotationType) {
     case RTC_OBJC_TYPE(RTCFileLoggerTypeApp):
       stream = std::make_unique<rtc::FileRotatingStreamReader>(_dirPath.UTF8String,
-                                                               kRTCFileLoggerRotatingLogPrefix);
+                                                               RTC_CONSTANT_TYPE(RTCFileLoggerRotatingLogPrefix));
       break;
     case RTC_OBJC_TYPE(RTCFileLoggerTypeCall):
       stream = std::make_unique<rtc::CallSessionFileRotatingStreamReader>(_dirPath.UTF8String);

--- a/sdk/objc/api/peerconnection/RTCFrameCryptor.h
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptor.h
@@ -26,11 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 @class RTC_OBJC_TYPE(RTCFrameCryptor);
 @class RTC_OBJC_TYPE(RTCPeerConnectionFactory);
 
-typedef NS_ENUM(NSUInteger, RTCCryptorAlgorithm) {
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCCryptorAlgorithm)) {
   RTCCryptorAlgorithmAesGcm = 0,
 };
 
-typedef NS_ENUM(NSInteger, FrameCryptionState) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(FrameCryptionState)) {
   FrameCryptionStateNew = 0,
   FrameCryptionStateOk,
   FrameCryptionStateEncryptionFailed,
@@ -46,7 +46,7 @@ RTC_OBJC_EXPORT
     /** Called when the RTCFrameCryptor got errors. */
     - (void)frameCryptor
     : (RTC_OBJC_TYPE(RTCFrameCryptor) *)frameCryptor didStateChangeWithParticipantId
-    : (NSString *)participantId withState : (FrameCryptionState)stateChanged;
+    : (NSString *)participantId withState : (RTC_OBJC_TYPE(FrameCryptionState))stateChanged;
 @end
 
 RTC_OBJC_EXPORT
@@ -63,13 +63,13 @@ RTC_OBJC_EXPORT
 - (nullable instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
                                rtpSender:(RTC_OBJC_TYPE(RTCRtpSender) *)sender
                            participantId:(NSString *)participantId
-                               algorithm:(RTCCryptorAlgorithm)algorithm
+                               algorithm:(RTC_OBJC_TYPE(RTCCryptorAlgorithm))algorithm
                              keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider;
 
 - (nullable instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
                              rtpReceiver:(RTC_OBJC_TYPE(RTCRtpReceiver) *)receiver
                            participantId:(NSString *)participantId
-                               algorithm:(RTCCryptorAlgorithm)algorithm
+                               algorithm:(RTC_OBJC_TYPE(RTCCryptorAlgorithm))algorithm
                              keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider;
 
 @end

--- a/sdk/objc/api/peerconnection/RTCFrameCryptor.h
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptor.h
@@ -27,17 +27,17 @@ NS_ASSUME_NONNULL_BEGIN
 @class RTC_OBJC_TYPE(RTCPeerConnectionFactory);
 
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCCryptorAlgorithm)) {
-  RTCCryptorAlgorithmAesGcm = 0,
+  RTC_OBJC_TYPE(RTCCryptorAlgorithmAesGcm) = 0,
 };
 
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(FrameCryptionState)) {
-  FrameCryptionStateNew = 0,
-  FrameCryptionStateOk,
-  FrameCryptionStateEncryptionFailed,
-  FrameCryptionStateDecryptionFailed,
-  FrameCryptionStateMissingKey,
-  FrameCryptionStateKeyRatcheted,
-  FrameCryptionStateInternalError,
+  RTC_OBJC_TYPE(FrameCryptionStateNew) = 0,
+  RTC_OBJC_TYPE(FrameCryptionStateOk),
+  RTC_OBJC_TYPE(FrameCryptionStateEncryptionFailed),
+  RTC_OBJC_TYPE(FrameCryptionStateDecryptionFailed),
+  RTC_OBJC_TYPE(FrameCryptionStateMissingKey),
+  RTC_OBJC_TYPE(FrameCryptionStateKeyRatcheted),
+  RTC_OBJC_TYPE(FrameCryptionStateInternalError),
 };
 
 RTC_OBJC_EXPORT

--- a/sdk/objc/api/peerconnection/RTCFrameCryptor.h
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptor.h
@@ -30,14 +30,14 @@ typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCCryptorAlgorithm)) {
   RTC_OBJC_TYPE(RTCCryptorAlgorithmAesGcm) = 0,
 };
 
-typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(FrameCryptionState)) {
-  RTC_OBJC_TYPE(FrameCryptionStateNew) = 0,
-  RTC_OBJC_TYPE(FrameCryptionStateOk),
-  RTC_OBJC_TYPE(FrameCryptionStateEncryptionFailed),
-  RTC_OBJC_TYPE(FrameCryptionStateDecryptionFailed),
-  RTC_OBJC_TYPE(FrameCryptionStateMissingKey),
-  RTC_OBJC_TYPE(FrameCryptionStateKeyRatcheted),
-  RTC_OBJC_TYPE(FrameCryptionStateInternalError),
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCFrameCryptorState)) {
+  RTC_OBJC_TYPE(RTCFrameCryptorStateNew) = 0,
+  RTC_OBJC_TYPE(RTCFrameCryptorStateOk),
+  RTC_OBJC_TYPE(RTCFrameCryptorStateEncryptionFailed),
+  RTC_OBJC_TYPE(RTCFrameCryptorStateDecryptionFailed),
+  RTC_OBJC_TYPE(RTCFrameCryptorStateMissingKey),
+  RTC_OBJC_TYPE(RTCFrameCryptorStateKeyRatcheted),
+  RTC_OBJC_TYPE(RTCFrameCryptorStateInternalError),
 };
 
 RTC_OBJC_EXPORT
@@ -46,7 +46,7 @@ RTC_OBJC_EXPORT
     /** Called when the RTCFrameCryptor got errors. */
     - (void)frameCryptor
     : (RTC_OBJC_TYPE(RTCFrameCryptor) *)frameCryptor didStateChangeWithParticipantId
-    : (NSString *)participantId withState : (RTC_OBJC_TYPE(FrameCryptionState))stateChanged;
+    : (NSString *)participantId withState : (RTC_OBJC_TYPE(RTCFrameCryptorState))stateChanged;
 @end
 
 RTC_OBJC_EXPORT

--- a/sdk/objc/api/peerconnection/RTCFrameCryptor.mm
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptor.mm
@@ -54,37 +54,37 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
       case FrameCryptionState::kNew:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(FrameCryptionStateNew)];
+                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateNew)];
         break;
       case FrameCryptionState::kOk:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(FrameCryptionStateOk)];
+                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateOk)];
         break;
       case FrameCryptionState::kEncryptionFailed:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(FrameCryptionStateEncryptionFailed)];
+                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateEncryptionFailed)];
         break;
       case FrameCryptionState::kDecryptionFailed:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(FrameCryptionStateDecryptionFailed)];
+                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateDecryptionFailed)];
         break;
       case FrameCryptionState::kMissingKey:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(FrameCryptionStateMissingKey)];
+                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateMissingKey)];
         break;
       case FrameCryptionState::kKeyRatcheted:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(FrameCryptionStateKeyRatcheted)];
+                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateKeyRatcheted)];
         break;
       case FrameCryptionState::kInternalError:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(FrameCryptionStateInternalError)];
+                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateInternalError)];
         break;
     }
   }

--- a/sdk/objc/api/peerconnection/RTCFrameCryptor.mm
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptor.mm
@@ -54,37 +54,37 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
       case FrameCryptionState::kNew:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:FrameCryptionStateNew];
+                                  withState:RTC_OBJC_TYPE(FrameCryptionStateNew)];
         break;
       case FrameCryptionState::kOk:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:FrameCryptionStateOk];
+                                  withState:RTC_OBJC_TYPE(FrameCryptionStateOk)];
         break;
       case FrameCryptionState::kEncryptionFailed:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:FrameCryptionStateEncryptionFailed];
+                                  withState:RTC_OBJC_TYPE(FrameCryptionStateEncryptionFailed)];
         break;
       case FrameCryptionState::kDecryptionFailed:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:FrameCryptionStateDecryptionFailed];
+                                  withState:RTC_OBJC_TYPE(FrameCryptionStateDecryptionFailed)];
         break;
       case FrameCryptionState::kMissingKey:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:FrameCryptionStateMissingKey];
+                                  withState:RTC_OBJC_TYPE(FrameCryptionStateMissingKey)];
         break;
       case FrameCryptionState::kKeyRatcheted:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:FrameCryptionStateKeyRatcheted];
+                                  withState:RTC_OBJC_TYPE(FrameCryptionStateKeyRatcheted)];
         break;
       case FrameCryptionState::kInternalError:
         [frameCryptor.delegate frameCryptor:frameCryptor
             didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:FrameCryptionStateInternalError];
+                                  withState:RTC_OBJC_TYPE(FrameCryptionStateInternalError)];
         break;
     }
   }
@@ -102,9 +102,9 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
 @synthesize participantId = _participantId;
 @synthesize delegate = _delegate;
 
-- (webrtc::FrameCryptorTransformer::Algorithm)algorithmFromEnum:(RTCCryptorAlgorithm)algorithm {
+- (webrtc::FrameCryptorTransformer::Algorithm)algorithmFromEnum:(RTC_OBJC_TYPE(RTCCryptorAlgorithm))algorithm {
   switch (algorithm) {
-    case RTCCryptorAlgorithmAesGcm:
+    case RTC_OBJC_TYPE(RTCCryptorAlgorithmAesGcm):
       return webrtc::FrameCryptorTransformer::Algorithm::kAesGcm;
     default:
       return webrtc::FrameCryptorTransformer::Algorithm::kAesGcm;
@@ -114,7 +114,7 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
 - (nullable instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
                                rtpSender:(RTC_OBJC_TYPE(RTCRtpSender) *)sender
                            participantId:(NSString *)participantId
-                               algorithm:(RTCCryptorAlgorithm)algorithm
+                               algorithm:(RTC_OBJC_TYPE(RTCCryptorAlgorithm))algorithm
                              keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider {
   if (self = [super init]) {
     _lock = OS_UNFAIR_LOCK_INIT;
@@ -154,7 +154,7 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
 - (nullable instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
                              rtpReceiver:(RTC_OBJC_TYPE(RTCRtpReceiver) *)receiver
                            participantId:(NSString *)participantId
-                               algorithm:(RTCCryptorAlgorithm)algorithm
+                               algorithm:(RTC_OBJC_TYPE(RTCCryptorAlgorithm))algorithm
                              keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider {
   if (self = [super init]) {
     _lock = OS_UNFAIR_LOCK_INIT;

--- a/sdk/objc/api/peerconnection/RTCIODevice+Private.h
+++ b/sdk/objc/api/peerconnection/RTCIODevice+Private.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RTC_OBJC_TYPE(RTCIODevice) ()
 
-- (instancetype)initWithType:(RTCIODeviceType)type
+- (instancetype)initWithType:(RTC_OBJC_TYPE(RTCIODeviceType))type
                     deviceId:(NSString *)deviceId
                         name:(NSString* )name;
 

--- a/sdk/objc/api/peerconnection/RTCIODevice.h
+++ b/sdk/objc/api/peerconnection/RTCIODevice.h
@@ -20,7 +20,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSInteger, RTCIODeviceType) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCIODeviceType)) {
   RTCIODeviceTypeOutput,
   RTCIODeviceTypeInput,
 };
@@ -28,11 +28,11 @@ typedef NS_ENUM(NSInteger, RTCIODeviceType) {
 RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE(RTCIODevice) : NSObject
 
-+ (instancetype)defaultDeviceWithType: (RTCIODeviceType)type;
++ (instancetype)defaultDeviceWithType: (RTC_OBJC_TYPE(RTCIODeviceType))type;
 - (instancetype)init NS_UNAVAILABLE;
 
 @property(nonatomic, readonly) BOOL isDefault;
-@property(nonatomic, readonly) RTCIODeviceType type;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCIODeviceType) type;
 @property(nonatomic, copy, readonly) NSString *deviceId;
 @property(nonatomic, copy, readonly) NSString *name;
 

--- a/sdk/objc/api/peerconnection/RTCIODevice.h
+++ b/sdk/objc/api/peerconnection/RTCIODevice.h
@@ -21,8 +21,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCIODeviceType)) {
-  RTCIODeviceTypeOutput,
-  RTCIODeviceTypeInput,
+  RTC_OBJC_TYPE(RTCIODeviceTypeOutput),
+  RTC_OBJC_TYPE(RTCIODeviceTypeInput),
 };
 
 RTC_OBJC_EXPORT

--- a/sdk/objc/api/peerconnection/RTCIODevice.mm
+++ b/sdk/objc/api/peerconnection/RTCIODevice.mm
@@ -25,13 +25,13 @@ NSString *const kDefaultDeviceId = @"default";
 @synthesize deviceId = _deviceId;
 @synthesize name = _name;
 
-+ (instancetype)defaultDeviceWithType: (RTCIODeviceType)type {
++ (instancetype)defaultDeviceWithType: (RTC_OBJC_TYPE(RTCIODeviceType))type {
   return [[self alloc] initWithType: type 
                            deviceId: kDefaultDeviceId
                                name: @""];
 }
 
-- (instancetype)initWithType: (RTCIODeviceType)type
+- (instancetype)initWithType: (RTC_OBJC_TYPE(RTCIODeviceType))type
                     deviceId: (NSString *)deviceId
                         name: (NSString* )name {
   if (self = [super init]) {

--- a/sdk/objc/api/peerconnection/RTCIceServer.h
+++ b/sdk/objc/api/peerconnection/RTCIceServer.h
@@ -12,7 +12,7 @@
 
 #import "RTCMacros.h"
 
-typedef NS_ENUM(NSUInteger, RTCTlsCertPolicy) {
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCTlsCertPolicy)) {
   RTCTlsCertPolicySecure,
   RTCTlsCertPolicyInsecureNoCheck
 };
@@ -34,7 +34,7 @@ RTC_OBJC_EXPORT
 /**
  * TLS certificate policy to use if this RTCIceServer object is a TURN server.
  */
-@property(nonatomic, readonly) RTCTlsCertPolicy tlsCertPolicy;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCTlsCertPolicy) tlsCertPolicy;
 
 /**
   If the URIs in `urls` only contain IP addresses, this field can be used
@@ -72,7 +72,7 @@ RTC_OBJC_EXPORT
 - (instancetype)initWithURLStrings:(NSArray<NSString *> *)urlStrings
                           username:(nullable NSString *)username
                         credential:(nullable NSString *)credential
-                     tlsCertPolicy:(RTCTlsCertPolicy)tlsCertPolicy;
+                     tlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy;
 
 /**
  * Initialize an RTCIceServer with its associated URLs, optional username,
@@ -81,7 +81,7 @@ RTC_OBJC_EXPORT
 - (instancetype)initWithURLStrings:(NSArray<NSString *> *)urlStrings
                           username:(nullable NSString *)username
                         credential:(nullable NSString *)credential
-                     tlsCertPolicy:(RTCTlsCertPolicy)tlsCertPolicy
+                     tlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy
                           hostname:(nullable NSString *)hostname;
 
 /**
@@ -91,7 +91,7 @@ RTC_OBJC_EXPORT
 - (instancetype)initWithURLStrings:(NSArray<NSString *> *)urlStrings
                           username:(nullable NSString *)username
                         credential:(nullable NSString *)credential
-                     tlsCertPolicy:(RTCTlsCertPolicy)tlsCertPolicy
+                     tlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy
                           hostname:(nullable NSString *)hostname
                   tlsAlpnProtocols:(NSArray<NSString *> *)tlsAlpnProtocols;
 
@@ -103,7 +103,7 @@ RTC_OBJC_EXPORT
 - (instancetype)initWithURLStrings:(NSArray<NSString *> *)urlStrings
                           username:(nullable NSString *)username
                         credential:(nullable NSString *)credential
-                     tlsCertPolicy:(RTCTlsCertPolicy)tlsCertPolicy
+                     tlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy
                           hostname:(nullable NSString *)hostname
                   tlsAlpnProtocols:(nullable NSArray<NSString *> *)tlsAlpnProtocols
                  tlsEllipticCurves:(nullable NSArray<NSString *> *)tlsEllipticCurves

--- a/sdk/objc/api/peerconnection/RTCIceServer.h
+++ b/sdk/objc/api/peerconnection/RTCIceServer.h
@@ -13,8 +13,8 @@
 #import "RTCMacros.h"
 
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCTlsCertPolicy)) {
-  RTCTlsCertPolicySecure,
-  RTCTlsCertPolicyInsecureNoCheck
+  RTC_OBJC_TYPE(RTCTlsCertPolicySecure),
+  RTC_OBJC_TYPE(RTCTlsCertPolicyInsecureNoCheck)
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/sdk/objc/api/peerconnection/RTCIceServer.mm
+++ b/sdk/objc/api/peerconnection/RTCIceServer.mm
@@ -52,7 +52,7 @@
                           username:(NSString *)username
                         credential:(NSString *)credential
                      tlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy
-                         hostname:(NSString *)hostname {
+                          hostname:(NSString *)hostname {
   return [self initWithURLStrings:urlStrings
                          username:username
                        credential:credential
@@ -67,7 +67,6 @@
                      tlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy
                           hostname:(NSString *)hostname
                   tlsAlpnProtocols:(NSArray<NSString *> *)tlsAlpnProtocols {
-
   return [self initWithURLStrings:urlStrings
                          username:username
                        credential:credential
@@ -84,7 +83,6 @@
                           hostname:(NSString *)hostname
                   tlsAlpnProtocols:(NSArray<NSString *> *)tlsAlpnProtocols
                  tlsEllipticCurves:(NSArray<NSString *> *)tlsEllipticCurves {
-
   NSParameterAssert(urlStrings.count);
   if (self = [super init]) {
     _urlStrings = [[NSArray alloc] initWithArray:urlStrings copyItems:YES];
@@ -114,9 +112,9 @@
 - (NSString *)stringForTlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy {
   switch (tlsCertPolicy) {
     case RTC_OBJC_TYPE(RTCTlsCertPolicySecure):
-      return @"TLS Secure Policy";
+      return @"RTCTlsCertPolicySecure";
     case RTC_OBJC_TYPE(RTCTlsCertPolicyInsecureNoCheck):
-      return @"TLS Insecure No Check Policy";
+      return @"RTCTlsCertPolicyInsecureNoCheck";
   }
 }
 

--- a/sdk/objc/api/peerconnection/RTCIceServer.mm
+++ b/sdk/objc/api/peerconnection/RTCIceServer.mm
@@ -12,7 +12,7 @@
 
 #import "helpers/NSString+StdString.h"
 
-@implementation RTC_OBJC_TYPE (RTCIceServer)
+@implementation RTC_OBJC_TYPE(RTCIceServer)
 
 @synthesize urlStrings = _urlStrings;
 @synthesize username = _username;
@@ -34,13 +34,13 @@
   return [self initWithURLStrings:urlStrings
                          username:username
                        credential:credential
-                    tlsCertPolicy:RTCTlsCertPolicySecure];
+                    tlsCertPolicy:RTC_OBJC_TYPE(RTCTlsCertPolicySecure)];
 }
 
 - (instancetype)initWithURLStrings:(NSArray<NSString *> *)urlStrings
                           username:(NSString *)username
                         credential:(NSString *)credential
-                     tlsCertPolicy:(RTCTlsCertPolicy)tlsCertPolicy {
+                     tlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy {
   return [self initWithURLStrings:urlStrings
                          username:username
                        credential:credential
@@ -51,8 +51,8 @@
 - (instancetype)initWithURLStrings:(NSArray<NSString *> *)urlStrings
                           username:(NSString *)username
                         credential:(NSString *)credential
-                     tlsCertPolicy:(RTCTlsCertPolicy)tlsCertPolicy
-                          hostname:(NSString *)hostname {
+                     tlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy
+                         hostname:(NSString *)hostname {
   return [self initWithURLStrings:urlStrings
                          username:username
                        credential:credential
@@ -64,9 +64,10 @@
 - (instancetype)initWithURLStrings:(NSArray<NSString *> *)urlStrings
                           username:(NSString *)username
                         credential:(NSString *)credential
-                     tlsCertPolicy:(RTCTlsCertPolicy)tlsCertPolicy
+                     tlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy
                           hostname:(NSString *)hostname
                   tlsAlpnProtocols:(NSArray<NSString *> *)tlsAlpnProtocols {
+
   return [self initWithURLStrings:urlStrings
                          username:username
                        credential:credential
@@ -79,10 +80,11 @@
 - (instancetype)initWithURLStrings:(NSArray<NSString *> *)urlStrings
                           username:(NSString *)username
                         credential:(NSString *)credential
-                     tlsCertPolicy:(RTCTlsCertPolicy)tlsCertPolicy
+                     tlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy 
                           hostname:(NSString *)hostname
                   tlsAlpnProtocols:(NSArray<NSString *> *)tlsAlpnProtocols
                  tlsEllipticCurves:(NSArray<NSString *> *)tlsEllipticCurves {
+
   NSParameterAssert(urlStrings.count);
   if (self = [super init]) {
     _urlStrings = [[NSArray alloc] initWithArray:urlStrings copyItems:YES];
@@ -109,12 +111,12 @@
 
 #pragma mark - Private
 
-- (NSString *)stringForTlsCertPolicy:(RTCTlsCertPolicy)tlsCertPolicy {
+- (NSString *)stringForTlsCertPolicy:(RTC_OBJC_TYPE(RTCTlsCertPolicy))tlsCertPolicy {
   switch (tlsCertPolicy) {
-    case RTCTlsCertPolicySecure:
-      return @"RTCTlsCertPolicySecure";
-    case RTCTlsCertPolicyInsecureNoCheck:
-      return @"RTCTlsCertPolicyInsecureNoCheck";
+    case RTC_OBJC_TYPE(RTCTlsCertPolicySecure):
+      return @"TLS Secure Policy";
+    case RTC_OBJC_TYPE(RTCTlsCertPolicyInsecureNoCheck):
+      return @"TLS Insecure No Check Policy";
   }
 }
 
@@ -140,11 +142,11 @@
   }];
 
   switch (_tlsCertPolicy) {
-    case RTCTlsCertPolicySecure:
+    case RTC_OBJC_TYPE(RTCTlsCertPolicySecure):
       iceServer.tls_cert_policy =
           webrtc::PeerConnectionInterface::kTlsCertPolicySecure;
       break;
-    case RTCTlsCertPolicyInsecureNoCheck:
+    case RTC_OBJC_TYPE(RTCTlsCertPolicyInsecureNoCheck):
       iceServer.tls_cert_policy =
           webrtc::PeerConnectionInterface::kTlsCertPolicyInsecureNoCheck;
       break;
@@ -172,14 +174,14 @@
   for (auto const &curve : nativeServer.tls_elliptic_curves) {
     [tlsEllipticCurves addObject:[NSString stringForStdString:curve]];
   }
-  RTCTlsCertPolicy tlsCertPolicy;
+  RTC_OBJC_TYPE(RTCTlsCertPolicy) tlsCertPolicy;
 
   switch (nativeServer.tls_cert_policy) {
     case webrtc::PeerConnectionInterface::kTlsCertPolicySecure:
-      tlsCertPolicy = RTCTlsCertPolicySecure;
+      tlsCertPolicy = RTC_OBJC_TYPE(RTCTlsCertPolicySecure);
       break;
     case webrtc::PeerConnectionInterface::kTlsCertPolicyInsecureNoCheck:
-      tlsCertPolicy = RTCTlsCertPolicyInsecureNoCheck;
+      tlsCertPolicy = RTC_OBJC_TYPE(RTCTlsCertPolicyInsecureNoCheck);
       break;
   }
 

--- a/sdk/objc/api/peerconnection/RTCMediaConstraints.h
+++ b/sdk/objc/api/peerconnection/RTCMediaConstraints.h
@@ -18,17 +18,17 @@ NS_ASSUME_NONNULL_BEGIN
 /** The value for this key should be a base64 encoded string containing
  *  the data from the serialized configuration proto.
  */
-RTC_EXTERN NSString *const kRTCMediaConstraintsAudioNetworkAdaptorConfig;
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsAudioNetworkAdaptorConfig);
 
 /** Constraint keys for generating offers and answers. */
-RTC_EXTERN NSString *const kRTCMediaConstraintsIceRestart;
-RTC_EXTERN NSString *const kRTCMediaConstraintsOfferToReceiveAudio;
-RTC_EXTERN NSString *const kRTCMediaConstraintsOfferToReceiveVideo;
-RTC_EXTERN NSString *const kRTCMediaConstraintsVoiceActivityDetection;
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsIceRestart);
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsOfferToReceiveAudio);
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsOfferToReceiveVideo);
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsVoiceActivityDetection);
 
 /** Constraint values for Boolean parameters. */
-RTC_EXTERN NSString *const kRTCMediaConstraintsValueTrue;
-RTC_EXTERN NSString *const kRTCMediaConstraintsValueFalse;
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsValueTrue);
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsValueFalse);
 
 RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCMediaConstraints) : NSObject

--- a/sdk/objc/api/peerconnection/RTCMediaConstraints.mm
+++ b/sdk/objc/api/peerconnection/RTCMediaConstraints.mm
@@ -14,19 +14,19 @@
 
 #include <memory>
 
-NSString *const kRTCMediaConstraintsAudioNetworkAdaptorConfig =
+NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsAudioNetworkAdaptorConfig) =
     @(webrtc::MediaConstraints::kAudioNetworkAdaptorConfig);
 
-NSString *const kRTCMediaConstraintsIceRestart = @(webrtc::MediaConstraints::kIceRestart);
-NSString *const kRTCMediaConstraintsOfferToReceiveAudio =
+NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsIceRestart) = @(webrtc::MediaConstraints::kIceRestart);
+NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsOfferToReceiveAudio) =
     @(webrtc::MediaConstraints::kOfferToReceiveAudio);
-NSString *const kRTCMediaConstraintsOfferToReceiveVideo =
+NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsOfferToReceiveVideo) =
     @(webrtc::MediaConstraints::kOfferToReceiveVideo);
-NSString *const kRTCMediaConstraintsVoiceActivityDetection =
+NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsVoiceActivityDetection) =
     @(webrtc::MediaConstraints::kVoiceActivityDetection);
 
-NSString *const kRTCMediaConstraintsValueTrue = @(webrtc::MediaConstraints::kValueTrue);
-NSString *const kRTCMediaConstraintsValueFalse = @(webrtc::MediaConstraints::kValueFalse);
+NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsValueTrue) = @(webrtc::MediaConstraints::kValueTrue);
+NSString *const RTC_CONSTANT_TYPE(RTCMediaConstraintsValueFalse) = @(webrtc::MediaConstraints::kValueFalse);
 
 @implementation RTC_OBJC_TYPE (RTCMediaConstraints) {
   NSDictionary<NSString *, NSString *> *_mandatory;
@@ -73,7 +73,7 @@ NSString *const kRTCMediaConstraintsValueFalse = @(webrtc::MediaConstraints::kVa
     NSString *value = [constraints objectForKey:key];
     NSAssert([value isKindOfClass:[NSString class]],
              @"%@ is not an NSString.", value);
-    if ([kRTCMediaConstraintsAudioNetworkAdaptorConfig isEqualToString:key]) {
+    if ([RTC_CONSTANT_TYPE(RTCMediaConstraintsAudioNetworkAdaptorConfig) isEqualToString:key]) {
       // This value is base64 encoded.
       NSData *charData = [[NSData alloc] initWithBase64EncodedString:value options:0];
       std::string configValue =

--- a/sdk/objc/api/peerconnection/RTCMediaSource+Private.h
+++ b/sdk/objc/api/peerconnection/RTCMediaSource+Private.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RTC_OBJC_TYPE(RTCPeerConnectionFactory);
 
-typedef NS_ENUM(NSInteger, RTCMediaSourceType) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCMediaSourceType)) {
   RTCMediaSourceTypeAudio,
   RTCMediaSourceTypeVideo,
 };

--- a/sdk/objc/api/peerconnection/RTCMediaSource+Private.h
+++ b/sdk/objc/api/peerconnection/RTCMediaSource+Private.h
@@ -17,8 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 @class RTC_OBJC_TYPE(RTCPeerConnectionFactory);
 
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCMediaSourceType)) {
-  RTCMediaSourceTypeAudio,
-  RTCMediaSourceTypeVideo,
+  RTC_OBJC_TYPE(RTCMediaSourceTypeAudio),
+  RTC_OBJC_TYPE(RTCMediaSourceTypeVideo),
 };
 
 @interface RTC_OBJC_TYPE (RTCMediaSource)
@@ -29,13 +29,13 @@ typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCMediaSourceType)) {
 
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
               nativeMediaSource:(rtc::scoped_refptr<webrtc::MediaSourceInterface>)nativeMediaSource
-                           type:(RTCMediaSourceType)type NS_DESIGNATED_INITIALIZER;
+                           type:(RTC_OBJC_TYPE(RTCMediaSourceType))type NS_DESIGNATED_INITIALIZER;
 
-+ (webrtc::MediaSourceInterface::SourceState)nativeSourceStateForState:(RTCSourceState)state;
++ (webrtc::MediaSourceInterface::SourceState)nativeSourceStateForState:(RTC_OBJC_TYPE(RTCSourceState))state;
 
-+ (RTCSourceState)sourceStateForNativeState:(webrtc::MediaSourceInterface::SourceState)nativeState;
++ (RTC_OBJC_TYPE(RTCSourceState))sourceStateForNativeState:(webrtc::MediaSourceInterface::SourceState)nativeState;
 
-+ (NSString *)stringForState:(RTCSourceState)state;
++ (NSString *)stringForState:(RTC_OBJC_TYPE(RTCSourceState))state;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCMediaSource.h
+++ b/sdk/objc/api/peerconnection/RTCMediaSource.h
@@ -13,10 +13,10 @@
 #import "RTCMacros.h"
 
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCSourceState)) {
-  RTCSourceStateInitializing,
-  RTCSourceStateLive,
-  RTCSourceStateEnded,
-  RTCSourceStateMuted,
+  RTC_OBJC_TYPE(RTCSourceStateInitializing),
+  RTC_OBJC_TYPE(RTCSourceStateLive),
+  RTC_OBJC_TYPE(RTCSourceStateEnded),
+  RTC_OBJC_TYPE(RTCSourceStateMuted),
 };
 
 NS_ASSUME_NONNULL_BEGIN
@@ -25,7 +25,7 @@ RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCMediaSource) : NSObject
 
 /** The current state of the RTCMediaSource. */
-@property(nonatomic, readonly) RTCSourceState state;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCSourceState) state;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/sdk/objc/api/peerconnection/RTCMediaSource.h
+++ b/sdk/objc/api/peerconnection/RTCMediaSource.h
@@ -12,7 +12,7 @@
 
 #import "RTCMacros.h"
 
-typedef NS_ENUM(NSInteger, RTCSourceState) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCSourceState)) {
   RTCSourceStateInitializing,
   RTCSourceStateLive,
   RTCSourceStateEnded,

--- a/sdk/objc/api/peerconnection/RTCMediaSource.mm
+++ b/sdk/objc/api/peerconnection/RTCMediaSource.mm
@@ -14,67 +14,66 @@
 
 @implementation RTC_OBJC_TYPE (RTCMediaSource) {
   RTC_OBJC_TYPE(RTCPeerConnectionFactory) * _factory;
-  RTCMediaSourceType _type;
+  RTC_OBJC_TYPE(RTCMediaSourceType) _type;
 }
 
 @synthesize nativeMediaSource = _nativeMediaSource;
 
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
               nativeMediaSource:(rtc::scoped_refptr<webrtc::MediaSourceInterface>)nativeMediaSource
-                           type:(RTCMediaSourceType)type {
+                           type:(RTC_OBJC_TYPE(RTCMediaSourceType))type {
   RTC_DCHECK(factory);
   RTC_DCHECK(nativeMediaSource);
   if (self = [super init]) {
-    _factory = factory;
     _nativeMediaSource = nativeMediaSource;
     _type = type;
   }
   return self;
 }
 
-- (RTCSourceState)state {
+- (RTC_OBJC_TYPE(RTCSourceState))state {
   return [[self class] sourceStateForNativeState:_nativeMediaSource->state()];
 }
 
 #pragma mark - Private
 
 + (webrtc::MediaSourceInterface::SourceState)nativeSourceStateForState:
-    (RTCSourceState)state {
+    (RTC_OBJC_TYPE(RTCSourceState))state {
   switch (state) {
-    case RTCSourceStateInitializing:
+    case RTC_OBJC_TYPE(RTCSourceStateInitializing):
       return webrtc::MediaSourceInterface::kInitializing;
-    case RTCSourceStateLive:
+    case RTC_OBJC_TYPE(RTCSourceStateLive):
       return webrtc::MediaSourceInterface::kLive;
-    case RTCSourceStateEnded:
+    case RTC_OBJC_TYPE(RTCSourceStateEnded):
       return webrtc::MediaSourceInterface::kEnded;
-    case RTCSourceStateMuted:
+    case RTC_OBJC_TYPE(RTCSourceStateMuted):
       return webrtc::MediaSourceInterface::kMuted;
   }
 }
 
-+ (RTCSourceState)sourceStateForNativeState:
++ (RTC_OBJC_TYPE(RTCSourceState))sourceStateForNativeState:
     (webrtc::MediaSourceInterface::SourceState)nativeState {
   switch (nativeState) {
     case webrtc::MediaSourceInterface::kInitializing:
-      return RTCSourceStateInitializing;
+      return RTC_OBJC_TYPE(RTCSourceStateInitializing);
     case webrtc::MediaSourceInterface::kLive:
-      return RTCSourceStateLive;
+      return RTC_OBJC_TYPE(RTCSourceStateLive);
     case webrtc::MediaSourceInterface::kEnded:
-      return RTCSourceStateEnded;
+      return RTC_OBJC_TYPE(RTCSourceStateEnded);
     case webrtc::MediaSourceInterface::kMuted:
-      return RTCSourceStateMuted;
+      return RTC_OBJC_TYPE(RTCSourceStateMuted);
   }
 }
 
-+ (NSString *)stringForState:(RTCSourceState)state {
++ (NSString *)stringForState:(RTC_OBJC_TYPE(RTCSourceState))state {
   switch (state) {
-    case RTCSourceStateInitializing:
+    case RTC_OBJC_TYPE(RTCSourceStateInitializing):
       return @"Initializing";
-    case RTCSourceStateLive:
+    case RTC_OBJC_TYPE(RTCSourceStateLive):
       return @"Live";
-    case RTCSourceStateEnded:
+    case RTC_OBJC_TYPE(RTCSourceStateEnded):
       return @"Ended";
-    case RTCSourceStateMuted:
+    case RTC_OBJC_TYPE(RTCSourceStateMuted):
       return @"Muted";
   }
 }

--- a/sdk/objc/api/peerconnection/RTCMediaSource.mm
+++ b/sdk/objc/api/peerconnection/RTCMediaSource.mm
@@ -25,6 +25,7 @@
   RTC_DCHECK(factory);
   RTC_DCHECK(nativeMediaSource);
   if (self = [super init]) {
+    _factory = factory;
     _nativeMediaSource = nativeMediaSource;
     _type = type;
   }

--- a/sdk/objc/api/peerconnection/RTCMediaStream.mm
+++ b/sdk/objc/api/peerconnection/RTCMediaStream.mm
@@ -132,7 +132,7 @@
     _nativeMediaStream = nativeMediaStream;
 
     for (auto &track : audioTracks) {
-      RTCMediaStreamTrackType type = RTCMediaStreamTrackTypeAudio;
+      RTC_OBJC_TYPE(RTCMediaStreamTrackType) type = RTC_OBJC_TYPE(RTCMediaStreamTrackTypeAudio);
       RTC_OBJC_TYPE(RTCAudioTrack) *audioTrack =
           [[RTC_OBJC_TYPE(RTCAudioTrack) alloc] initWithFactory:_factory
                                                     nativeTrack:track
@@ -141,7 +141,7 @@
     }
 
     for (auto &track : videoTracks) {
-      RTCMediaStreamTrackType type = RTCMediaStreamTrackTypeVideo;
+      RTC_OBJC_TYPE(RTCMediaStreamTrackType) type = RTC_OBJC_TYPE(RTCMediaStreamTrackTypeVideo);
       RTC_OBJC_TYPE(RTCVideoTrack) *videoTrack =
           [[RTC_OBJC_TYPE(RTCVideoTrack) alloc] initWithFactory:_factory
                                                     nativeTrack:track

--- a/sdk/objc/api/peerconnection/RTCMediaStreamTrack+Private.h
+++ b/sdk/objc/api/peerconnection/RTCMediaStreamTrack+Private.h
@@ -13,8 +13,8 @@
 #include "api/media_stream_interface.h"
 
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCMediaStreamTrackType)) {
-  RTCMediaStreamTrackTypeAudio,
-  RTCMediaStreamTrackTypeVideo,
+  RTC_OBJC_TYPE(RTCMediaStreamTrackTypeAudio),
+  RTC_OBJC_TYPE(RTCMediaStreamTrackTypeVideo),
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/sdk/objc/api/peerconnection/RTCMediaStreamTrack+Private.h
+++ b/sdk/objc/api/peerconnection/RTCMediaStreamTrack+Private.h
@@ -12,7 +12,7 @@
 
 #include "api/media_stream_interface.h"
 
-typedef NS_ENUM(NSInteger, RTCMediaStreamTrackType) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCMediaStreamTrackType)) {
   RTCMediaStreamTrackTypeAudio,
   RTCMediaStreamTrackTypeVideo,
 };
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
                     nativeTrack:(rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>)nativeTrack
-                           type:(RTCMediaStreamTrackType)type NS_DESIGNATED_INITIALIZER;
+                           type:(RTC_OBJC_TYPE(RTCMediaStreamTrackType))type NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
                     nativeTrack:(rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>)nativeTrack;
@@ -46,12 +46,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToTrack:(RTC_OBJC_TYPE(RTCMediaStreamTrack) *)track;
 
 + (webrtc::MediaStreamTrackInterface::TrackState)nativeTrackStateForState:
-    (RTCMediaStreamTrackState)state;
+    (RTC_OBJC_TYPE(RTCMediaStreamTrackState))state;
 
-+ (RTCMediaStreamTrackState)trackStateForNativeState:
++ (RTC_OBJC_TYPE(RTCMediaStreamTrackState))trackStateForNativeState:
     (webrtc::MediaStreamTrackInterface::TrackState)nativeState;
 
-+ (NSString *)stringForState:(RTCMediaStreamTrackState)state;
++ (NSString *)stringForState:(RTC_OBJC_TYPE(RTCMediaStreamTrackState))state;
 
 + (RTC_OBJC_TYPE(RTCMediaStreamTrack) *)
     mediaTrackForNativeTrack:(rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>)nativeTrack

--- a/sdk/objc/api/peerconnection/RTCMediaStreamTrack.h
+++ b/sdk/objc/api/peerconnection/RTCMediaStreamTrack.h
@@ -22,8 +22,8 @@ typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCMediaStreamTrackState)) {
 
 NS_ASSUME_NONNULL_BEGIN
 
-RTC_EXTERN NSString *const kRTCMediaStreamTrackKindAudio;
-RTC_EXTERN NSString *const kRTCMediaStreamTrackKindVideo;
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindAudio);
+RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindVideo);
 
 RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCMediaStreamTrack) : NSObject

--- a/sdk/objc/api/peerconnection/RTCMediaStreamTrack.h
+++ b/sdk/objc/api/peerconnection/RTCMediaStreamTrack.h
@@ -16,8 +16,8 @@
  * Represents the state of the track. This exposes the same states in C++.
  */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCMediaStreamTrackState)) {
-  RTCMediaStreamTrackStateLive,
-  RTCMediaStreamTrackStateEnded
+  RTC_OBJC_TYPE(RTCMediaStreamTrackStateLive),
+  RTC_OBJC_TYPE(RTCMediaStreamTrackStateEnded)
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/sdk/objc/api/peerconnection/RTCMediaStreamTrack.h
+++ b/sdk/objc/api/peerconnection/RTCMediaStreamTrack.h
@@ -15,7 +15,7 @@
 /**
  * Represents the state of the track. This exposes the same states in C++.
  */
-typedef NS_ENUM(NSInteger, RTCMediaStreamTrackState) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCMediaStreamTrackState)) {
   RTCMediaStreamTrackStateLive,
   RTCMediaStreamTrackStateEnded
 };
@@ -41,7 +41,7 @@ RTC_OBJC_EXPORT
 @property(nonatomic, assign) BOOL isEnabled;
 
 /** The state of the track. */
-@property(nonatomic, readonly) RTCMediaStreamTrackState readyState;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCMediaStreamTrackState) readyState;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/sdk/objc/api/peerconnection/RTCMediaStreamTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCMediaStreamTrack.mm
@@ -19,10 +19,10 @@ NSString * const kRTCMediaStreamTrackKindAudio =
 NSString * const kRTCMediaStreamTrackKindVideo =
     @(webrtc::MediaStreamTrackInterface::kVideoKind);
 
-@implementation RTC_OBJC_TYPE (RTCMediaStreamTrack) {
+@implementation RTC_OBJC_TYPE(RTCMediaStreamTrack) {
   RTC_OBJC_TYPE(RTCPeerConnectionFactory) * _factory;
   rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> _nativeTrack;
-  RTCMediaStreamTrackType _type;
+  RTC_OBJC_TYPE(RTCMediaStreamTrackType) _type;
 }
 
 - (NSString *)kind {
@@ -41,7 +41,7 @@ NSString * const kRTCMediaStreamTrackKindVideo =
   _nativeTrack->set_enabled(isEnabled);
 }
 
-- (RTCMediaStreamTrackState)readyState {
+- (RTC_OBJC_TYPE(RTCMediaStreamTrackState))readyState {
   return [[self class] trackStateForNativeState:_nativeTrack->state()];
 }
 
@@ -78,7 +78,7 @@ NSString * const kRTCMediaStreamTrackKindVideo =
 
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
                     nativeTrack:(rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>)nativeTrack
-                           type:(RTCMediaStreamTrackType)type {
+                           type:(RTC_OBJC_TYPE(RTCMediaStreamTrackType))type {
   NSParameterAssert(nativeTrack);
   NSParameterAssert(factory);
   if (self = [super init]) {
@@ -94,11 +94,11 @@ NSString * const kRTCMediaStreamTrackKindVideo =
   NSParameterAssert(nativeTrack);
   if (nativeTrack->kind() ==
       std::string(webrtc::MediaStreamTrackInterface::kAudioKind)) {
-    return [self initWithFactory:factory nativeTrack:nativeTrack type:RTCMediaStreamTrackTypeAudio];
+    return [self initWithFactory:factory nativeTrack:nativeTrack type:RTC_OBJC_TYPE(RTCMediaStreamTrackTypeAudio)];
   }
   if (nativeTrack->kind() ==
       std::string(webrtc::MediaStreamTrackInterface::kVideoKind)) {
-    return [self initWithFactory:factory nativeTrack:nativeTrack type:RTCMediaStreamTrackTypeVideo];
+    return [self initWithFactory:factory nativeTrack:nativeTrack type:RTC_OBJC_TYPE(RTCMediaStreamTrackTypeVideo)];
   }
   return nil;
 }
@@ -111,30 +111,30 @@ NSString * const kRTCMediaStreamTrackKindVideo =
 }
 
 + (webrtc::MediaStreamTrackInterface::TrackState)nativeTrackStateForState:
-    (RTCMediaStreamTrackState)state {
+    (RTC_OBJC_TYPE(RTCMediaStreamTrackState))state {
   switch (state) {
-    case RTCMediaStreamTrackStateLive:
+    case RTC_OBJC_TYPE(RTCMediaStreamTrackStateLive):
       return webrtc::MediaStreamTrackInterface::kLive;
-    case RTCMediaStreamTrackStateEnded:
+    case RTC_OBJC_TYPE(RTCMediaStreamTrackStateEnded):
       return webrtc::MediaStreamTrackInterface::kEnded;
   }
 }
 
-+ (RTCMediaStreamTrackState)trackStateForNativeState:
++ (RTC_OBJC_TYPE(RTCMediaStreamTrackState))trackStateForNativeState:
     (webrtc::MediaStreamTrackInterface::TrackState)nativeState {
   switch (nativeState) {
     case webrtc::MediaStreamTrackInterface::kLive:
-      return RTCMediaStreamTrackStateLive;
+      return RTC_OBJC_TYPE(RTCMediaStreamTrackStateLive);
     case webrtc::MediaStreamTrackInterface::kEnded:
-      return RTCMediaStreamTrackStateEnded;
+      return RTC_OBJC_TYPE(RTCMediaStreamTrackStateEnded);
   }
 }
 
-+ (NSString *)stringForState:(RTCMediaStreamTrackState)state {
++ (NSString *)stringForState:(RTC_OBJC_TYPE(RTCMediaStreamTrackState))state {
   switch (state) {
-    case RTCMediaStreamTrackStateLive:
+    case RTC_OBJC_TYPE(RTCMediaStreamTrackStateLive):
       return @"Live";
-    case RTCMediaStreamTrackStateEnded:
+    case RTC_OBJC_TYPE(RTCMediaStreamTrackStateEnded):
       return @"Ended";
   }
 }
@@ -147,11 +147,11 @@ NSString * const kRTCMediaStreamTrackKindVideo =
   if (nativeTrack->kind() == webrtc::MediaStreamTrackInterface::kAudioKind) {
     return [[RTC_OBJC_TYPE(RTCAudioTrack) alloc] initWithFactory:factory
                                                      nativeTrack:nativeTrack
-                                                            type:RTCMediaStreamTrackTypeAudio];
+                                                            type:RTC_OBJC_TYPE(RTCMediaStreamTrackTypeAudio)];
   } else if (nativeTrack->kind() == webrtc::MediaStreamTrackInterface::kVideoKind) {
     return [[RTC_OBJC_TYPE(RTCVideoTrack) alloc] initWithFactory:factory
                                                      nativeTrack:nativeTrack
-                                                            type:RTCMediaStreamTrackTypeVideo];
+                                                            type:RTC_OBJC_TYPE(RTCMediaStreamTrackTypeVideo)];
   } else {
     return [[RTC_OBJC_TYPE(RTCMediaStreamTrack) alloc] initWithFactory:factory
                                                            nativeTrack:nativeTrack];

--- a/sdk/objc/api/peerconnection/RTCMediaStreamTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCMediaStreamTrack.mm
@@ -14,9 +14,9 @@
 
 #import "helpers/NSString+StdString.h"
 
-NSString * const kRTCMediaStreamTrackKindAudio =
+NSString * const RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindAudio) =
     @(webrtc::MediaStreamTrackInterface::kAudioKind);
-NSString * const kRTCMediaStreamTrackKindVideo =
+NSString * const RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindVideo) =
     @(webrtc::MediaStreamTrackInterface::kVideoKind);
 
 @implementation RTC_OBJC_TYPE(RTCMediaStreamTrack) {

--- a/sdk/objc/api/peerconnection/RTCPeerConnection+Private.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnection+Private.h
@@ -104,39 +104,39 @@ class PeerConnectionDelegateAdapter : public PeerConnectionObserver {
     NS_DESIGNATED_INITIALIZER;
 
 + (webrtc::PeerConnectionInterface::SignalingState)nativeSignalingStateForState:
-    (RTCSignalingState)state;
+    (RTC_OBJC_TYPE(RTCSignalingState))state;
 
-+ (RTCSignalingState)signalingStateForNativeState:
++ (RTC_OBJC_TYPE(RTCSignalingState))signalingStateForNativeState:
     (webrtc::PeerConnectionInterface::SignalingState)nativeState;
 
-+ (NSString *)stringForSignalingState:(RTCSignalingState)state;
++ (NSString *)stringForSignalingState:(RTC_OBJC_TYPE(RTCSignalingState))state;
 
 + (webrtc::PeerConnectionInterface::IceConnectionState)nativeIceConnectionStateForState:
-    (RTCIceConnectionState)state;
+    (RTC_OBJC_TYPE(RTCIceConnectionState))state;
 
 + (webrtc::PeerConnectionInterface::PeerConnectionState)nativeConnectionStateForState:
-    (RTCPeerConnectionState)state;
+    (RTC_OBJC_TYPE(RTCPeerConnectionState))state;
 
-+ (RTCIceConnectionState)iceConnectionStateForNativeState:
++ (RTC_OBJC_TYPE(RTCIceConnectionState))iceConnectionStateForNativeState:
     (webrtc::PeerConnectionInterface::IceConnectionState)nativeState;
 
-+ (RTCPeerConnectionState)connectionStateForNativeState:
++ (RTC_OBJC_TYPE(RTCPeerConnectionState))connectionStateForNativeState:
     (webrtc::PeerConnectionInterface::PeerConnectionState)nativeState;
 
-+ (NSString *)stringForIceConnectionState:(RTCIceConnectionState)state;
++ (NSString *)stringForIceConnectionState:(RTC_OBJC_TYPE(RTCIceConnectionState))state;
 
-+ (NSString *)stringForConnectionState:(RTCPeerConnectionState)state;
++ (NSString *)stringForConnectionState:(RTC_OBJC_TYPE(RTCPeerConnectionState))state;
 
 + (webrtc::PeerConnectionInterface::IceGatheringState)nativeIceGatheringStateForState:
-    (RTCIceGatheringState)state;
+    (RTC_OBJC_TYPE(RTCIceGatheringState))state;
 
-+ (RTCIceGatheringState)iceGatheringStateForNativeState:
++ (RTC_OBJC_TYPE(RTCIceGatheringState))iceGatheringStateForNativeState:
     (webrtc::PeerConnectionInterface::IceGatheringState)nativeState;
 
-+ (NSString *)stringForIceGatheringState:(RTCIceGatheringState)state;
++ (NSString *)stringForIceGatheringState:(RTC_OBJC_TYPE(RTCIceGatheringState))state;
 
 + (webrtc::PeerConnectionInterface::StatsOutputLevel)nativeStatsOutputLevelForLevel:
-    (RTCStatsOutputLevel)level;
+    (RTC_OBJC_TYPE(RTCStatsOutputLevel))level;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnection+Stats.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnection+Stats.mm
@@ -88,7 +88,7 @@ class StatsObserverAdapter : public StatsObserver {
 }
 
 - (void)statsForTrack:(RTC_OBJC_TYPE(RTCMediaStreamTrack) *)mediaStreamTrack
-     statsOutputLevel:(RTCStatsOutputLevel)statsOutputLevel
+     statsOutputLevel:(RTC_OBJC_TYPE(RTCStatsOutputLevel))statsOutputLevel
     completionHandler:
         (void (^)(NSArray<RTC_OBJC_TYPE(RTCLegacyStatsReport) *> *stats))completionHandler {
   rtc::scoped_refptr<webrtc::StatsObserverAdapter> observer =

--- a/sdk/objc/api/peerconnection/RTCPeerConnection.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnection.h
@@ -33,8 +33,8 @@ typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtpMediaType));
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const kRTCPeerConnectionErrorDomain;
-extern int const kRTCSessionDescriptionErrorCode;
+extern NSString *const RTC_CONSTANT_TYPE(RTCPeerConnectionErrorDomain);
+extern int const RTC_CONSTANT_TYPE(RTCSessionDescriptionErrorCode);
 
 /** Represents the signaling state of the peer connection. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCSignalingState)) {

--- a/sdk/objc/api/peerconnection/RTCPeerConnection.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnection.h
@@ -29,7 +29,7 @@
 @class RTC_OBJC_TYPE(RTCStatisticsReport);
 @class RTC_OBJC_TYPE(RTCLegacyStatsReport);
 
-typedef NS_ENUM(NSInteger, RTCRtpMediaType);
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtpMediaType));
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -37,7 +37,7 @@ extern NSString *const kRTCPeerConnectionErrorDomain;
 extern int const kRTCSessionDescriptionErrorCode;
 
 /** Represents the signaling state of the peer connection. */
-typedef NS_ENUM(NSInteger, RTCSignalingState) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCSignalingState)) {
   RTCSignalingStateStable,
   RTCSignalingStateHaveLocalOffer,
   RTCSignalingStateHaveLocalPrAnswer,
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSInteger, RTCSignalingState) {
 };
 
 /** Represents the ice connection state of the peer connection. */
-typedef NS_ENUM(NSInteger, RTCIceConnectionState) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCIceConnectionState)) {
   RTCIceConnectionStateNew,
   RTCIceConnectionStateChecking,
   RTCIceConnectionStateConnected,
@@ -60,7 +60,7 @@ typedef NS_ENUM(NSInteger, RTCIceConnectionState) {
 };
 
 /** Represents the combined ice+dtls connection state of the peer connection. */
-typedef NS_ENUM(NSInteger, RTCPeerConnectionState) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCPeerConnectionState)) {
   RTCPeerConnectionStateNew,
   RTCPeerConnectionStateConnecting,
   RTCPeerConnectionStateConnected,
@@ -70,14 +70,14 @@ typedef NS_ENUM(NSInteger, RTCPeerConnectionState) {
 };
 
 /** Represents the ice gathering state of the peer connection. */
-typedef NS_ENUM(NSInteger, RTCIceGatheringState) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCIceGatheringState)) {
   RTCIceGatheringStateNew,
   RTCIceGatheringStateGathering,
   RTCIceGatheringStateComplete,
 };
 
 /** Represents the stats output level. */
-typedef NS_ENUM(NSInteger, RTCStatsOutputLevel) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCStatsOutputLevel)) {
   RTCStatsOutputLevelStandard,
   RTCStatsOutputLevelDebug,
 };
@@ -96,7 +96,7 @@ RTC_OBJC_EXPORT
     /** Called when the SignalingState changed. */
     - (void)peerConnection
     : (RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection didChangeSignalingState
-    : (RTCSignalingState)stateChanged;
+    : (RTC_OBJC_TYPE(RTCSignalingState))stateChanged;
 
 /** Called when media is received on a new stream from remote peer. */
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
@@ -113,11 +113,11 @@ RTC_OBJC_EXPORT
 
 /** Called any time the IceConnectionState changes. */
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
-    didChangeIceConnectionState:(RTCIceConnectionState)newState;
+    didChangeIceConnectionState:(RTC_OBJC_TYPE(RTCIceConnectionState))newState;
 
 /** Called any time the IceGatheringState changes. */
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
-    didChangeIceGatheringState:(RTCIceGatheringState)newState;
+    didChangeIceGatheringState:(RTC_OBJC_TYPE(RTCIceGatheringState))newState;
 
 /** New ice candidate has been found. */
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
@@ -139,11 +139,11 @@ RTC_OBJC_EXPORT
 /** Called any time the IceConnectionState changes following standardized
  * transition. */
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
-    didChangeStandardizedIceConnectionState:(RTCIceConnectionState)newState;
+    didChangeStandardizedIceConnectionState:(RTC_OBJC_TYPE(RTCIceConnectionState))newState;
 
 /** Called any time the PeerConnectionState changes. */
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
-    didChangeConnectionState:(RTCPeerConnectionState)newState;
+    didChangeConnectionState:(RTC_OBJC_TYPE(RTCPeerConnectionState))newState;
 
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
     didStartReceivingOnTransceiver:(RTC_OBJC_TYPE(RTCRtpTransceiver) *)transceiver;
@@ -183,10 +183,10 @@ RTC_OBJC_EXPORT
 @property(nonatomic, readonly) NSArray<RTC_OBJC_TYPE(RTCMediaStream) *> *localStreams;
 @property(nonatomic, readonly, nullable) RTC_OBJC_TYPE(RTCSessionDescription) * localDescription;
 @property(nonatomic, readonly, nullable) RTC_OBJC_TYPE(RTCSessionDescription) * remoteDescription;
-@property(nonatomic, readonly) RTCSignalingState signalingState;
-@property(nonatomic, readonly) RTCIceConnectionState iceConnectionState;
-@property(nonatomic, readonly) RTCPeerConnectionState connectionState;
-@property(nonatomic, readonly) RTCIceGatheringState iceGatheringState;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCSignalingState) signalingState;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCIceConnectionState) iceConnectionState;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCPeerConnectionState) connectionState;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCIceGatheringState) iceGatheringState;
 @property(nonatomic, readonly, copy) RTC_OBJC_TYPE(RTCConfiguration) * configuration;
 
 /** Gets all RTCRtpSenders associated with this peer connection.
@@ -295,9 +295,9 @@ RTC_OBJC_EXPORT
 /** Adds a transceiver with the given kind. Can either be RTCRtpMediaTypeAudio
  *  or RTCRtpMediaTypeVideo.
  */
-- (nullable RTC_OBJC_TYPE(RTCRtpTransceiver) *)addTransceiverOfType:(RTCRtpMediaType)mediaType;
+- (nullable RTC_OBJC_TYPE(RTCRtpTransceiver) *)addTransceiverOfType:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType;
 - (nullable RTC_OBJC_TYPE(RTCRtpTransceiver) *)
-    addTransceiverOfType:(RTCRtpMediaType)mediaType
+    addTransceiverOfType:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType
                     init:(RTC_OBJC_TYPE(RTCRtpTransceiverInit) *)init;
 
 /** Tells the PeerConnection that ICE should be restarted. This triggers a need
@@ -374,7 +374,7 @@ typedef void (^RTCStatisticsCompletionHandler)(RTC_OBJC_TYPE(RTCStatisticsReport
      */
     - (void)statsForTrack
     : (nullable RTC_OBJC_TYPE(RTCMediaStreamTrack) *)mediaStreamTrack statsOutputLevel
-    : (RTCStatsOutputLevel)statsOutputLevel completionHandler
+    : (RTC_OBJC_TYPE(RTCStatsOutputLevel))statsOutputLevel completionHandler
     : (nullable void (^)(NSArray<RTC_OBJC_TYPE(RTCLegacyStatsReport) *> *stats))completionHandler;
 
 /** Gather statistic through the v2 statistics API. */

--- a/sdk/objc/api/peerconnection/RTCPeerConnection.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnection.h
@@ -38,48 +38,48 @@ extern int const kRTCSessionDescriptionErrorCode;
 
 /** Represents the signaling state of the peer connection. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCSignalingState)) {
-  RTCSignalingStateStable,
-  RTCSignalingStateHaveLocalOffer,
-  RTCSignalingStateHaveLocalPrAnswer,
-  RTCSignalingStateHaveRemoteOffer,
-  RTCSignalingStateHaveRemotePrAnswer,
+  RTC_OBJC_TYPE(RTCSignalingStateStable),
+  RTC_OBJC_TYPE(RTCSignalingStateHaveLocalOffer),
+  RTC_OBJC_TYPE(RTCSignalingStateHaveLocalPrAnswer),
+  RTC_OBJC_TYPE(RTCSignalingStateHaveRemoteOffer),
+  RTC_OBJC_TYPE(RTCSignalingStateHaveRemotePrAnswer),
   // Not an actual state, represents the total number of states.
-  RTCSignalingStateClosed,
+  RTC_OBJC_TYPE(RTCSignalingStateClosed),
 };
 
 /** Represents the ice connection state of the peer connection. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCIceConnectionState)) {
-  RTCIceConnectionStateNew,
-  RTCIceConnectionStateChecking,
-  RTCIceConnectionStateConnected,
-  RTCIceConnectionStateCompleted,
-  RTCIceConnectionStateFailed,
-  RTCIceConnectionStateDisconnected,
-  RTCIceConnectionStateClosed,
-  RTCIceConnectionStateCount,
+  RTC_OBJC_TYPE(RTCIceConnectionStateNew),
+  RTC_OBJC_TYPE(RTCIceConnectionStateChecking),
+  RTC_OBJC_TYPE(RTCIceConnectionStateConnected),
+  RTC_OBJC_TYPE(RTCIceConnectionStateCompleted),
+  RTC_OBJC_TYPE(RTCIceConnectionStateFailed),
+  RTC_OBJC_TYPE(RTCIceConnectionStateDisconnected),
+  RTC_OBJC_TYPE(RTCIceConnectionStateClosed),
+  RTC_OBJC_TYPE(RTCIceConnectionStateCount),
 };
 
 /** Represents the combined ice+dtls connection state of the peer connection. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCPeerConnectionState)) {
-  RTCPeerConnectionStateNew,
-  RTCPeerConnectionStateConnecting,
-  RTCPeerConnectionStateConnected,
-  RTCPeerConnectionStateDisconnected,
-  RTCPeerConnectionStateFailed,
-  RTCPeerConnectionStateClosed,
+  RTC_OBJC_TYPE(RTCPeerConnectionStateNew),
+  RTC_OBJC_TYPE(RTCPeerConnectionStateConnecting),
+  RTC_OBJC_TYPE(RTCPeerConnectionStateConnected),
+  RTC_OBJC_TYPE(RTCPeerConnectionStateDisconnected),
+  RTC_OBJC_TYPE(RTCPeerConnectionStateFailed),
+  RTC_OBJC_TYPE(RTCPeerConnectionStateClosed),
 };
 
 /** Represents the ice gathering state of the peer connection. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCIceGatheringState)) {
-  RTCIceGatheringStateNew,
-  RTCIceGatheringStateGathering,
-  RTCIceGatheringStateComplete,
+  RTC_OBJC_TYPE(RTCIceGatheringStateNew),
+  RTC_OBJC_TYPE(RTCIceGatheringStateGathering),
+  RTC_OBJC_TYPE(RTCIceGatheringStateComplete),
 };
 
 /** Represents the stats output level. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCStatsOutputLevel)) {
-  RTCStatsOutputLevelStandard,
-  RTCStatsOutputLevelDebug,
+  RTC_OBJC_TYPE(RTCStatsOutputLevelStandard),
+  RTC_OBJC_TYPE(RTCStatsOutputLevelDebug),
 };
 
 typedef void (^RTCCreateSessionDescriptionCompletionHandler)(

--- a/sdk/objc/api/peerconnection/RTCPeerConnection.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnection.mm
@@ -414,8 +414,7 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
 }
 
 - (RTC_OBJC_TYPE(RTCIceConnectionState))iceConnectionState {
-  return [[self class]
-      iceConnectionStateForNativeState:self.nativePeerConnection->ice_connection_state()];
+  return [[self class] iceConnectionStateForNativeState:self.nativePeerConnection->ice_connection_state()];
 }
 
 - (RTC_OBJC_TYPE(RTCPeerConnectionState))connectionState {
@@ -423,8 +422,7 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
 }
 
 - (RTC_OBJC_TYPE(RTCIceGatheringState))iceGatheringState {
-  return [[self class]
-      iceGatheringStateForNativeState:self.nativePeerConnection->ice_gathering_state()];
+  return [[self class] iceGatheringStateForNativeState:self.nativePeerConnection->ice_gathering_state()];
 }
 
 - (BOOL)setConfiguration:(RTC_OBJC_TYPE(RTCConfiguration) *)configuration {
@@ -543,10 +541,8 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
       nativeRtpTransceiver:nativeTransceiverOrError.MoveValue()];
 }
 
-- (nullable RTC_OBJC_TYPE(RTCRtpTransceiver) *)addTransceiverOfType:
-    (RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
-  return [self addTransceiverOfType:mediaType
-                               init:[[RTC_OBJC_TYPE(RTCRtpTransceiverInit) alloc] init]];
+- (nullable RTC_OBJC_TYPE(RTCRtpTransceiver) *)addTransceiverOfType:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
+  return [self addTransceiverOfType:mediaType init:[[RTC_OBJC_TYPE(RTCRtpTransceiverInit) alloc] init]];
 }
 
 - (nullable RTC_OBJC_TYPE(RTCRtpTransceiver) *)
@@ -750,17 +746,17 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
 + (NSString *)stringForSignalingState:(RTC_OBJC_TYPE(RTCSignalingState))state {
   switch (state) {
     case RTC_OBJC_TYPE(RTCSignalingStateStable):
-      return @"RTCSignalingStateStable";
+      return @"STABLE";
     case RTC_OBJC_TYPE(RTCSignalingStateHaveLocalOffer):
-      return @"RTCSignalingStateHaveLocalOffer";
+      return @"HAVE_LOCAL_OFFER";
     case RTC_OBJC_TYPE(RTCSignalingStateHaveLocalPrAnswer):
-      return @"RTCSignalingStateHaveLocalPrAnswer";
+      return @"HAVE_LOCAL_PRANSWER";
     case RTC_OBJC_TYPE(RTCSignalingStateHaveRemoteOffer):
-      return @"RTCSignalingStateHaveRemoteOffer";
+      return @"HAVE_REMOTE_OFFER";
     case RTC_OBJC_TYPE(RTCSignalingStateHaveRemotePrAnswer):
-      return @"RTCSignalingStateHaveRemotePrAnswer";
+      return @"HAVE_REMOTE_PRANSWER";
     case RTC_OBJC_TYPE(RTCSignalingStateClosed):
-      return @"RTCSignalingStateClosed";
+      return @"CLOSED";
   }
 }
 
@@ -803,17 +799,17 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
 + (NSString *)stringForConnectionState:(RTC_OBJC_TYPE(RTCPeerConnectionState))state {
   switch (state) {
     case RTC_OBJC_TYPE(RTCPeerConnectionStateNew):
-      return @"RTCPeerConnectionStateNew";
+      return @"NEW";
     case RTC_OBJC_TYPE(RTCPeerConnectionStateConnecting):
-      return @"RTCPeerConnectionStateConnecting";
+      return @"CONNECTING";
     case RTC_OBJC_TYPE(RTCPeerConnectionStateConnected):
-      return @"RTCPeerConnectionStateConnected";
+      return @"CONNECTED";
     case RTC_OBJC_TYPE(RTCPeerConnectionStateFailed):
-      return @"RTCPeerConnectionStateFailed";
+      return @"FAILED";
     case RTC_OBJC_TYPE(RTCPeerConnectionStateDisconnected):
-      return @"RTCPeerConnectionStateDisconnected";
+      return @"DISCONNECTED";
     case RTC_OBJC_TYPE(RTCPeerConnectionStateClosed):
-      return @"RTCPeerConnectionStateClosed";
+      return @"CLOSED";
   }
 }
 
@@ -835,9 +831,7 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
     case RTC_OBJC_TYPE(RTCIceConnectionStateClosed):
       return webrtc::PeerConnectionInterface::kIceConnectionClosed;
     case RTC_OBJC_TYPE(RTCIceConnectionStateCount):
-      // This is not a real state, just used for counting.
-      RTCLogError(@"Attempting to convert RTCIceConnectionStateCount to native state");
-      return webrtc::PeerConnectionInterface::kIceConnectionNew;
+      return webrtc::PeerConnectionInterface::kIceConnectionMax;
   }
 }
 
@@ -859,8 +853,6 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
     case webrtc::PeerConnectionInterface::kIceConnectionClosed:
       return RTC_OBJC_TYPE(RTCIceConnectionStateClosed);
     case webrtc::PeerConnectionInterface::kIceConnectionMax:
-      // This is not a real state, just used for counting.
-      RTCLogError(@"Attempting to convert kIceConnectionMax to RTCIceConnectionState");
       return RTC_OBJC_TYPE(RTCIceConnectionStateCount);
   }
 }
@@ -868,21 +860,21 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
 + (NSString *)stringForIceConnectionState:(RTC_OBJC_TYPE(RTCIceConnectionState))state {
   switch (state) {
     case RTC_OBJC_TYPE(RTCIceConnectionStateNew):
-      return @"RTCIceConnectionStateNew";
+      return @"NEW";
     case RTC_OBJC_TYPE(RTCIceConnectionStateChecking):
-      return @"RTCIceConnectionStateChecking";
+      return @"CHECKING";
     case RTC_OBJC_TYPE(RTCIceConnectionStateConnected):
-      return @"RTCIceConnectionStateConnected";
+      return @"CONNECTED";
     case RTC_OBJC_TYPE(RTCIceConnectionStateCompleted):
-      return @"RTCIceConnectionStateCompleted";
+      return @"COMPLETED";
     case RTC_OBJC_TYPE(RTCIceConnectionStateFailed):
-      return @"RTCIceConnectionStateFailed";
+      return @"FAILED";
     case RTC_OBJC_TYPE(RTCIceConnectionStateDisconnected):
-      return @"RTCIceConnectionStateDisconnected";
+      return @"DISCONNECTED";
     case RTC_OBJC_TYPE(RTCIceConnectionStateClosed):
-      return @"RTCIceConnectionStateClosed";
+      return @"CLOSED";
     case RTC_OBJC_TYPE(RTCIceConnectionStateCount):
-      return @"RTCIceConnectionStateCount";
+      return @"COUNT";
   }
 }
 
@@ -913,11 +905,11 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
 + (NSString *)stringForIceGatheringState:(RTC_OBJC_TYPE(RTCIceGatheringState))state {
   switch (state) {
     case RTC_OBJC_TYPE(RTCIceGatheringStateNew):
-      return @"RTCIceGatheringStateNew";
+      return @"NEW";
     case RTC_OBJC_TYPE(RTCIceGatheringStateGathering):
-      return @"RTCIceGatheringStateGathering";
+      return @"GATHERING";
     case RTC_OBJC_TYPE(RTCIceGatheringStateComplete):
-      return @"RTCIceGatheringStateComplete";
+      return @"COMPLETE";
   }
 }
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnection.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnection.mm
@@ -36,8 +36,8 @@
 #include "rtc_base/numerics/safe_conversions.h"
 #include "sdk/objc/native/api/ssl_certificate_verifier.h"
 
-NSString *const kRTCPeerConnectionErrorDomain = @"org.webrtc.RTC_OBJC_TYPE(RTCPeerConnection)";
-int const kRTCPeerConnnectionSessionDescriptionError = -1;
+NSString *const RTC_CONSTANT_TYPE(RTCPeerConnectionErrorDomain) = @"org.webrtc.RTC_OBJC_TYPE(RTCPeerConnection)";
+int const RTC_CONSTANT_TYPE(RTCPeerConnnectionSessionDescriptionError) = -1;
 
 namespace {
 
@@ -64,8 +64,8 @@ class SetSessionDescriptionObserver : public webrtc::SetLocalDescriptionObserver
     } else {
       // TODO(hta): Add handling of error.type()
       NSString *str = [NSString stringForStdString:error.message()];
-      NSError *err = [NSError errorWithDomain:kRTCPeerConnectionErrorDomain
-                                         code:kRTCPeerConnnectionSessionDescriptionError
+      NSError *err = [NSError errorWithDomain:RTC_CONSTANT_TYPE(RTCPeerConnectionErrorDomain)
+                                         code:RTC_CONSTANT_TYPE(RTCPeerConnnectionSessionDescriptionError)
                                      userInfo:@{NSLocalizedDescriptionKey : str}];
       completion_handler_(err);
     }
@@ -103,8 +103,8 @@ class CreateSessionDescriptionObserverAdapter
     // TODO(hta): Add handling of error.type()
     NSString *str = [NSString stringForStdString:error.message()];
     NSError* err =
-        [NSError errorWithDomain:kRTCPeerConnectionErrorDomain
-                            code:kRTCPeerConnnectionSessionDescriptionError
+        [NSError errorWithDomain:RTC_CONSTANT_TYPE(RTCPeerConnectionErrorDomain)
+                            code:RTC_CONSTANT_TYPE(RTCPeerConnnectionSessionDescriptionError)
                         userInfo:@{ NSLocalizedDescriptionKey : str }];
     completion_handler_(nil, err);
     completion_handler_ = nil;
@@ -460,7 +460,7 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
           completionHandler(nil);
         } else {
           NSString *str = [NSString stringForStdString:error.message()];
-          NSError *err = [NSError errorWithDomain:kRTCPeerConnectionErrorDomain
+          NSError *err = [NSError errorWithDomain:RTC_CONSTANT_TYPE(RTCPeerConnectionErrorDomain)
                                              code:static_cast<NSInteger>(error.type())
                                          userInfo:@{NSLocalizedDescriptionKey : str}];
           completionHandler(err);

--- a/sdk/objc/api/peerconnection/RTCPeerConnection.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnection.mm
@@ -126,7 +126,7 @@ PeerConnectionDelegateAdapter::~PeerConnectionDelegateAdapter() {
 
 void PeerConnectionDelegateAdapter::OnSignalingChange(
     PeerConnectionInterface::SignalingState new_state) {
-  RTCSignalingState state =
+  RTC_OBJC_TYPE(RTCSignalingState) state =
       [[RTC_OBJC_TYPE(RTCPeerConnection) class] signalingStateForNativeState:new_state];
   RTC_OBJC_TYPE(RTCPeerConnection) *peer_connection = peer_connection_;
   [peer_connection.delegate peerConnection:peer_connection
@@ -184,7 +184,7 @@ void PeerConnectionDelegateAdapter::OnRenegotiationNeeded() {
 
 void PeerConnectionDelegateAdapter::OnIceConnectionChange(
     PeerConnectionInterface::IceConnectionState new_state) {
-  RTCIceConnectionState state =
+  RTC_OBJC_TYPE(RTCIceConnectionState) state =
       [RTC_OBJC_TYPE(RTCPeerConnection) iceConnectionStateForNativeState:new_state];
   [peer_connection_.delegate peerConnection:peer_connection_ didChangeIceConnectionState:state];
 }
@@ -193,7 +193,7 @@ void PeerConnectionDelegateAdapter::OnStandardizedIceConnectionChange(
     PeerConnectionInterface::IceConnectionState new_state) {
   if ([peer_connection_.delegate
           respondsToSelector:@selector(peerConnection:didChangeStandardizedIceConnectionState:)]) {
-    RTCIceConnectionState state =
+    RTC_OBJC_TYPE(RTCIceConnectionState) state =
         [RTC_OBJC_TYPE(RTCPeerConnection) iceConnectionStateForNativeState:new_state];
     [peer_connection_.delegate peerConnection:peer_connection_
         didChangeStandardizedIceConnectionState:state];
@@ -204,7 +204,7 @@ void PeerConnectionDelegateAdapter::OnConnectionChange(
     PeerConnectionInterface::PeerConnectionState new_state) {
   if ([peer_connection_.delegate
           respondsToSelector:@selector(peerConnection:didChangeConnectionState:)]) {
-    RTCPeerConnectionState state =
+    RTC_OBJC_TYPE(RTCPeerConnectionState) state =
         [RTC_OBJC_TYPE(RTCPeerConnection) connectionStateForNativeState:new_state];
     [peer_connection_.delegate peerConnection:peer_connection_ didChangeConnectionState:state];
   }
@@ -212,7 +212,7 @@ void PeerConnectionDelegateAdapter::OnConnectionChange(
 
 void PeerConnectionDelegateAdapter::OnIceGatheringChange(
     PeerConnectionInterface::IceGatheringState new_state) {
-  RTCIceGatheringState state =
+  RTC_OBJC_TYPE(RTCIceGatheringState) state =
       [[RTC_OBJC_TYPE(RTCPeerConnection) class] iceGatheringStateForNativeState:new_state];
   RTC_OBJC_TYPE(RTCPeerConnection) *peer_connection = peer_connection_;
   [peer_connection.delegate peerConnection:peer_connection
@@ -409,23 +409,22 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
   });
 }
 
-- (RTCSignalingState)signalingState {
+- (RTC_OBJC_TYPE(RTCSignalingState))signalingState {
+  return [[self class] signalingStateForNativeState:self.nativePeerConnection->signaling_state()];
+}
+
+- (RTC_OBJC_TYPE(RTCIceConnectionState))iceConnectionState {
   return [[self class]
-      signalingStateForNativeState:_peerConnection->signaling_state()];
+      iceConnectionStateForNativeState:self.nativePeerConnection->ice_connection_state()];
 }
 
-- (RTCIceConnectionState)iceConnectionState {
-  return [[self class] iceConnectionStateForNativeState:
-      _peerConnection->ice_connection_state()];
+- (RTC_OBJC_TYPE(RTCPeerConnectionState))connectionState {
+  return [[self class] connectionStateForNativeState:self.nativePeerConnection->peer_connection_state()];
 }
 
-- (RTCPeerConnectionState)connectionState {
-  return [[self class] connectionStateForNativeState:_peerConnection->peer_connection_state()];
-}
-
-- (RTCIceGatheringState)iceGatheringState {
-  return [[self class] iceGatheringStateForNativeState:
-      _peerConnection->ice_gathering_state()];
+- (RTC_OBJC_TYPE(RTCIceGatheringState))iceGatheringState {
+  return [[self class]
+      iceGatheringStateForNativeState:self.nativePeerConnection->ice_gathering_state()];
 }
 
 - (BOOL)setConfiguration:(RTC_OBJC_TYPE(RTCConfiguration) *)configuration {
@@ -544,13 +543,14 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
       nativeRtpTransceiver:nativeTransceiverOrError.MoveValue()];
 }
 
-- (nullable RTC_OBJC_TYPE(RTCRtpTransceiver) *)addTransceiverOfType:(RTCRtpMediaType)mediaType {
+- (nullable RTC_OBJC_TYPE(RTCRtpTransceiver) *)addTransceiverOfType:
+    (RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
   return [self addTransceiverOfType:mediaType
                                init:[[RTC_OBJC_TYPE(RTCRtpTransceiverInit) alloc] init]];
 }
 
 - (nullable RTC_OBJC_TYPE(RTCRtpTransceiver) *)
-    addTransceiverOfType:(RTCRtpMediaType)mediaType
+    addTransceiverOfType:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType
                     init:(RTC_OBJC_TYPE(RTCRtpTransceiverInit) *)init {
   webrtc::RTCErrorOr<rtc::scoped_refptr<webrtc::RtpTransceiverInterface>> nativeTransceiverOrError =
       _peerConnection->AddTransceiver(
@@ -712,217 +712,221 @@ void PeerConnectionDelegateAdapter::OnRemoveTrack(
 #pragma mark - Private
 
 + (webrtc::PeerConnectionInterface::SignalingState)nativeSignalingStateForState:
-    (RTCSignalingState)state {
+    (RTC_OBJC_TYPE(RTCSignalingState))state {
   switch (state) {
-    case RTCSignalingStateStable:
+    case RTC_OBJC_TYPE(RTCSignalingStateStable):
       return webrtc::PeerConnectionInterface::kStable;
-    case RTCSignalingStateHaveLocalOffer:
+    case RTC_OBJC_TYPE(RTCSignalingStateHaveLocalOffer):
       return webrtc::PeerConnectionInterface::kHaveLocalOffer;
-    case RTCSignalingStateHaveLocalPrAnswer:
+    case RTC_OBJC_TYPE(RTCSignalingStateHaveLocalPrAnswer):
       return webrtc::PeerConnectionInterface::kHaveLocalPrAnswer;
-    case RTCSignalingStateHaveRemoteOffer:
+    case RTC_OBJC_TYPE(RTCSignalingStateHaveRemoteOffer):
       return webrtc::PeerConnectionInterface::kHaveRemoteOffer;
-    case RTCSignalingStateHaveRemotePrAnswer:
+    case RTC_OBJC_TYPE(RTCSignalingStateHaveRemotePrAnswer):
       return webrtc::PeerConnectionInterface::kHaveRemotePrAnswer;
-    case RTCSignalingStateClosed:
+    case RTC_OBJC_TYPE(RTCSignalingStateClosed):
       return webrtc::PeerConnectionInterface::kClosed;
   }
 }
 
-+ (RTCSignalingState)signalingStateForNativeState:
++ (RTC_OBJC_TYPE(RTCSignalingState))signalingStateForNativeState:
     (webrtc::PeerConnectionInterface::SignalingState)nativeState {
   switch (nativeState) {
     case webrtc::PeerConnectionInterface::kStable:
-      return RTCSignalingStateStable;
+      return RTC_OBJC_TYPE(RTCSignalingStateStable);
     case webrtc::PeerConnectionInterface::kHaveLocalOffer:
-      return RTCSignalingStateHaveLocalOffer;
+      return RTC_OBJC_TYPE(RTCSignalingStateHaveLocalOffer);
     case webrtc::PeerConnectionInterface::kHaveLocalPrAnswer:
-      return RTCSignalingStateHaveLocalPrAnswer;
+      return RTC_OBJC_TYPE(RTCSignalingStateHaveLocalPrAnswer);
     case webrtc::PeerConnectionInterface::kHaveRemoteOffer:
-      return RTCSignalingStateHaveRemoteOffer;
+      return RTC_OBJC_TYPE(RTCSignalingStateHaveRemoteOffer);
     case webrtc::PeerConnectionInterface::kHaveRemotePrAnswer:
-      return RTCSignalingStateHaveRemotePrAnswer;
+      return RTC_OBJC_TYPE(RTCSignalingStateHaveRemotePrAnswer);
     case webrtc::PeerConnectionInterface::kClosed:
-      return RTCSignalingStateClosed;
+      return RTC_OBJC_TYPE(RTCSignalingStateClosed);
   }
 }
 
-+ (NSString *)stringForSignalingState:(RTCSignalingState)state {
++ (NSString *)stringForSignalingState:(RTC_OBJC_TYPE(RTCSignalingState))state {
   switch (state) {
-    case RTCSignalingStateStable:
-      return @"STABLE";
-    case RTCSignalingStateHaveLocalOffer:
-      return @"HAVE_LOCAL_OFFER";
-    case RTCSignalingStateHaveLocalPrAnswer:
-      return @"HAVE_LOCAL_PRANSWER";
-    case RTCSignalingStateHaveRemoteOffer:
-      return @"HAVE_REMOTE_OFFER";
-    case RTCSignalingStateHaveRemotePrAnswer:
-      return @"HAVE_REMOTE_PRANSWER";
-    case RTCSignalingStateClosed:
-      return @"CLOSED";
+    case RTC_OBJC_TYPE(RTCSignalingStateStable):
+      return @"RTCSignalingStateStable";
+    case RTC_OBJC_TYPE(RTCSignalingStateHaveLocalOffer):
+      return @"RTCSignalingStateHaveLocalOffer";
+    case RTC_OBJC_TYPE(RTCSignalingStateHaveLocalPrAnswer):
+      return @"RTCSignalingStateHaveLocalPrAnswer";
+    case RTC_OBJC_TYPE(RTCSignalingStateHaveRemoteOffer):
+      return @"RTCSignalingStateHaveRemoteOffer";
+    case RTC_OBJC_TYPE(RTCSignalingStateHaveRemotePrAnswer):
+      return @"RTCSignalingStateHaveRemotePrAnswer";
+    case RTC_OBJC_TYPE(RTCSignalingStateClosed):
+      return @"RTCSignalingStateClosed";
   }
 }
 
 + (webrtc::PeerConnectionInterface::PeerConnectionState)nativeConnectionStateForState:
-        (RTCPeerConnectionState)state {
+        (RTC_OBJC_TYPE(RTCPeerConnectionState))state {
   switch (state) {
-    case RTCPeerConnectionStateNew:
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateNew):
       return webrtc::PeerConnectionInterface::PeerConnectionState::kNew;
-    case RTCPeerConnectionStateConnecting:
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateConnecting):
       return webrtc::PeerConnectionInterface::PeerConnectionState::kConnecting;
-    case RTCPeerConnectionStateConnected:
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateConnected):
       return webrtc::PeerConnectionInterface::PeerConnectionState::kConnected;
-    case RTCPeerConnectionStateFailed:
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateFailed):
       return webrtc::PeerConnectionInterface::PeerConnectionState::kFailed;
-    case RTCPeerConnectionStateDisconnected:
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateDisconnected):
       return webrtc::PeerConnectionInterface::PeerConnectionState::kDisconnected;
-    case RTCPeerConnectionStateClosed:
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateClosed):
       return webrtc::PeerConnectionInterface::PeerConnectionState::kClosed;
   }
 }
 
-+ (RTCPeerConnectionState)connectionStateForNativeState:
++ (RTC_OBJC_TYPE(RTCPeerConnectionState))connectionStateForNativeState:
         (webrtc::PeerConnectionInterface::PeerConnectionState)nativeState {
   switch (nativeState) {
     case webrtc::PeerConnectionInterface::PeerConnectionState::kNew:
-      return RTCPeerConnectionStateNew;
+      return RTC_OBJC_TYPE(RTCPeerConnectionStateNew);
     case webrtc::PeerConnectionInterface::PeerConnectionState::kConnecting:
-      return RTCPeerConnectionStateConnecting;
+      return RTC_OBJC_TYPE(RTCPeerConnectionStateConnecting);
     case webrtc::PeerConnectionInterface::PeerConnectionState::kConnected:
-      return RTCPeerConnectionStateConnected;
+      return RTC_OBJC_TYPE(RTCPeerConnectionStateConnected);
     case webrtc::PeerConnectionInterface::PeerConnectionState::kFailed:
-      return RTCPeerConnectionStateFailed;
+      return RTC_OBJC_TYPE(RTCPeerConnectionStateFailed);
     case webrtc::PeerConnectionInterface::PeerConnectionState::kDisconnected:
-      return RTCPeerConnectionStateDisconnected;
+      return RTC_OBJC_TYPE(RTCPeerConnectionStateDisconnected);
     case webrtc::PeerConnectionInterface::PeerConnectionState::kClosed:
-      return RTCPeerConnectionStateClosed;
+      return RTC_OBJC_TYPE(RTCPeerConnectionStateClosed);
   }
 }
 
-+ (NSString *)stringForConnectionState:(RTCPeerConnectionState)state {
++ (NSString *)stringForConnectionState:(RTC_OBJC_TYPE(RTCPeerConnectionState))state {
   switch (state) {
-    case RTCPeerConnectionStateNew:
-      return @"NEW";
-    case RTCPeerConnectionStateConnecting:
-      return @"CONNECTING";
-    case RTCPeerConnectionStateConnected:
-      return @"CONNECTED";
-    case RTCPeerConnectionStateFailed:
-      return @"FAILED";
-    case RTCPeerConnectionStateDisconnected:
-      return @"DISCONNECTED";
-    case RTCPeerConnectionStateClosed:
-      return @"CLOSED";
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateNew):
+      return @"RTCPeerConnectionStateNew";
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateConnecting):
+      return @"RTCPeerConnectionStateConnecting";
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateConnected):
+      return @"RTCPeerConnectionStateConnected";
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateFailed):
+      return @"RTCPeerConnectionStateFailed";
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateDisconnected):
+      return @"RTCPeerConnectionStateDisconnected";
+    case RTC_OBJC_TYPE(RTCPeerConnectionStateClosed):
+      return @"RTCPeerConnectionStateClosed";
   }
 }
 
 + (webrtc::PeerConnectionInterface::IceConnectionState)
-    nativeIceConnectionStateForState:(RTCIceConnectionState)state {
+    nativeIceConnectionStateForState:(RTC_OBJC_TYPE(RTCIceConnectionState))state {
   switch (state) {
-    case RTCIceConnectionStateNew:
+    case RTC_OBJC_TYPE(RTCIceConnectionStateNew):
       return webrtc::PeerConnectionInterface::kIceConnectionNew;
-    case RTCIceConnectionStateChecking:
+    case RTC_OBJC_TYPE(RTCIceConnectionStateChecking):
       return webrtc::PeerConnectionInterface::kIceConnectionChecking;
-    case RTCIceConnectionStateConnected:
+    case RTC_OBJC_TYPE(RTCIceConnectionStateConnected):
       return webrtc::PeerConnectionInterface::kIceConnectionConnected;
-    case RTCIceConnectionStateCompleted:
+    case RTC_OBJC_TYPE(RTCIceConnectionStateCompleted):
       return webrtc::PeerConnectionInterface::kIceConnectionCompleted;
-    case RTCIceConnectionStateFailed:
+    case RTC_OBJC_TYPE(RTCIceConnectionStateFailed):
       return webrtc::PeerConnectionInterface::kIceConnectionFailed;
-    case RTCIceConnectionStateDisconnected:
+    case RTC_OBJC_TYPE(RTCIceConnectionStateDisconnected):
       return webrtc::PeerConnectionInterface::kIceConnectionDisconnected;
-    case RTCIceConnectionStateClosed:
+    case RTC_OBJC_TYPE(RTCIceConnectionStateClosed):
       return webrtc::PeerConnectionInterface::kIceConnectionClosed;
-    case RTCIceConnectionStateCount:
-      return webrtc::PeerConnectionInterface::kIceConnectionMax;
+    case RTC_OBJC_TYPE(RTCIceConnectionStateCount):
+      // This is not a real state, just used for counting.
+      RTCLogError(@"Attempting to convert RTCIceConnectionStateCount to native state");
+      return webrtc::PeerConnectionInterface::kIceConnectionNew;
   }
 }
 
-+ (RTCIceConnectionState)iceConnectionStateForNativeState:
++ (RTC_OBJC_TYPE(RTCIceConnectionState))iceConnectionStateForNativeState:
     (webrtc::PeerConnectionInterface::IceConnectionState)nativeState {
   switch (nativeState) {
     case webrtc::PeerConnectionInterface::kIceConnectionNew:
-      return RTCIceConnectionStateNew;
+      return RTC_OBJC_TYPE(RTCIceConnectionStateNew);
     case webrtc::PeerConnectionInterface::kIceConnectionChecking:
-      return RTCIceConnectionStateChecking;
+      return RTC_OBJC_TYPE(RTCIceConnectionStateChecking);
     case webrtc::PeerConnectionInterface::kIceConnectionConnected:
-      return RTCIceConnectionStateConnected;
+      return RTC_OBJC_TYPE(RTCIceConnectionStateConnected);
     case webrtc::PeerConnectionInterface::kIceConnectionCompleted:
-      return RTCIceConnectionStateCompleted;
+      return RTC_OBJC_TYPE(RTCIceConnectionStateCompleted);
     case webrtc::PeerConnectionInterface::kIceConnectionFailed:
-      return RTCIceConnectionStateFailed;
+      return RTC_OBJC_TYPE(RTCIceConnectionStateFailed);
     case webrtc::PeerConnectionInterface::kIceConnectionDisconnected:
-      return RTCIceConnectionStateDisconnected;
+      return RTC_OBJC_TYPE(RTCIceConnectionStateDisconnected);
     case webrtc::PeerConnectionInterface::kIceConnectionClosed:
-      return RTCIceConnectionStateClosed;
+      return RTC_OBJC_TYPE(RTCIceConnectionStateClosed);
     case webrtc::PeerConnectionInterface::kIceConnectionMax:
-      return RTCIceConnectionStateCount;
+      // This is not a real state, just used for counting.
+      RTCLogError(@"Attempting to convert kIceConnectionMax to RTCIceConnectionState");
+      return RTC_OBJC_TYPE(RTCIceConnectionStateCount);
   }
 }
 
-+ (NSString *)stringForIceConnectionState:(RTCIceConnectionState)state {
++ (NSString *)stringForIceConnectionState:(RTC_OBJC_TYPE(RTCIceConnectionState))state {
   switch (state) {
-    case RTCIceConnectionStateNew:
-      return @"NEW";
-    case RTCIceConnectionStateChecking:
-      return @"CHECKING";
-    case RTCIceConnectionStateConnected:
-      return @"CONNECTED";
-    case RTCIceConnectionStateCompleted:
-      return @"COMPLETED";
-    case RTCIceConnectionStateFailed:
-      return @"FAILED";
-    case RTCIceConnectionStateDisconnected:
-      return @"DISCONNECTED";
-    case RTCIceConnectionStateClosed:
-      return @"CLOSED";
-    case RTCIceConnectionStateCount:
-      return @"COUNT";
+    case RTC_OBJC_TYPE(RTCIceConnectionStateNew):
+      return @"RTCIceConnectionStateNew";
+    case RTC_OBJC_TYPE(RTCIceConnectionStateChecking):
+      return @"RTCIceConnectionStateChecking";
+    case RTC_OBJC_TYPE(RTCIceConnectionStateConnected):
+      return @"RTCIceConnectionStateConnected";
+    case RTC_OBJC_TYPE(RTCIceConnectionStateCompleted):
+      return @"RTCIceConnectionStateCompleted";
+    case RTC_OBJC_TYPE(RTCIceConnectionStateFailed):
+      return @"RTCIceConnectionStateFailed";
+    case RTC_OBJC_TYPE(RTCIceConnectionStateDisconnected):
+      return @"RTCIceConnectionStateDisconnected";
+    case RTC_OBJC_TYPE(RTCIceConnectionStateClosed):
+      return @"RTCIceConnectionStateClosed";
+    case RTC_OBJC_TYPE(RTCIceConnectionStateCount):
+      return @"RTCIceConnectionStateCount";
   }
 }
 
 + (webrtc::PeerConnectionInterface::IceGatheringState)
-    nativeIceGatheringStateForState:(RTCIceGatheringState)state {
+    nativeIceGatheringStateForState:(RTC_OBJC_TYPE(RTCIceGatheringState))state {
   switch (state) {
-    case RTCIceGatheringStateNew:
+    case RTC_OBJC_TYPE(RTCIceGatheringStateNew):
       return webrtc::PeerConnectionInterface::kIceGatheringNew;
-    case RTCIceGatheringStateGathering:
+    case RTC_OBJC_TYPE(RTCIceGatheringStateGathering):
       return webrtc::PeerConnectionInterface::kIceGatheringGathering;
-    case RTCIceGatheringStateComplete:
+    case RTC_OBJC_TYPE(RTCIceGatheringStateComplete):
       return webrtc::PeerConnectionInterface::kIceGatheringComplete;
   }
 }
 
-+ (RTCIceGatheringState)iceGatheringStateForNativeState:
++ (RTC_OBJC_TYPE(RTCIceGatheringState))iceGatheringStateForNativeState:
     (webrtc::PeerConnectionInterface::IceGatheringState)nativeState {
   switch (nativeState) {
     case webrtc::PeerConnectionInterface::kIceGatheringNew:
-      return RTCIceGatheringStateNew;
+      return RTC_OBJC_TYPE(RTCIceGatheringStateNew);
     case webrtc::PeerConnectionInterface::kIceGatheringGathering:
-      return RTCIceGatheringStateGathering;
+      return RTC_OBJC_TYPE(RTCIceGatheringStateGathering);
     case webrtc::PeerConnectionInterface::kIceGatheringComplete:
-      return RTCIceGatheringStateComplete;
+      return RTC_OBJC_TYPE(RTCIceGatheringStateComplete);
   }
 }
 
-+ (NSString *)stringForIceGatheringState:(RTCIceGatheringState)state {
++ (NSString *)stringForIceGatheringState:(RTC_OBJC_TYPE(RTCIceGatheringState))state {
   switch (state) {
-    case RTCIceGatheringStateNew:
-      return @"NEW";
-    case RTCIceGatheringStateGathering:
-      return @"GATHERING";
-    case RTCIceGatheringStateComplete:
-      return @"COMPLETE";
+    case RTC_OBJC_TYPE(RTCIceGatheringStateNew):
+      return @"RTCIceGatheringStateNew";
+    case RTC_OBJC_TYPE(RTCIceGatheringStateGathering):
+      return @"RTCIceGatheringStateGathering";
+    case RTC_OBJC_TYPE(RTCIceGatheringStateComplete):
+      return @"RTCIceGatheringStateComplete";
   }
 }
 
 + (webrtc::PeerConnectionInterface::StatsOutputLevel)
-    nativeStatsOutputLevelForLevel:(RTCStatsOutputLevel)level {
+    nativeStatsOutputLevelForLevel:(RTC_OBJC_TYPE(RTCStatsOutputLevel))level {
   switch (level) {
-    case RTCStatsOutputLevelStandard:
+    case RTC_OBJC_TYPE(RTCStatsOutputLevelStandard):
       return webrtc::PeerConnectionInterface::kStatsOutputLevelStandard;
-    case RTCStatsOutputLevelDebug:
+    case RTC_OBJC_TYPE(RTCStatsOutputLevelDebug):
       return webrtc::PeerConnectionInterface::kStatsOutputLevelDebug;
   }
 }

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory+Native.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory+Native.h
@@ -9,7 +9,6 @@
  */
 
 #import "RTCPeerConnectionFactory.h"
-#import "RTCAudioDeviceModule.h"
 
 #include "api/scoped_refptr.h"
 
@@ -49,14 +48,26 @@ NS_ASSUME_NONNULL_BEGIN
                         nativeVideoDecoderFactory:
                             (std::unique_ptr<webrtc::VideoDecoderFactory>)videoDecoderFactory
                                 audioDeviceModule:
-                                    (rtc::scoped_refptr<webrtc::AudioDeviceModule>)audioDeviceModule
+                                    (nullable webrtc::AudioDeviceModule *)audioDeviceModule
                             audioProcessingModule:
                                 (rtc::scoped_refptr<webrtc::AudioProcessing>)audioProcessingModule
-                         networkControllerFactory:
-                             (std::unique_ptr<webrtc::NetworkControllerFactoryInterface>)
-                                 networkControllerFactory
-                            audioDeviceModuleType:(RTC_OBJC_TYPE(RTCAudioDeviceModuleType))audioDeviceModuleType
                             bypassVoiceProcessing:(BOOL)bypassVoiceProcessing;
+
+- (instancetype)
+    initWithNativeAudioEncoderFactory:
+        (rtc::scoped_refptr<webrtc::AudioEncoderFactory>)audioEncoderFactory
+            nativeAudioDecoderFactory:
+                (rtc::scoped_refptr<webrtc::AudioDecoderFactory>)audioDecoderFactory
+            nativeVideoEncoderFactory:
+                (std::unique_ptr<webrtc::VideoEncoderFactory>)videoEncoderFactory
+            nativeVideoDecoderFactory:
+                (std::unique_ptr<webrtc::VideoDecoderFactory>)videoDecoderFactory
+                    audioDeviceModule:(nullable webrtc::AudioDeviceModule *)audioDeviceModule
+                audioProcessingModule:
+                    (rtc::scoped_refptr<webrtc::AudioProcessing>)audioProcessingModule
+             networkControllerFactory:(std::unique_ptr<webrtc::NetworkControllerFactoryInterface>)
+                                          networkControllerFactory
+                bypassVoiceProcessing:(BOOL)bypassVoiceProcessing;
 
 - (instancetype)
     initWithEncoderFactory:(nullable id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)>)encoderFactory

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory+Native.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory+Native.h
@@ -9,6 +9,7 @@
  */
 
 #import "RTCPeerConnectionFactory.h"
+#import "RTCAudioDeviceModule.h"
 
 #include "api/scoped_refptr.h"
 
@@ -48,26 +49,14 @@ NS_ASSUME_NONNULL_BEGIN
                         nativeVideoDecoderFactory:
                             (std::unique_ptr<webrtc::VideoDecoderFactory>)videoDecoderFactory
                                 audioDeviceModule:
-                                    (nullable webrtc::AudioDeviceModule *)audioDeviceModule
+                                    (rtc::scoped_refptr<webrtc::AudioDeviceModule>)audioDeviceModule
                             audioProcessingModule:
                                 (rtc::scoped_refptr<webrtc::AudioProcessing>)audioProcessingModule
+                         networkControllerFactory:
+                             (std::unique_ptr<webrtc::NetworkControllerFactoryInterface>)
+                                 networkControllerFactory
+                            audioDeviceModuleType:(RTC_OBJC_TYPE(RTCAudioDeviceModuleType))audioDeviceModuleType
                             bypassVoiceProcessing:(BOOL)bypassVoiceProcessing;
-
-- (instancetype)
-    initWithNativeAudioEncoderFactory:
-        (rtc::scoped_refptr<webrtc::AudioEncoderFactory>)audioEncoderFactory
-            nativeAudioDecoderFactory:
-                (rtc::scoped_refptr<webrtc::AudioDecoderFactory>)audioDecoderFactory
-            nativeVideoEncoderFactory:
-                (std::unique_ptr<webrtc::VideoEncoderFactory>)videoEncoderFactory
-            nativeVideoDecoderFactory:
-                (std::unique_ptr<webrtc::VideoDecoderFactory>)videoDecoderFactory
-                    audioDeviceModule:(nullable webrtc::AudioDeviceModule *)audioDeviceModule
-                audioProcessingModule:
-                    (rtc::scoped_refptr<webrtc::AudioProcessing>)audioProcessingModule
-             networkControllerFactory:(std::unique_ptr<webrtc::NetworkControllerFactoryInterface>)
-                                          networkControllerFactory
-                bypassVoiceProcessing:(BOOL)bypassVoiceProcessing;
 
 - (instancetype)
     initWithEncoderFactory:(nullable id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)>)encoderFactory

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
@@ -11,6 +11,7 @@
 #import <Foundation/Foundation.h>
 
 #import "RTCMacros.h"
+#import "RTCAudioDeviceModule.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -61,7 +62,8 @@ RTC_OBJC_EXPORT
 
 /* Initialize object with bypass voice processing */
 - (instancetype)
-    initWithBypassVoiceProcessing:(BOOL)bypassVoiceProcessing
+    initWithAudioDeviceModuleType:(RTC_OBJC_TYPE(RTCAudioDeviceModuleType))audioDeviceModuleType
+            bypassVoiceProcessing:(BOOL)bypassVoiceProcessing
                    encoderFactory:(nullable id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)>)encoderFactory
                    decoderFactory:(nullable id<RTC_OBJC_TYPE(RTCVideoDecoderFactory)>)decoderFactory
             audioProcessingModule:

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class RTC_OBJC_TYPE(RTCAudioDeviceModule);
 @class RTC_OBJC_TYPE(RTCRtpCapabilities);
 
-typedef NS_ENUM(NSInteger, RTCRtpMediaType);
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtpMediaType));
 
 @protocol RTC_OBJC_TYPE
 (RTCPeerConnectionDelegate);

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
@@ -11,7 +11,6 @@
 #import <Foundation/Foundation.h>
 
 #import "RTCMacros.h"
-#import "RTCAudioDeviceModule.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class RTC_OBJC_TYPE(RTCAudioDeviceModule);
 @class RTC_OBJC_TYPE(RTCRtpCapabilities);
 
-typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtpMediaType));
+typedef NS_ENUM(NSInteger, RTCRtpMediaType);
 
 @protocol RTC_OBJC_TYPE
 (RTCPeerConnectionDelegate);
@@ -62,8 +61,7 @@ RTC_OBJC_EXPORT
 
 /* Initialize object with bypass voice processing */
 - (instancetype)
-    initWithAudioDeviceModuleType:(RTC_OBJC_TYPE(RTCAudioDeviceModuleType))audioDeviceModuleType
-            bypassVoiceProcessing:(BOOL)bypassVoiceProcessing
+    initWithBypassVoiceProcessing:(BOOL)bypassVoiceProcessing
                    encoderFactory:(nullable id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)>)encoderFactory
                    decoderFactory:(nullable id<RTC_OBJC_TYPE(RTCVideoDecoderFactory)>)decoderFactory
             audioProcessingModule:

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -441,9 +441,9 @@
 #pragma mark - Private
 
 + (cricket::MediaType)mediaTypeForKind:(NSString *)kind {
-  if (kind == kRTCMediaStreamTrackKindAudio) {
+  if (kind == RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindAudio)) {
     return cricket::MEDIA_TYPE_AUDIO;
-  } else if (kind == kRTCMediaStreamTrackKindVideo) {
+  } else if (kind == RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindVideo)) {
     return cricket::MEDIA_TYPE_VIDEO;
   } else {
     RTC_DCHECK_NOTREACHED();

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -47,6 +47,7 @@
 #import "components/video_codec/RTCVideoEncoderFactoryH264.h"
 #include "media/base/media_constants.h"
 #include "modules/audio_device/include/audio_device.h"
+#include "modules/audio_device/audio_engine_device.h"
 #include "modules/audio_processing/include/audio_processing.h"
 
 #include "sdk/objc/native/api/objc_audio_device_module.h"
@@ -75,14 +76,6 @@
 @synthesize nativeFactory = _nativeFactory;
 @synthesize audioDeviceModule = _audioDeviceModule;
 
-- (rtc::scoped_refptr<webrtc::AudioDeviceModule>)createAudioDeviceModule:(BOOL)bypassVoiceProcessing {
-#if defined(WEBRTC_IOS)
-  return webrtc::CreateAudioDeviceModule(bypassVoiceProcessing);
-#else
-  return nullptr;
-#endif
-}
-
 - (instancetype)init {
   return [self
       initWithNativeAudioEncoderFactory:webrtc::CreateBuiltinAudioEncoderFactory()
@@ -91,8 +84,10 @@
                                             RTCVideoEncoderFactoryH264) alloc] init])
               nativeVideoDecoderFactory:webrtc::ObjCToNativeVideoDecoderFactory([[RTC_OBJC_TYPE(
                                             RTCVideoDecoderFactoryH264) alloc] init])
-                      audioDeviceModule:[self createAudioDeviceModule:NO].get()
+                      audioDeviceModule:nullptr
                   audioProcessingModule:nullptr
+               networkControllerFactory:nullptr
+                  audioDeviceModuleType:RTC_OBJC_TYPE(RTCAudioDeviceModuleTypePlatformDefault)
                   bypassVoiceProcessing:NO];
 }
 
@@ -119,28 +114,30 @@
   }
   rtc::scoped_refptr<webrtc::AudioDeviceModule> audio_device_module;
   if (audioDevice) {
+    // TODO: Should be created on worker thread ?
     audio_device_module = webrtc::CreateAudioDeviceModule(audioDevice);
-  } else {
-    audio_device_module = [self createAudioDeviceModule:NO];
   }
+
   return [self initWithNativeAudioEncoderFactory:webrtc::CreateBuiltinAudioEncoderFactory()
                        nativeAudioDecoderFactory:webrtc::CreateBuiltinAudioDecoderFactory()
                        nativeVideoEncoderFactory:std::move(native_encoder_factory)
                        nativeVideoDecoderFactory:std::move(native_decoder_factory)
-                               audioDeviceModule:audio_device_module.get()
+                               audioDeviceModule:audio_device_module
                            audioProcessingModule:nullptr
+                        networkControllerFactory:nullptr
+                           audioDeviceModuleType:RTC_OBJC_TYPE(RTCAudioDeviceModuleTypePlatformDefault)
                            bypassVoiceProcessing:NO];
 #endif
 }
 
-- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpSenderCapabilitiesFor:(RTCRtpMediaType)mediaType {
+- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpSenderCapabilitiesFor:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
 
   webrtc::RtpCapabilities capabilities = _nativeFactory->GetRtpSenderCapabilities([RTC_OBJC_TYPE(RTCRtpReceiver) nativeMediaTypeForMediaType: mediaType]);
 
   return [[RTC_OBJC_TYPE(RTCRtpCapabilities) alloc] initWithNativeRtpCapabilities:capabilities];
 }
 
-- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpReceiverCapabilitiesFor:(RTCRtpMediaType)mediaType {
+- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpReceiverCapabilitiesFor:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
 
   webrtc::RtpCapabilities capabilities = _nativeFactory->GetRtpReceiverCapabilities([RTC_OBJC_TYPE(RTCRtpReceiver) nativeMediaTypeForMediaType: mediaType]);
 
@@ -148,7 +145,8 @@
 }
 
 - (instancetype)
-    initWithBypassVoiceProcessing:(BOOL)bypassVoiceProcessing
+    initWithAudioDeviceModuleType:(RTC_OBJC_TYPE(RTCAudioDeviceModuleType))audioDeviceModuleType
+            bypassVoiceProcessing:(BOOL)bypassVoiceProcessing
                    encoderFactory:(nullable id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)>)encoderFactory
                    decoderFactory:(nullable id<RTC_OBJC_TYPE(RTCVideoDecoderFactory)>)decoderFactory
             audioProcessingModule:
@@ -164,7 +162,6 @@
   if (decoderFactory) {
     native_decoder_factory = webrtc::ObjCToNativeVideoDecoderFactory(decoderFactory);
   }
-  rtc::scoped_refptr<webrtc::AudioDeviceModule> audio_device_module = [self createAudioDeviceModule:bypassVoiceProcessing];
 
   if ([audioProcessingModule isKindOfClass:[RTC_OBJC_TYPE(RTCDefaultAudioProcessingModule) class]]) {
     _defaultAudioProcessingModule = (RTC_OBJC_TYPE(RTCDefaultAudioProcessingModule) *)audioProcessingModule;
@@ -172,15 +169,16 @@
     _defaultAudioProcessingModule = [[RTC_OBJC_TYPE(RTCDefaultAudioProcessingModule) alloc] init];
   }
 
-  NSLog(@"AudioProcessingModule: %@", _defaultAudioProcessingModule);
-  
-  return [self initWithNativeAudioEncoderFactory:webrtc::CreateBuiltinAudioEncoderFactory()
-                       nativeAudioDecoderFactory:webrtc::CreateBuiltinAudioDecoderFactory()
-                       nativeVideoEncoderFactory:std::move(native_encoder_factory)
-                       nativeVideoDecoderFactory:std::move(native_decoder_factory)
-                               audioDeviceModule:audio_device_module.get()
-                           audioProcessingModule:_defaultAudioProcessingModule.nativeAudioProcessingModule
-                           bypassVoiceProcessing:bypassVoiceProcessing];
+  return [self
+      initWithNativeAudioEncoderFactory:webrtc::CreateBuiltinAudioEncoderFactory()
+              nativeAudioDecoderFactory:webrtc::CreateBuiltinAudioDecoderFactory()
+              nativeVideoEncoderFactory:std::move(native_encoder_factory)
+              nativeVideoDecoderFactory:std::move(native_decoder_factory)
+                      audioDeviceModule:nullptr
+                  audioProcessingModule:_defaultAudioProcessingModule.nativeAudioProcessingModule
+               networkControllerFactory:nullptr
+                  audioDeviceModuleType:audioDeviceModuleType
+                  bypassVoiceProcessing:bypassVoiceProcessing];
 #endif
 }
 
@@ -210,9 +208,8 @@
     dependencies.network_thread = _networkThread.get();
     dependencies.worker_thread = _workerThread.get();
     dependencies.signaling_thread = _signalingThread.get();
-    if (webrtc::field_trial::IsEnabled("WebRTC-Network-UseNWPathMonitor")) {
-      dependencies.network_monitor_factory = webrtc::CreateNetworkMonitorFactory();
-    }
+    dependencies.network_monitor_factory = webrtc::CreateNetworkMonitorFactory();
+
     _nativeFactory = webrtc::CreateModularPeerConnectionFactory(std::move(dependencies));
     NSAssert(_nativeFactory, @"Failed to initialize PeerConnectionFactory!");
   }
@@ -227,55 +224,38 @@
                             (std::unique_ptr<webrtc::VideoEncoderFactory>)videoEncoderFactory
                         nativeVideoDecoderFactory:
                             (std::unique_ptr<webrtc::VideoDecoderFactory>)videoDecoderFactory
-                                audioDeviceModule:(webrtc::AudioDeviceModule *)audioDeviceModule
-                            audioProcessingModule:
-                                (rtc::scoped_refptr<webrtc::AudioProcessing>)audioProcessingModule
-                            bypassVoiceProcessing:(BOOL)bypassVoiceProcessing {
-  return [self initWithNativeAudioEncoderFactory:audioEncoderFactory
-                       nativeAudioDecoderFactory:audioDecoderFactory
-                       nativeVideoEncoderFactory:std::move(videoEncoderFactory)
-                       nativeVideoDecoderFactory:std::move(videoDecoderFactory)
-                               audioDeviceModule:audioDeviceModule
-                           audioProcessingModule:audioProcessingModule
-                        networkControllerFactory:nullptr
-                           bypassVoiceProcessing:bypassVoiceProcessing];
-}
-- (instancetype)initWithNativeAudioEncoderFactory:
-                    (rtc::scoped_refptr<webrtc::AudioEncoderFactory>)audioEncoderFactory
-                        nativeAudioDecoderFactory:
-                            (rtc::scoped_refptr<webrtc::AudioDecoderFactory>)audioDecoderFactory
-                        nativeVideoEncoderFactory:
-                            (std::unique_ptr<webrtc::VideoEncoderFactory>)videoEncoderFactory
-                        nativeVideoDecoderFactory:
-                            (std::unique_ptr<webrtc::VideoDecoderFactory>)videoDecoderFactory
-                                audioDeviceModule:(webrtc::AudioDeviceModule *)audioDeviceModule
+                                audioDeviceModule:
+                                    (rtc::scoped_refptr<webrtc::AudioDeviceModule>)audioDeviceModule
                             audioProcessingModule:
                                 (rtc::scoped_refptr<webrtc::AudioProcessing>)audioProcessingModule
                          networkControllerFactory:
                              (std::unique_ptr<webrtc::NetworkControllerFactoryInterface>)
                                  networkControllerFactory
+                            audioDeviceModuleType:(RTC_OBJC_TYPE(RTCAudioDeviceModuleType))audioDeviceModuleType
                             bypassVoiceProcessing:(BOOL)bypassVoiceProcessing {
   if (self = [self initNative]) {
     webrtc::PeerConnectionFactoryDependencies dependencies;
     dependencies.network_thread = _networkThread.get();
     dependencies.worker_thread = _workerThread.get();
     dependencies.signaling_thread = _signalingThread.get();
-    if (webrtc::field_trial::IsEnabled("WebRTC-Network-UseNWPathMonitor")) {
-      dependencies.network_monitor_factory = webrtc::CreateNetworkMonitorFactory();
-    }
+    dependencies.network_monitor_factory = webrtc::CreateNetworkMonitorFactory();
     dependencies.trials = std::make_unique<webrtc::FieldTrialBasedConfig>();
     dependencies.task_queue_factory =
         webrtc::CreateDefaultTaskQueueFactory(dependencies.trials.get());
-   
-    if(audioDeviceModule) {
-      _nativeAudioDeviceModule = std::move(audioDeviceModule);
-    } else {
-      // always create ADM on worker thread
-      _nativeAudioDeviceModule = _workerThread->BlockingCall([&dependencies, &bypassVoiceProcessing]() {
-        return webrtc::AudioDeviceModule::Create(webrtc::AudioDeviceModule::AudioLayer::kPlatformDefaultAudio,
-                                                dependencies.task_queue_factory.get(),
-                                                bypassVoiceProcessing == YES);
+
+    if (audioDeviceModule != nullptr) {
+      _nativeAudioDeviceModule = audioDeviceModule;
+    } else if (audioDeviceModuleType == RTC_OBJC_TYPE(RTCAudioDeviceModuleTypeAudioEngine)) {
+      _nativeAudioDeviceModule = _workerThread->BlockingCall([&bypassVoiceProcessing]() {
+        return rtc::make_ref_counted<webrtc::AudioEngineDevice>(bypassVoiceProcessing == YES);
       });
+    } else {
+      _nativeAudioDeviceModule =
+          _workerThread->BlockingCall([&bypassVoiceProcessing, &dependencies]() {
+            return webrtc::AudioDeviceModule::Create(
+                webrtc::AudioDeviceModule::AudioLayer::kPlatformDefaultAudio,
+                dependencies.task_queue_factory.get(), bypassVoiceProcessing == YES);
+          });
     }
 
     _audioDeviceModule = [[RTC_OBJC_TYPE(RTCAudioDeviceModule) alloc] initWithNativeModule: _nativeAudioDeviceModule

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -133,14 +133,14 @@
 #endif
 }
 
-- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpSenderCapabilitiesFor:(RTCRtpMediaType)mediaType {
+- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpSenderCapabilitiesFor:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
 
   webrtc::RtpCapabilities capabilities = _nativeFactory->GetRtpSenderCapabilities([RTC_OBJC_TYPE(RTCRtpReceiver) nativeMediaTypeForMediaType: mediaType]);
 
   return [[RTC_OBJC_TYPE(RTCRtpCapabilities) alloc] initWithNativeRtpCapabilities:capabilities];
 }
 
-- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpReceiverCapabilitiesFor:(RTCRtpMediaType)mediaType {
+- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpReceiverCapabilitiesFor:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
 
   webrtc::RtpCapabilities capabilities = _nativeFactory->GetRtpReceiverCapabilities([RTC_OBJC_TYPE(RTCRtpReceiver) nativeMediaTypeForMediaType: mediaType]);
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -47,7 +47,6 @@
 #import "components/video_codec/RTCVideoEncoderFactoryH264.h"
 #include "media/base/media_constants.h"
 #include "modules/audio_device/include/audio_device.h"
-#include "modules/audio_device/audio_engine_device.h"
 #include "modules/audio_processing/include/audio_processing.h"
 
 #include "sdk/objc/native/api/objc_audio_device_module.h"
@@ -76,6 +75,14 @@
 @synthesize nativeFactory = _nativeFactory;
 @synthesize audioDeviceModule = _audioDeviceModule;
 
+- (rtc::scoped_refptr<webrtc::AudioDeviceModule>)createAudioDeviceModule:(BOOL)bypassVoiceProcessing {
+#if defined(WEBRTC_IOS)
+  return webrtc::CreateAudioDeviceModule(bypassVoiceProcessing);
+#else
+  return nullptr;
+#endif
+}
+
 - (instancetype)init {
   return [self
       initWithNativeAudioEncoderFactory:webrtc::CreateBuiltinAudioEncoderFactory()
@@ -84,10 +91,8 @@
                                             RTCVideoEncoderFactoryH264) alloc] init])
               nativeVideoDecoderFactory:webrtc::ObjCToNativeVideoDecoderFactory([[RTC_OBJC_TYPE(
                                             RTCVideoDecoderFactoryH264) alloc] init])
-                      audioDeviceModule:nullptr
+                      audioDeviceModule:[self createAudioDeviceModule:NO].get()
                   audioProcessingModule:nullptr
-               networkControllerFactory:nullptr
-                  audioDeviceModuleType:RTC_OBJC_TYPE(RTCAudioDeviceModuleTypePlatformDefault)
                   bypassVoiceProcessing:NO];
 }
 
@@ -114,30 +119,28 @@
   }
   rtc::scoped_refptr<webrtc::AudioDeviceModule> audio_device_module;
   if (audioDevice) {
-    // TODO: Should be created on worker thread ?
     audio_device_module = webrtc::CreateAudioDeviceModule(audioDevice);
+  } else {
+    audio_device_module = [self createAudioDeviceModule:NO];
   }
-
   return [self initWithNativeAudioEncoderFactory:webrtc::CreateBuiltinAudioEncoderFactory()
                        nativeAudioDecoderFactory:webrtc::CreateBuiltinAudioDecoderFactory()
                        nativeVideoEncoderFactory:std::move(native_encoder_factory)
                        nativeVideoDecoderFactory:std::move(native_decoder_factory)
-                               audioDeviceModule:audio_device_module
+                               audioDeviceModule:audio_device_module.get()
                            audioProcessingModule:nullptr
-                        networkControllerFactory:nullptr
-                           audioDeviceModuleType:RTC_OBJC_TYPE(RTCAudioDeviceModuleTypePlatformDefault)
                            bypassVoiceProcessing:NO];
 #endif
 }
 
-- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpSenderCapabilitiesFor:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
+- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpSenderCapabilitiesFor:(RTCRtpMediaType)mediaType {
 
   webrtc::RtpCapabilities capabilities = _nativeFactory->GetRtpSenderCapabilities([RTC_OBJC_TYPE(RTCRtpReceiver) nativeMediaTypeForMediaType: mediaType]);
 
   return [[RTC_OBJC_TYPE(RTCRtpCapabilities) alloc] initWithNativeRtpCapabilities:capabilities];
 }
 
-- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpReceiverCapabilitiesFor:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
+- (RTC_OBJC_TYPE(RTCRtpCapabilities) *)rtpReceiverCapabilitiesFor:(RTCRtpMediaType)mediaType {
 
   webrtc::RtpCapabilities capabilities = _nativeFactory->GetRtpReceiverCapabilities([RTC_OBJC_TYPE(RTCRtpReceiver) nativeMediaTypeForMediaType: mediaType]);
 
@@ -145,8 +148,7 @@
 }
 
 - (instancetype)
-    initWithAudioDeviceModuleType:(RTC_OBJC_TYPE(RTCAudioDeviceModuleType))audioDeviceModuleType
-            bypassVoiceProcessing:(BOOL)bypassVoiceProcessing
+    initWithBypassVoiceProcessing:(BOOL)bypassVoiceProcessing
                    encoderFactory:(nullable id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)>)encoderFactory
                    decoderFactory:(nullable id<RTC_OBJC_TYPE(RTCVideoDecoderFactory)>)decoderFactory
             audioProcessingModule:
@@ -162,6 +164,7 @@
   if (decoderFactory) {
     native_decoder_factory = webrtc::ObjCToNativeVideoDecoderFactory(decoderFactory);
   }
+  rtc::scoped_refptr<webrtc::AudioDeviceModule> audio_device_module = [self createAudioDeviceModule:bypassVoiceProcessing];
 
   if ([audioProcessingModule isKindOfClass:[RTC_OBJC_TYPE(RTCDefaultAudioProcessingModule) class]]) {
     _defaultAudioProcessingModule = (RTC_OBJC_TYPE(RTCDefaultAudioProcessingModule) *)audioProcessingModule;
@@ -169,16 +172,15 @@
     _defaultAudioProcessingModule = [[RTC_OBJC_TYPE(RTCDefaultAudioProcessingModule) alloc] init];
   }
 
-  return [self
-      initWithNativeAudioEncoderFactory:webrtc::CreateBuiltinAudioEncoderFactory()
-              nativeAudioDecoderFactory:webrtc::CreateBuiltinAudioDecoderFactory()
-              nativeVideoEncoderFactory:std::move(native_encoder_factory)
-              nativeVideoDecoderFactory:std::move(native_decoder_factory)
-                      audioDeviceModule:nullptr
-                  audioProcessingModule:_defaultAudioProcessingModule.nativeAudioProcessingModule
-               networkControllerFactory:nullptr
-                  audioDeviceModuleType:audioDeviceModuleType
-                  bypassVoiceProcessing:bypassVoiceProcessing];
+  NSLog(@"AudioProcessingModule: %@", _defaultAudioProcessingModule);
+  
+  return [self initWithNativeAudioEncoderFactory:webrtc::CreateBuiltinAudioEncoderFactory()
+                       nativeAudioDecoderFactory:webrtc::CreateBuiltinAudioDecoderFactory()
+                       nativeVideoEncoderFactory:std::move(native_encoder_factory)
+                       nativeVideoDecoderFactory:std::move(native_decoder_factory)
+                               audioDeviceModule:audio_device_module.get()
+                           audioProcessingModule:_defaultAudioProcessingModule.nativeAudioProcessingModule
+                           bypassVoiceProcessing:bypassVoiceProcessing];
 #endif
 }
 
@@ -208,8 +210,9 @@
     dependencies.network_thread = _networkThread.get();
     dependencies.worker_thread = _workerThread.get();
     dependencies.signaling_thread = _signalingThread.get();
-    dependencies.network_monitor_factory = webrtc::CreateNetworkMonitorFactory();
-
+    if (webrtc::field_trial::IsEnabled("WebRTC-Network-UseNWPathMonitor")) {
+      dependencies.network_monitor_factory = webrtc::CreateNetworkMonitorFactory();
+    }
     _nativeFactory = webrtc::CreateModularPeerConnectionFactory(std::move(dependencies));
     NSAssert(_nativeFactory, @"Failed to initialize PeerConnectionFactory!");
   }
@@ -224,38 +227,55 @@
                             (std::unique_ptr<webrtc::VideoEncoderFactory>)videoEncoderFactory
                         nativeVideoDecoderFactory:
                             (std::unique_ptr<webrtc::VideoDecoderFactory>)videoDecoderFactory
-                                audioDeviceModule:
-                                    (rtc::scoped_refptr<webrtc::AudioDeviceModule>)audioDeviceModule
+                                audioDeviceModule:(webrtc::AudioDeviceModule *)audioDeviceModule
+                            audioProcessingModule:
+                                (rtc::scoped_refptr<webrtc::AudioProcessing>)audioProcessingModule
+                            bypassVoiceProcessing:(BOOL)bypassVoiceProcessing {
+  return [self initWithNativeAudioEncoderFactory:audioEncoderFactory
+                       nativeAudioDecoderFactory:audioDecoderFactory
+                       nativeVideoEncoderFactory:std::move(videoEncoderFactory)
+                       nativeVideoDecoderFactory:std::move(videoDecoderFactory)
+                               audioDeviceModule:audioDeviceModule
+                           audioProcessingModule:audioProcessingModule
+                        networkControllerFactory:nullptr
+                           bypassVoiceProcessing:bypassVoiceProcessing];
+}
+- (instancetype)initWithNativeAudioEncoderFactory:
+                    (rtc::scoped_refptr<webrtc::AudioEncoderFactory>)audioEncoderFactory
+                        nativeAudioDecoderFactory:
+                            (rtc::scoped_refptr<webrtc::AudioDecoderFactory>)audioDecoderFactory
+                        nativeVideoEncoderFactory:
+                            (std::unique_ptr<webrtc::VideoEncoderFactory>)videoEncoderFactory
+                        nativeVideoDecoderFactory:
+                            (std::unique_ptr<webrtc::VideoDecoderFactory>)videoDecoderFactory
+                                audioDeviceModule:(webrtc::AudioDeviceModule *)audioDeviceModule
                             audioProcessingModule:
                                 (rtc::scoped_refptr<webrtc::AudioProcessing>)audioProcessingModule
                          networkControllerFactory:
                              (std::unique_ptr<webrtc::NetworkControllerFactoryInterface>)
                                  networkControllerFactory
-                            audioDeviceModuleType:(RTC_OBJC_TYPE(RTCAudioDeviceModuleType))audioDeviceModuleType
                             bypassVoiceProcessing:(BOOL)bypassVoiceProcessing {
   if (self = [self initNative]) {
     webrtc::PeerConnectionFactoryDependencies dependencies;
     dependencies.network_thread = _networkThread.get();
     dependencies.worker_thread = _workerThread.get();
     dependencies.signaling_thread = _signalingThread.get();
-    dependencies.network_monitor_factory = webrtc::CreateNetworkMonitorFactory();
+    if (webrtc::field_trial::IsEnabled("WebRTC-Network-UseNWPathMonitor")) {
+      dependencies.network_monitor_factory = webrtc::CreateNetworkMonitorFactory();
+    }
     dependencies.trials = std::make_unique<webrtc::FieldTrialBasedConfig>();
     dependencies.task_queue_factory =
         webrtc::CreateDefaultTaskQueueFactory(dependencies.trials.get());
-
-    if (audioDeviceModule != nullptr) {
-      _nativeAudioDeviceModule = audioDeviceModule;
-    } else if (audioDeviceModuleType == RTC_OBJC_TYPE(RTCAudioDeviceModuleTypeAudioEngine)) {
-      _nativeAudioDeviceModule = _workerThread->BlockingCall([&bypassVoiceProcessing]() {
-        return rtc::make_ref_counted<webrtc::AudioEngineDevice>(bypassVoiceProcessing == YES);
-      });
+   
+    if(audioDeviceModule) {
+      _nativeAudioDeviceModule = std::move(audioDeviceModule);
     } else {
-      _nativeAudioDeviceModule =
-          _workerThread->BlockingCall([&bypassVoiceProcessing, &dependencies]() {
-            return webrtc::AudioDeviceModule::Create(
-                webrtc::AudioDeviceModule::AudioLayer::kPlatformDefaultAudio,
-                dependencies.task_queue_factory.get(), bypassVoiceProcessing == YES);
-          });
+      // always create ADM on worker thread
+      _nativeAudioDeviceModule = _workerThread->BlockingCall([&dependencies, &bypassVoiceProcessing]() {
+        return webrtc::AudioDeviceModule::Create(webrtc::AudioDeviceModule::AudioLayer::kPlatformDefaultAudio,
+                                                dependencies.task_queue_factory.get(),
+                                                bypassVoiceProcessing == YES);
+      });
     }
 
     _audioDeviceModule = [[RTC_OBJC_TYPE(RTCAudioDeviceModule) alloc] initWithNativeModule: _nativeAudioDeviceModule

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.mm
@@ -13,6 +13,7 @@
 
 #include "api/audio_codecs/audio_decoder_factory.h"
 #include "api/audio_codecs/audio_encoder_factory.h"
+#include "api/transport/network_control.h"
 #include "api/video_codecs/video_decoder_factory.h"
 #include "api/video_codecs/video_encoder_factory.h"
 #include "modules/audio_device/include/audio_device.h"
@@ -38,8 +39,10 @@
                           nativeAudioDecoderFactory:_audioDecoderFactory
                           nativeVideoEncoderFactory:std::move(_videoEncoderFactory)
                           nativeVideoDecoderFactory:std::move(_videoDecoderFactory)
-                                  audioDeviceModule:_audioDeviceModule.get()
+                                  audioDeviceModule:_audioDeviceModule
                               audioProcessingModule:_audioProcessingModule
+                           networkControllerFactory:nullptr
+                           audioDeviceModuleType:RTC_OBJC_TYPE(RTCAudioDeviceModuleTypePlatformDefault)
                               bypassVoiceProcessing:NO];
 }
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactoryBuilder.mm
@@ -13,7 +13,6 @@
 
 #include "api/audio_codecs/audio_decoder_factory.h"
 #include "api/audio_codecs/audio_encoder_factory.h"
-#include "api/transport/network_control.h"
 #include "api/video_codecs/video_decoder_factory.h"
 #include "api/video_codecs/video_encoder_factory.h"
 #include "modules/audio_device/include/audio_device.h"
@@ -39,10 +38,8 @@
                           nativeAudioDecoderFactory:_audioDecoderFactory
                           nativeVideoEncoderFactory:std::move(_videoEncoderFactory)
                           nativeVideoDecoderFactory:std::move(_videoDecoderFactory)
-                                  audioDeviceModule:_audioDeviceModule
+                                  audioDeviceModule:_audioDeviceModule.get()
                               audioProcessingModule:_audioProcessingModule
-                           networkControllerFactory:nullptr
-                           audioDeviceModuleType:RTC_OBJC_TYPE(RTCAudioDeviceModuleTypePlatformDefault)
                               bypassVoiceProcessing:NO];
 }
 

--- a/sdk/objc/api/peerconnection/RTCRtpCodecCapability.mm
+++ b/sdk/objc/api/peerconnection/RTCRtpCodecCapability.mm
@@ -41,10 +41,10 @@
     _name = [NSString stringForStdString:nativeRtpCodecCapability.name];
     switch (nativeRtpCodecCapability.kind) {
       case cricket::MEDIA_TYPE_AUDIO:
-        _kind = kRTCMediaStreamTrackKindAudio;
+        _kind = RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindAudio);
         break;
       case cricket::MEDIA_TYPE_VIDEO:
-        _kind = kRTCMediaStreamTrackKindVideo;
+        _kind = RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindVideo);
         break;
       case cricket::MEDIA_TYPE_DATA:
         RTC_DCHECK_NOTREACHED();
@@ -92,9 +92,9 @@
   rtpCodecCapability.name = [NSString stdStringForString:_name];
   // NSString pointer comparison is safe here since "kind" is readonly and only
   // populated above.
-  if (_kind == kRTCMediaStreamTrackKindAudio) {
+  if (_kind == RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindAudio)) {
     rtpCodecCapability.kind = cricket::MEDIA_TYPE_AUDIO;
-  } else if (_kind == kRTCMediaStreamTrackKindVideo) {
+  } else if (_kind == RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindVideo)) {
     rtpCodecCapability.kind = cricket::MEDIA_TYPE_VIDEO;
   } else {
     RTC_DCHECK_NOTREACHED();

--- a/sdk/objc/api/peerconnection/RTCRtpCodecParameters.h
+++ b/sdk/objc/api/peerconnection/RTCRtpCodecParameters.h
@@ -14,23 +14,23 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-RTC_EXTERN const NSString *const kRTCRtxCodecName;
-RTC_EXTERN const NSString *const kRTCRedCodecName;
-RTC_EXTERN const NSString *const kRTCUlpfecCodecName;
-RTC_EXTERN const NSString *const kRTCFlexfecCodecName;
-RTC_EXTERN const NSString *const kRTCOpusCodecName;
-RTC_EXTERN const NSString *const kRTCIsacCodecName;
-RTC_EXTERN const NSString *const kRTCL16CodecName;
-RTC_EXTERN const NSString *const kRTCG722CodecName;
-RTC_EXTERN const NSString *const kRTCIlbcCodecName;
-RTC_EXTERN const NSString *const kRTCPcmuCodecName;
-RTC_EXTERN const NSString *const kRTCPcmaCodecName;
-RTC_EXTERN const NSString *const kRTCDtmfCodecName;
-RTC_EXTERN const NSString *const kRTCComfortNoiseCodecName;
-RTC_EXTERN const NSString *const kRTCVp8CodecName;
-RTC_EXTERN const NSString *const kRTCVp9CodecName;
-RTC_EXTERN const NSString *const kRTCH264CodecName;
-RTC_EXTERN const NSString *const kRTCAv1CodecName;
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCRtxCodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCRedCodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCUlpfecCodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCFlexfecCodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCOpusCodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCIsacCodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCL16CodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCG722CodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCIlbcCodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCPcmuCodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCPcmaCodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCDtmfCodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCComfortNoiseCodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCVp8CodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCVp9CodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCH264CodecName);
+RTC_EXTERN const NSString *const RTC_CONSTANT_TYPE(RTCAv1CodecName);
 
 /** Defined in https://www.w3.org/TR/webrtc/#idl-def-rtcrtpcodecparameters */
 RTC_OBJC_EXPORT

--- a/sdk/objc/api/peerconnection/RTCRtpCodecParameters.mm
+++ b/sdk/objc/api/peerconnection/RTCRtpCodecParameters.mm
@@ -16,23 +16,23 @@
 #include "media/base/media_constants.h"
 #include "rtc_base/checks.h"
 
-const NSString * const kRTCRtxCodecName = @(cricket::kRtxCodecName);
-const NSString * const kRTCRedCodecName = @(cricket::kRedCodecName);
-const NSString * const kRTCUlpfecCodecName = @(cricket::kUlpfecCodecName);
-const NSString * const kRTCFlexfecCodecName = @(cricket::kFlexfecCodecName);
-const NSString * const kRTCOpusCodecName = @(cricket::kOpusCodecName);
-const NSString * const kRTCL16CodecName  = @(cricket::kL16CodecName);
-const NSString * const kRTCG722CodecName = @(cricket::kG722CodecName);
-const NSString * const kRTCIlbcCodecName = @(cricket::kIlbcCodecName);
-const NSString * const kRTCPcmuCodecName = @(cricket::kPcmuCodecName);
-const NSString * const kRTCPcmaCodecName = @(cricket::kPcmaCodecName);
-const NSString * const kRTCDtmfCodecName = @(cricket::kDtmfCodecName);
-const NSString * const kRTCComfortNoiseCodecName =
+const NSString * const RTC_CONSTANT_TYPE(RTCRtxCodecName) = @(cricket::kRtxCodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCRedCodecName) = @(cricket::kRedCodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCUlpfecCodecName) = @(cricket::kUlpfecCodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCFlexfecCodecName) = @(cricket::kFlexfecCodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCOpusCodecName) = @(cricket::kOpusCodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCL16CodecName)  = @(cricket::kL16CodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCG722CodecName) = @(cricket::kG722CodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCIlbcCodecName) = @(cricket::kIlbcCodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCPcmuCodecName) = @(cricket::kPcmuCodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCPcmaCodecName) = @(cricket::kPcmaCodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCDtmfCodecName) = @(cricket::kDtmfCodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCComfortNoiseCodecName) =
     @(cricket::kComfortNoiseCodecName);
-const NSString * const kRTCVp8CodecName = @(cricket::kVp8CodecName);
-const NSString * const kRTCVp9CodecName = @(cricket::kVp9CodecName);
-const NSString * const kRTCH264CodecName = @(cricket::kH264CodecName);
-const NSString * const kRTCAv1CodecName = @(cricket::kAv1CodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCVp8CodecName) = @(cricket::kVp8CodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCVp9CodecName) = @(cricket::kVp9CodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCH264CodecName) = @(cricket::kH264CodecName);
+const NSString * const RTC_CONSTANT_TYPE(RTCAv1CodecName) = @(cricket::kAv1CodecName);
 
 @implementation RTC_OBJC_TYPE (RTCRtpCodecParameters)
 
@@ -55,10 +55,10 @@ const NSString * const kRTCAv1CodecName = @(cricket::kAv1CodecName);
     _name = [NSString stringForStdString:nativeParameters.name];
     switch (nativeParameters.kind) {
       case cricket::MEDIA_TYPE_AUDIO:
-        _kind = kRTCMediaStreamTrackKindAudio;
+        _kind = RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindAudio);
         break;
       case cricket::MEDIA_TYPE_VIDEO:
-        _kind = kRTCMediaStreamTrackKindVideo;
+        _kind = RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindVideo);
         break;
       case cricket::MEDIA_TYPE_DATA:
         RTC_DCHECK_NOTREACHED();
@@ -89,9 +89,9 @@ const NSString * const kRTCAv1CodecName = @(cricket::kAv1CodecName);
   parameters.name = [NSString stdStringForString:_name];
   // NSString pointer comparison is safe here since "kind" is readonly and only
   // populated above.
-  if (_kind == kRTCMediaStreamTrackKindAudio) {
+  if (_kind == RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindAudio)) {
     parameters.kind = cricket::MEDIA_TYPE_AUDIO;
-  } else if (_kind == kRTCMediaStreamTrackKindVideo) {
+  } else if (_kind == RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindVideo)) {
     parameters.kind = cricket::MEDIA_TYPE_VIDEO;
   } else {
     RTC_DCHECK_NOTREACHED();

--- a/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.h
+++ b/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.h
@@ -16,10 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Corresponds to webrtc::Priority. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCPriority)) {
-  RTCPriorityVeryLow,
-  RTCPriorityLow,
-  RTCPriorityMedium,
-  RTCPriorityHigh
+  RTC_OBJC_TYPE(RTCPriorityVeryLow),
+  RTC_OBJC_TYPE(RTCPriorityLow),
+  RTC_OBJC_TYPE(RTCPriorityMedium),
+  RTC_OBJC_TYPE(RTCPriorityHigh)
 };
 
 RTC_OBJC_EXPORT

--- a/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.h
+++ b/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.h
@@ -15,7 +15,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Corresponds to webrtc::Priority. */
-typedef NS_ENUM(NSInteger, RTCPriority) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCPriority)) {
   RTCPriorityVeryLow,
   RTCPriorityLow,
   RTCPriorityMedium,
@@ -63,7 +63,7 @@ RTC_OBJC_EXPORT
 @property(nonatomic, assign) double bitratePriority;
 
 /** The relative DiffServ Code Point priority. */
-@property(nonatomic, assign) RTCPriority networkPriority;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCPriority) networkPriority;
 
 /** Allow dynamic frame length changes for audio:
  https://w3c.github.io/webrtc-extensions/#dom-rtcrtpencodingparameters-adaptiveptime */

--- a/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.mm
+++ b/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.mm
@@ -106,29 +106,29 @@
   return parameters;
 }
 
-+ (webrtc::Priority)nativePriorityFromPriority:(RTCPriority)networkPriority {
++ (webrtc::Priority)nativePriorityFromPriority:(RTC_OBJC_TYPE(RTCPriority))networkPriority {
   switch (networkPriority) {
-    case RTCPriorityVeryLow:
+    case RTC_OBJC_TYPE(RTCPriorityVeryLow):
       return webrtc::Priority::kVeryLow;
-    case RTCPriorityLow:
+    case RTC_OBJC_TYPE(RTCPriorityLow):
       return webrtc::Priority::kLow;
-    case RTCPriorityMedium:
+    case RTC_OBJC_TYPE(RTCPriorityMedium):
       return webrtc::Priority::kMedium;
-    case RTCPriorityHigh:
+    case RTC_OBJC_TYPE(RTCPriorityHigh):
       return webrtc::Priority::kHigh;
   }
 }
 
-+ (RTCPriority)priorityFromNativePriority:(webrtc::Priority)nativePriority {
++ (RTC_OBJC_TYPE(RTCPriority))priorityFromNativePriority:(webrtc::Priority)nativePriority {
   switch (nativePriority) {
     case webrtc::Priority::kVeryLow:
-      return RTCPriorityVeryLow;
+      return RTC_OBJC_TYPE(RTCPriorityVeryLow);
     case webrtc::Priority::kLow:
-      return RTCPriorityLow;
+      return RTC_OBJC_TYPE(RTCPriorityLow);
     case webrtc::Priority::kMedium:
-      return RTCPriorityMedium;
+      return RTC_OBJC_TYPE(RTCPriorityMedium);
     case webrtc::Priority::kHigh:
-      return RTCPriorityHigh;
+      return RTC_OBJC_TYPE(RTCPriorityHigh);
   }
 }
 

--- a/sdk/objc/api/peerconnection/RTCRtpParameters.h
+++ b/sdk/objc/api/peerconnection/RTCRtpParameters.h
@@ -20,10 +20,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Corresponds to webrtc::DegradationPreference. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCDegradationPreference)) {
-  RTCDegradationPreferenceDisabled,
-  RTCDegradationPreferenceMaintainFramerate,
-  RTCDegradationPreferenceMaintainResolution,
-  RTCDegradationPreferenceBalanced
+  RTC_OBJC_TYPE(RTCDegradationPreferenceDisabled),
+  RTC_OBJC_TYPE(RTCDegradationPreferenceMaintainFramerate),
+  RTC_OBJC_TYPE(RTCDegradationPreferenceMaintainResolution),
+  RTC_OBJC_TYPE(RTCDegradationPreferenceBalanced)
 };
 
 RTC_OBJC_EXPORT

--- a/sdk/objc/api/peerconnection/RTCRtpParameters.h
+++ b/sdk/objc/api/peerconnection/RTCRtpParameters.h
@@ -19,7 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Corresponds to webrtc::DegradationPreference. */
-typedef NS_ENUM(NSInteger, RTCDegradationPreference) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCDegradationPreference)) {
   RTCDegradationPreferenceDisabled,
   RTCDegradationPreferenceMaintainFramerate,
   RTCDegradationPreferenceMaintainResolution,

--- a/sdk/objc/api/peerconnection/RTCRtpParameters.mm
+++ b/sdk/objc/api/peerconnection/RTCRtpParameters.mm
@@ -80,22 +80,22 @@
   }
   if (_degradationPreference) {
     parameters.degradation_preference = [RTC_OBJC_TYPE(RTCRtpParameters)
-        nativeDegradationPreferenceFromDegradationPreference:(RTCDegradationPreference)
+        nativeDegradationPreferenceFromDegradationPreference:(RTC_OBJC_TYPE(RTCDegradationPreference))
                                                                  _degradationPreference.intValue];
   }
   return parameters;
 }
 
 + (webrtc::DegradationPreference)nativeDegradationPreferenceFromDegradationPreference:
-    (RTCDegradationPreference)degradationPreference {
+    (RTC_OBJC_TYPE(RTCDegradationPreference))degradationPreference {
   switch (degradationPreference) {
-    case RTCDegradationPreferenceDisabled:
+    case RTC_OBJC_TYPE(RTCDegradationPreferenceDisabled):
       return webrtc::DegradationPreference::DISABLED;
-    case RTCDegradationPreferenceMaintainFramerate:
+    case RTC_OBJC_TYPE(RTCDegradationPreferenceMaintainFramerate):
       return webrtc::DegradationPreference::MAINTAIN_FRAMERATE;
-    case RTCDegradationPreferenceMaintainResolution:
+    case RTC_OBJC_TYPE(RTCDegradationPreferenceMaintainResolution):
       return webrtc::DegradationPreference::MAINTAIN_RESOLUTION;
-    case RTCDegradationPreferenceBalanced:
+    case RTC_OBJC_TYPE(RTCDegradationPreferenceBalanced):
       return webrtc::DegradationPreference::BALANCED;
   }
 }
@@ -108,13 +108,13 @@
 
   switch (*nativeDegradationPreference) {
     case webrtc::DegradationPreference::DISABLED:
-      return @(RTCDegradationPreferenceDisabled);
+      return @(RTC_OBJC_TYPE(RTCDegradationPreferenceDisabled));
     case webrtc::DegradationPreference::MAINTAIN_FRAMERATE:
-      return @(RTCDegradationPreferenceMaintainFramerate);
+      return @(RTC_OBJC_TYPE(RTCDegradationPreferenceMaintainFramerate));
     case webrtc::DegradationPreference::MAINTAIN_RESOLUTION:
-      return @(RTCDegradationPreferenceMaintainResolution);
+      return @(RTC_OBJC_TYPE(RTCDegradationPreferenceMaintainResolution));
     case webrtc::DegradationPreference::BALANCED:
-      return @(RTCDegradationPreferenceBalanced);
+      return @(RTC_OBJC_TYPE(RTCDegradationPreferenceBalanced));
   }
 }
 

--- a/sdk/objc/api/peerconnection/RTCRtpReceiver+Private.h
+++ b/sdk/objc/api/peerconnection/RTCRtpReceiver+Private.h
@@ -41,11 +41,11 @@ class RtpReceiverDelegateAdapter : public RtpReceiverObserverInterface {
               nativeRtpReceiver:(rtc::scoped_refptr<webrtc::RtpReceiverInterface>)nativeRtpReceiver
     NS_DESIGNATED_INITIALIZER;
 
-+ (RTCRtpMediaType)mediaTypeForNativeMediaType:(cricket::MediaType)nativeMediaType;
++ (RTC_OBJC_TYPE(RTCRtpMediaType))mediaTypeForNativeMediaType:(cricket::MediaType)nativeMediaType;
 
-+ (cricket::MediaType)nativeMediaTypeForMediaType:(RTCRtpMediaType)mediaType;
++ (cricket::MediaType)nativeMediaTypeForMediaType:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType;
 
-+ (NSString *)stringForMediaType:(RTCRtpMediaType)mediaType;
++ (NSString *)stringForMediaType:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCRtpReceiver.h
+++ b/sdk/objc/api/peerconnection/RTCRtpReceiver.h
@@ -18,10 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Represents the media type of the RtpReceiver. */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtpMediaType)) {
-  RTCRtpMediaTypeAudio,
-  RTCRtpMediaTypeVideo,
-  RTCRtpMediaTypeData,
-  RTCRtpMediaTypeUnsupported,
+  RTC_OBJC_TYPE(RTCRtpMediaTypeAudio),
+  RTC_OBJC_TYPE(RTCRtpMediaTypeVideo),
+  RTC_OBJC_TYPE(RTCRtpMediaTypeData),
+  RTC_OBJC_TYPE(RTCRtpMediaTypeUnsupported),
 };
 
 @class RTC_OBJC_TYPE(RTCRtpReceiver);
@@ -44,7 +44,7 @@ RTC_OBJC_EXPORT
      */
     - (void)rtpReceiver
     : (RTC_OBJC_TYPE(RTCRtpReceiver) *)rtpReceiver didReceiveFirstPacketForMediaType
-    : (RTCRtpMediaType)mediaType;
+    : (RTC_OBJC_TYPE(RTCRtpMediaType))mediaType;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCRtpReceiver.h
+++ b/sdk/objc/api/peerconnection/RTCRtpReceiver.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Represents the media type of the RtpReceiver. */
-typedef NS_ENUM(NSInteger, RTCRtpMediaType) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtpMediaType)) {
   RTCRtpMediaTypeAudio,
   RTCRtpMediaTypeVideo,
   RTCRtpMediaTypeData,

--- a/sdk/objc/api/peerconnection/RTCRtpReceiver.mm
+++ b/sdk/objc/api/peerconnection/RTCRtpReceiver.mm
@@ -27,7 +27,7 @@ RtpReceiverDelegateAdapter::RtpReceiverDelegateAdapter(RTC_OBJC_TYPE(RTCRtpRecei
 
 void RtpReceiverDelegateAdapter::OnFirstPacketReceived(
     cricket::MediaType media_type) {
-  RTCRtpMediaType packet_media_type =
+  RTC_OBJC_TYPE(RTCRtpMediaType) packet_media_type =
       [RTC_OBJC_TYPE(RTCRtpReceiver) mediaTypeForNativeMediaType:media_type];
   RTC_OBJC_TYPE(RTCRtpReceiver) *receiver = receiver_;
   [receiver.delegate rtpReceiver:receiver didReceiveFirstPacketForMediaType:packet_media_type];
@@ -116,42 +116,42 @@ void RtpReceiverDelegateAdapter::OnFirstPacketReceived(
   return self;
 }
 
-+ (RTCRtpMediaType)mediaTypeForNativeMediaType:
++ (RTC_OBJC_TYPE(RTCRtpMediaType))mediaTypeForNativeMediaType:
     (cricket::MediaType)nativeMediaType {
   switch (nativeMediaType) {
     case cricket::MEDIA_TYPE_AUDIO:
-      return RTCRtpMediaTypeAudio;
+      return RTC_OBJC_TYPE(RTCRtpMediaTypeAudio);
     case cricket::MEDIA_TYPE_VIDEO:
-      return RTCRtpMediaTypeVideo;
+      return RTC_OBJC_TYPE(RTCRtpMediaTypeVideo);
     case cricket::MEDIA_TYPE_DATA:
-      return RTCRtpMediaTypeData;
+      return RTC_OBJC_TYPE(RTCRtpMediaTypeData);
     case cricket::MEDIA_TYPE_UNSUPPORTED:
-      return RTCRtpMediaTypeUnsupported;
+      return RTC_OBJC_TYPE(RTCRtpMediaTypeUnsupported);
   }
 }
 
-+ (cricket::MediaType)nativeMediaTypeForMediaType:(RTCRtpMediaType)mediaType {
++ (cricket::MediaType)nativeMediaTypeForMediaType:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
   switch (mediaType) {
-    case RTCRtpMediaTypeAudio:
+    case RTC_OBJC_TYPE(RTCRtpMediaTypeAudio):
       return cricket::MEDIA_TYPE_AUDIO;
-    case RTCRtpMediaTypeVideo:
+    case RTC_OBJC_TYPE(RTCRtpMediaTypeVideo):
       return cricket::MEDIA_TYPE_VIDEO;
-    case RTCRtpMediaTypeData:
+    case RTC_OBJC_TYPE(RTCRtpMediaTypeData):
       return cricket::MEDIA_TYPE_DATA;
-    case RTCRtpMediaTypeUnsupported:
+    case RTC_OBJC_TYPE(RTCRtpMediaTypeUnsupported):
       return cricket::MEDIA_TYPE_UNSUPPORTED;
   }
 }
 
-+ (NSString *)stringForMediaType:(RTCRtpMediaType)mediaType {
++ (NSString *)stringForMediaType:(RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
   switch (mediaType) {
-    case RTCRtpMediaTypeAudio:
+    case RTC_OBJC_TYPE(RTCRtpMediaTypeAudio):
       return @"AUDIO";
-    case RTCRtpMediaTypeVideo:
+    case RTC_OBJC_TYPE(RTCRtpMediaTypeVideo):
       return @"VIDEO";
-    case RTCRtpMediaTypeData:
+    case RTC_OBJC_TYPE(RTCRtpMediaTypeData):
       return @"DATA";
-    case RTCRtpMediaTypeUnsupported:
+    case RTC_OBJC_TYPE(RTCRtpMediaTypeUnsupported):
       return @"UNSUPPORTED";
   }
 }

--- a/sdk/objc/api/peerconnection/RTCRtpTransceiver+Private.h
+++ b/sdk/objc/api/peerconnection/RTCRtpTransceiver+Private.h
@@ -36,9 +36,9 @@ NS_ASSUME_NONNULL_BEGIN
     NS_DESIGNATED_INITIALIZER;
 
 + (webrtc::RtpTransceiverDirection)nativeRtpTransceiverDirectionFromDirection:
-    (RTCRtpTransceiverDirection)direction;
+    (RTC_OBJC_TYPE(RTCRtpTransceiverDirection))direction;
 
-+ (RTCRtpTransceiverDirection)rtpTransceiverDirectionFromNativeDirection:
++ (RTC_OBJC_TYPE(RTCRtpTransceiverDirection))rtpTransceiverDirectionFromNativeDirection:
     (webrtc::RtpTransceiverDirection)nativeDirection;
 
 @end

--- a/sdk/objc/api/peerconnection/RTCRtpTransceiver.h
+++ b/sdk/objc/api/peerconnection/RTCRtpTransceiver.h
@@ -18,7 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const kRTCRtpTransceiverErrorDomain;
+extern NSString *const RTC_CONSTANT_TYPE(RTCRtpTransceiverErrorDomain);
 
 /** https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiverdirection */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtpTransceiverDirection)) {

--- a/sdk/objc/api/peerconnection/RTCRtpTransceiver.h
+++ b/sdk/objc/api/peerconnection/RTCRtpTransceiver.h
@@ -22,11 +22,11 @@ extern NSString *const kRTCRtpTransceiverErrorDomain;
 
 /** https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiverdirection */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtpTransceiverDirection)) {
-  RTCRtpTransceiverDirectionSendRecv,
-  RTCRtpTransceiverDirectionSendOnly,
-  RTCRtpTransceiverDirectionRecvOnly,
-  RTCRtpTransceiverDirectionInactive,
-  RTCRtpTransceiverDirectionStopped
+  RTC_OBJC_TYPE(RTCRtpTransceiverDirectionSendRecv),
+  RTC_OBJC_TYPE(RTCRtpTransceiverDirectionSendOnly),
+  RTC_OBJC_TYPE(RTCRtpTransceiverDirectionRecvOnly),
+  RTC_OBJC_TYPE(RTCRtpTransceiverDirectionInactive),
+  RTC_OBJC_TYPE(RTCRtpTransceiverDirectionStopped)
 };
 
 /** Structure for initializing an RTCRtpTransceiver in a call to

--- a/sdk/objc/api/peerconnection/RTCRtpTransceiver.h
+++ b/sdk/objc/api/peerconnection/RTCRtpTransceiver.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString *const kRTCRtpTransceiverErrorDomain;
 
 /** https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiverdirection */
-typedef NS_ENUM(NSInteger, RTCRtpTransceiverDirection) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCRtpTransceiverDirection)) {
   RTCRtpTransceiverDirectionSendRecv,
   RTCRtpTransceiverDirectionSendOnly,
   RTCRtpTransceiverDirectionRecvOnly,
@@ -37,7 +37,7 @@ RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCRtpTransceiverInit) : NSObject
 
 /** Direction of the RTCRtpTransceiver. See RTCRtpTransceiver.direction. */
-@property(nonatomic) RTCRtpTransceiverDirection direction;
+@property(nonatomic) RTC_OBJC_TYPE(RTCRtpTransceiverDirection) direction;
 
 /** The added RTCRtpTransceiver will be added to these streams. */
 @property(nonatomic) NSArray<NSString *> *streamIds;
@@ -70,7 +70,7 @@ RTC_OBJC_EXPORT
     /** Media type of the transceiver. The sender and receiver will also have this
      *  type.
      */
-    @property(nonatomic, readonly) RTCRtpMediaType mediaType;
+    @property(nonatomic, readonly) RTC_OBJC_TYPE(RTCRtpMediaType) mediaType;
 
 /** The mid attribute is the mid negotiated and present in the local and
  *  remote descriptions. Before negotiation is complete, the mid value may be
@@ -105,7 +105,7 @@ RTC_OBJC_EXPORT
  *  transceiver, which will be used in calls to createOffer and createAnswer.
  *  https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiver-direction
  */
-@property(nonatomic, readonly) RTCRtpTransceiverDirection direction;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCRtpTransceiverDirection) direction;
 
 @property(nonatomic, copy) NSArray<RTC_OBJC_TYPE(RTCRtpCodecCapability) *> *codecPreferences;
 
@@ -115,7 +115,7 @@ RTC_OBJC_EXPORT
  *  present and this method returns NO.
  *  https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiver-currentdirection
  */
-- (BOOL)currentDirection:(RTCRtpTransceiverDirection *)currentDirectionOut;
+- (BOOL)currentDirection:(RTC_OBJC_TYPE(RTCRtpTransceiverDirection) *)currentDirectionOut;
 
 /** The stop method irreversibly stops the RTCRtpTransceiver. The sender of
  *  this transceiver will no longer send, the receiver will no longer receive.
@@ -134,7 +134,7 @@ RTC_OBJC_EXPORT
  *  descriptions as sendrecv, sendonly, recvonly, or inactive.
  *  https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiver-direction
  */
-- (void)setDirection:(RTCRtpTransceiverDirection)direction error:(NSError **)error;
+- (void)setDirection:(RTC_OBJC_TYPE(RTCRtpTransceiverDirection))direction error:(NSError **)error;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCRtpTransceiver.mm
+++ b/sdk/objc/api/peerconnection/RTCRtpTransceiver.mm
@@ -32,7 +32,7 @@ NSString *const kRTCRtpTransceiverErrorDomain = @"org.webrtc.RTCRtpTranceiver";
 
 - (instancetype)init {
   if (self = [super init]) {
-    _direction = RTCRtpTransceiverDirectionSendRecv;
+    _direction = RTC_OBJC_TYPE(RTCRtpTransceiverDirectionSendRecv);
   }
   return self;
 }
@@ -57,7 +57,7 @@ NSString *const kRTCRtpTransceiverErrorDomain = @"org.webrtc.RTCRtpTranceiver";
   rtc::scoped_refptr<webrtc::RtpTransceiverInterface> _nativeRtpTransceiver;
 }
 
-- (RTCRtpMediaType)mediaType {
+- (RTC_OBJC_TYPE(RTCRtpMediaType))mediaType {
   return [RTC_OBJC_TYPE(RTCRtpReceiver)
       mediaTypeForNativeMediaType:_nativeRtpTransceiver->media_type()];
 }
@@ -91,12 +91,12 @@ NSString *const kRTCRtpTransceiverErrorDomain = @"org.webrtc.RTCRtpTranceiver";
   return _nativeRtpTransceiver->stopped();
 }
 
-- (RTCRtpTransceiverDirection)direction {
+- (RTC_OBJC_TYPE(RTCRtpTransceiverDirection))direction {
   return [RTC_OBJC_TYPE(RTCRtpTransceiver)
       rtpTransceiverDirectionFromNativeDirection:_nativeRtpTransceiver->direction()];
 }
 
-- (void)setDirection:(RTCRtpTransceiverDirection)direction error:(NSError **)error {
+- (void)setDirection:(RTC_OBJC_TYPE(RTCRtpTransceiverDirection))direction error:(NSError **)error {
   webrtc::RTCError nativeError = _nativeRtpTransceiver->SetDirectionWithError(
       [RTC_OBJC_TYPE(RTCRtpTransceiver) nativeRtpTransceiverDirectionFromDirection:direction]);
 
@@ -110,7 +110,7 @@ NSString *const kRTCRtpTransceiverErrorDomain = @"org.webrtc.RTCRtpTranceiver";
   }
 }
 
-- (BOOL)currentDirection:(RTCRtpTransceiverDirection *)currentDirectionOut {
+- (BOOL)currentDirection:(RTC_OBJC_TYPE(RTCRtpTransceiverDirection) *)currentDirectionOut {
   if (_nativeRtpTransceiver->current_direction()) {
     *currentDirectionOut = [RTC_OBJC_TYPE(RTCRtpTransceiver)
         rtpTransceiverDirectionFromNativeDirection:*_nativeRtpTransceiver->current_direction()];
@@ -183,34 +183,34 @@ NSString *const kRTCRtpTransceiverErrorDomain = @"org.webrtc.RTCRtpTranceiver";
 }
 
 + (webrtc::RtpTransceiverDirection)nativeRtpTransceiverDirectionFromDirection:
-        (RTCRtpTransceiverDirection)direction {
+        (RTC_OBJC_TYPE(RTCRtpTransceiverDirection))direction {
   switch (direction) {
-    case RTCRtpTransceiverDirectionSendRecv:
+    case RTC_OBJC_TYPE(RTCRtpTransceiverDirectionSendRecv):
       return webrtc::RtpTransceiverDirection::kSendRecv;
-    case RTCRtpTransceiverDirectionSendOnly:
+    case RTC_OBJC_TYPE(RTCRtpTransceiverDirectionSendOnly):
       return webrtc::RtpTransceiverDirection::kSendOnly;
-    case RTCRtpTransceiverDirectionRecvOnly:
+    case RTC_OBJC_TYPE(RTCRtpTransceiverDirectionRecvOnly):
       return webrtc::RtpTransceiverDirection::kRecvOnly;
-    case RTCRtpTransceiverDirectionInactive:
+    case RTC_OBJC_TYPE(RTCRtpTransceiverDirectionInactive):
       return webrtc::RtpTransceiverDirection::kInactive;
-    case RTCRtpTransceiverDirectionStopped:
+    case RTC_OBJC_TYPE(RTCRtpTransceiverDirectionStopped):
       return webrtc::RtpTransceiverDirection::kStopped;
   }
 }
 
-+ (RTCRtpTransceiverDirection)rtpTransceiverDirectionFromNativeDirection:
++ (RTC_OBJC_TYPE(RTCRtpTransceiverDirection))rtpTransceiverDirectionFromNativeDirection:
         (webrtc::RtpTransceiverDirection)nativeDirection {
   switch (nativeDirection) {
     case webrtc::RtpTransceiverDirection::kSendRecv:
-      return RTCRtpTransceiverDirectionSendRecv;
+      return RTC_OBJC_TYPE(RTCRtpTransceiverDirectionSendRecv);
     case webrtc::RtpTransceiverDirection::kSendOnly:
-      return RTCRtpTransceiverDirectionSendOnly;
+      return RTC_OBJC_TYPE(RTCRtpTransceiverDirectionSendOnly);
     case webrtc::RtpTransceiverDirection::kRecvOnly:
-      return RTCRtpTransceiverDirectionRecvOnly;
+      return RTC_OBJC_TYPE(RTCRtpTransceiverDirectionRecvOnly);
     case webrtc::RtpTransceiverDirection::kInactive:
-      return RTCRtpTransceiverDirectionInactive;
+      return RTC_OBJC_TYPE(RTCRtpTransceiverDirectionInactive);
     case webrtc::RtpTransceiverDirection::kStopped:
-      return RTCRtpTransceiverDirectionStopped;
+      return RTC_OBJC_TYPE(RTCRtpTransceiverDirectionStopped);
   }
 }
 

--- a/sdk/objc/api/peerconnection/RTCRtpTransceiver.mm
+++ b/sdk/objc/api/peerconnection/RTCRtpTransceiver.mm
@@ -22,7 +22,7 @@
 
 #include "api/rtp_parameters.h"
 
-NSString *const kRTCRtpTransceiverErrorDomain = @"org.webrtc.RTCRtpTranceiver";
+NSString *const RTC_CONSTANT_TYPE(RTCRtpTransceiverErrorDomain) = @"org.webrtc.RTCRtpTranceiver";
 
 @implementation RTC_OBJC_TYPE (RTCRtpTransceiverInit)
 
@@ -101,7 +101,7 @@ NSString *const kRTCRtpTransceiverErrorDomain = @"org.webrtc.RTCRtpTranceiver";
       [RTC_OBJC_TYPE(RTCRtpTransceiver) nativeRtpTransceiverDirectionFromDirection:direction]);
 
   if (!nativeError.ok() && error) {
-    *error = [NSError errorWithDomain:kRTCRtpTransceiverErrorDomain
+    *error = [NSError errorWithDomain:RTC_CONSTANT_TYPE(RTCRtpTransceiverErrorDomain)
                                  code:static_cast<int>(nativeError.type())
                              userInfo:@{
                                @"message" : [NSString stringWithCString:nativeError.message()

--- a/sdk/objc/api/peerconnection/RTCSSLAdapter.h
+++ b/sdk/objc/api/peerconnection/RTCSSLAdapter.h
@@ -16,5 +16,5 @@
  * Initialize and clean up the SSL library. Failure is fatal. These call the
  * corresponding functions in webrtc/rtc_base/ssladapter.h.
  */
-RTC_EXTERN BOOL RTCInitializeSSL(void);
-RTC_EXTERN BOOL RTCCleanupSSL(void);
+RTC_EXTERN BOOL RTC_OBJC_TYPE(RTCInitializeSSL)(void);
+RTC_EXTERN BOOL RTC_OBJC_TYPE(RTCCleanupSSL)(void);

--- a/sdk/objc/api/peerconnection/RTCSSLAdapter.mm
+++ b/sdk/objc/api/peerconnection/RTCSSLAdapter.mm
@@ -13,13 +13,13 @@
 #include "rtc_base/checks.h"
 #include "rtc_base/ssl_adapter.h"
 
-BOOL RTCInitializeSSL(void) {
+BOOL RTC_OBJC_TYPE(RTCInitializeSSL)(void) {
   BOOL initialized = rtc::InitializeSSL();
   RTC_DCHECK(initialized);
   return initialized;
 }
 
-BOOL RTCCleanupSSL(void) {
+BOOL RTC_OBJC_TYPE(RTCCleanupSSL)(void) {
   BOOL cleanedUp = rtc::CleanupSSL();
   RTC_DCHECK(cleanedUp);
   return cleanedUp;

--- a/sdk/objc/api/peerconnection/RTCSessionDescription+Private.h
+++ b/sdk/objc/api/peerconnection/RTCSessionDescription+Private.h
@@ -33,9 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithNativeDescription:
     (const webrtc::SessionDescriptionInterface *)nativeDescription;
 
-+ (std::string)stdStringForType:(RTCSdpType)type;
++ (std::string)stdStringForType:(RTC_OBJC_TYPE(RTCSdpType))type;
 
-+ (RTCSdpType)typeForStdString:(const std::string &)string;
++ (RTC_OBJC_TYPE(RTCSdpType))typeForStdString:(const std::string &)string;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCSessionDescription.h
+++ b/sdk/objc/api/peerconnection/RTCSessionDescription.h
@@ -17,10 +17,10 @@
  * in C++, which doesn't include the rollback type that is in the W3C spec.
  */
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCSdpType)) {
-  RTCSdpTypeOffer,
-  RTCSdpTypePrAnswer,
-  RTCSdpTypeAnswer,
-  RTCSdpTypeRollback,
+  RTC_OBJC_TYPE(RTCSdpTypeOffer),
+  RTC_OBJC_TYPE(RTCSdpTypePrAnswer),
+  RTC_OBJC_TYPE(RTCSdpTypeAnswer),
+  RTC_OBJC_TYPE(RTCSdpTypeRollback),
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/sdk/objc/api/peerconnection/RTCSessionDescription.h
+++ b/sdk/objc/api/peerconnection/RTCSessionDescription.h
@@ -16,7 +16,7 @@
  * Represents the session description type. This exposes the same types that are
  * in C++, which doesn't include the rollback type that is in the W3C spec.
  */
-typedef NS_ENUM(NSInteger, RTCSdpType) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCSdpType)) {
   RTCSdpTypeOffer,
   RTCSdpTypePrAnswer,
   RTCSdpTypeAnswer,
@@ -29,7 +29,7 @@ RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCSessionDescription) : NSObject
 
 /** The type of session description. */
-@property(nonatomic, readonly) RTCSdpType type;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCSdpType) type;
 
 /** The SDP string representation of this session description. */
 @property(nonatomic, readonly) NSString *sdp;
@@ -37,11 +37,11 @@ RTC_OBJC_EXPORT
 - (instancetype)init NS_UNAVAILABLE;
 
 /** Initialize a session description with a type and SDP string. */
-- (instancetype)initWithType:(RTCSdpType)type sdp:(NSString *)sdp NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithType:(RTC_OBJC_TYPE(RTCSdpType))type sdp:(NSString *)sdp NS_DESIGNATED_INITIALIZER;
 
-+ (NSString *)stringForType:(RTCSdpType)type;
++ (NSString *)stringForType:(RTC_OBJC_TYPE(RTCSdpType))type;
 
-+ (RTCSdpType)typeForString:(NSString *)string;
++ (RTC_OBJC_TYPE(RTCSdpType))typeForString:(NSString *)string;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCSessionDescription.mm
+++ b/sdk/objc/api/peerconnection/RTCSessionDescription.mm
@@ -20,17 +20,17 @@
 @synthesize type = _type;
 @synthesize sdp = _sdp;
 
-+ (NSString *)stringForType:(RTCSdpType)type {
++ (NSString *)stringForType:(RTC_OBJC_TYPE(RTCSdpType))type {
   std::string string = [[self class] stdStringForType:type];
   return [NSString stringForStdString:string];
 }
 
-+ (RTCSdpType)typeForString:(NSString *)string {
++ (RTC_OBJC_TYPE(RTCSdpType))typeForString:(NSString *)string {
   std::string typeString = string.stdString;
   return [[self class] typeForStdString:typeString];
 }
 
-- (instancetype)initWithType:(RTCSdpType)type sdp:(NSString *)sdp {
+- (instancetype)initWithType:(RTC_OBJC_TYPE(RTCSdpType))type sdp:(NSString *)sdp {
   if (self = [super init]) {
     _type = type;
     _sdp = [sdp copy];
@@ -66,37 +66,37 @@
   NSParameterAssert(nativeDescription);
   std::string sdp;
   nativeDescription->ToString(&sdp);
-  RTCSdpType type = [[self class] typeForStdString:nativeDescription->type()];
+  RTC_OBJC_TYPE(RTCSdpType) type = [[self class] typeForStdString:nativeDescription->type()];
 
   return [self initWithType:type
                         sdp:[NSString stringForStdString:sdp]];
 }
 
-+ (std::string)stdStringForType:(RTCSdpType)type {
++ (std::string)stdStringForType:(RTC_OBJC_TYPE(RTCSdpType))type {
   switch (type) {
-    case RTCSdpTypeOffer:
+    case RTC_OBJC_TYPE(RTCSdpTypeOffer):
       return webrtc::SessionDescriptionInterface::kOffer;
-    case RTCSdpTypePrAnswer:
+    case RTC_OBJC_TYPE(RTCSdpTypePrAnswer):
       return webrtc::SessionDescriptionInterface::kPrAnswer;
-    case RTCSdpTypeAnswer:
+    case RTC_OBJC_TYPE(RTCSdpTypeAnswer):
       return webrtc::SessionDescriptionInterface::kAnswer;
-    case RTCSdpTypeRollback:
+    case RTC_OBJC_TYPE(RTCSdpTypeRollback):
       return webrtc::SessionDescriptionInterface::kRollback;
   }
 }
 
-+ (RTCSdpType)typeForStdString:(const std::string &)string {
++ (RTC_OBJC_TYPE(RTCSdpType))typeForStdString:(const std::string &)string {
   if (string == webrtc::SessionDescriptionInterface::kOffer) {
-    return RTCSdpTypeOffer;
+    return RTC_OBJC_TYPE(RTCSdpTypeOffer);
   } else if (string == webrtc::SessionDescriptionInterface::kPrAnswer) {
-    return RTCSdpTypePrAnswer;
+    return RTC_OBJC_TYPE(RTCSdpTypePrAnswer);
   } else if (string == webrtc::SessionDescriptionInterface::kAnswer) {
-    return RTCSdpTypeAnswer;
+    return RTC_OBJC_TYPE(RTCSdpTypeAnswer);
   } else if (string == webrtc::SessionDescriptionInterface::kRollback) {
-    return RTCSdpTypeRollback;
+    return RTC_OBJC_TYPE(RTCSdpTypeRollback);
   } else {
     RTC_DCHECK_NOTREACHED();
-    return RTCSdpTypeOffer;
+    return RTC_OBJC_TYPE(RTCSdpTypeOffer);
   }
 }
 

--- a/sdk/objc/api/peerconnection/RTCTracing.h
+++ b/sdk/objc/api/peerconnection/RTCTracing.h
@@ -12,10 +12,10 @@
 
 #import "RTCMacros.h"
 
-RTC_EXTERN void RTCSetupInternalTracer(void);
+RTC_EXTERN void RTC_OBJC_TYPE(RTCSetupInternalTracer)(void);
 /** Starts capture to specified file. Must be a valid writable path.
  *  Returns YES if capture starts.
  */
-RTC_EXTERN BOOL RTCStartInternalCapture(NSString* filePath);
-RTC_EXTERN void RTCStopInternalCapture(void);
-RTC_EXTERN void RTCShutdownInternalTracer(void);
+RTC_EXTERN BOOL RTC_OBJC_TYPE(RTCStartInternalCapture)(NSString* filePath);
+RTC_EXTERN void RTC_OBJC_TYPE(RTCStopInternalCapture)(void);
+RTC_EXTERN void RTC_OBJC_TYPE(RTCShutdownInternalTracer)(void);

--- a/sdk/objc/api/peerconnection/RTCTracing.mm
+++ b/sdk/objc/api/peerconnection/RTCTracing.mm
@@ -12,18 +12,18 @@
 
 #include "rtc_base/event_tracer.h"
 
-void RTCSetupInternalTracer(void) {
+void RTC_OBJC_TYPE(RTCSetupInternalTracer)(void) {
   rtc::tracing::SetupInternalTracer();
 }
 
-BOOL RTCStartInternalCapture(NSString *filePath) {
+BOOL RTC_OBJC_TYPE(RTCStartInternalCapture)(NSString *filePath) {
   return rtc::tracing::StartInternalCapture(filePath.UTF8String);
 }
 
-void RTCStopInternalCapture(void) {
+void RTC_OBJC_TYPE(RTCStopInternalCapture)(void) {
   rtc::tracing::StopInternalCapture();
 }
 
-void RTCShutdownInternalTracer(void) {
+void RTC_OBJC_TYPE(RTCShutdownInternalTracer)(void) {
   rtc::tracing::ShutdownInternalTracer();
 }

--- a/sdk/objc/api/peerconnection/RTCVideoEncoderSettings+Private.mm
+++ b/sdk/objc/api/peerconnection/RTCVideoEncoderSettings+Private.mm
@@ -28,7 +28,7 @@
       self.minBitrate = videoCodec->minBitrate;
       self.maxFramerate = videoCodec->maxFramerate;
       self.qpMax = videoCodec->qpMax;
-      self.mode = (RTCVideoCodecMode)videoCodec->mode;
+      self.mode = (RTC_OBJC_TYPE(RTCVideoCodecMode))videoCodec->mode;
     }
   }
 

--- a/sdk/objc/api/peerconnection/RTCVideoSource+Private.h
+++ b/sdk/objc/api/peerconnection/RTCVideoSource+Private.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
               nativeMediaSource:(rtc::scoped_refptr<webrtc::MediaSourceInterface>)nativeMediaSource
-                           type:(RTCMediaSourceType)type NS_UNAVAILABLE;
+                           type:(RTC_OBJC_TYPE(RTCMediaSourceType))type NS_UNAVAILABLE;
 
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
                 signalingThread:(rtc::Thread *)signalingThread

--- a/sdk/objc/api/peerconnection/RTCVideoSource.mm
+++ b/sdk/objc/api/peerconnection/RTCVideoSource.mm
@@ -35,7 +35,7 @@ static webrtc::ObjCVideoTrackSource *getObjCVideoSource(
   RTC_DCHECK(nativeVideoSource);
   if (self = [super initWithFactory:factory
                   nativeMediaSource:nativeVideoSource
-                               type:RTCMediaSourceTypeVideo]) {
+                               type:RTC_OBJC_TYPE(RTCMediaSourceTypeVideo)]) {
     _nativeVideoSource = nativeVideoSource;
   }
   return self;
@@ -43,7 +43,7 @@ static webrtc::ObjCVideoTrackSource *getObjCVideoSource(
 
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
               nativeMediaSource:(rtc::scoped_refptr<webrtc::MediaSourceInterface>)nativeMediaSource
-                           type:(RTCMediaSourceType)type {
+                           type:(RTC_OBJC_TYPE(RTCMediaSourceType))type {
   RTC_DCHECK_NOTREACHED();
   return nil;
 }

--- a/sdk/objc/api/peerconnection/RTCVideoTrack.mm
+++ b/sdk/objc/api/peerconnection/RTCVideoTrack.mm
@@ -32,7 +32,7 @@
   std::string nativeId = [NSString stdStringForString:trackId];
   rtc::scoped_refptr<webrtc::VideoTrackInterface> track =
       factory.nativeFactory->CreateVideoTrack(source.nativeVideoSource, nativeId);
-  if (self = [self initWithFactory:factory nativeTrack:track type:RTCMediaStreamTrackTypeVideo]) {
+  if (self = [self initWithFactory:factory nativeTrack:track type:RTC_OBJC_TYPE(RTCMediaStreamTrackTypeVideo)]) {
     _source = source;
   }
   return self;
@@ -41,10 +41,10 @@
 - (instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
                     nativeTrack:
                         (rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>)nativeMediaTrack
-                           type:(RTCMediaStreamTrackType)type {
+                           type:(RTC_OBJC_TYPE(RTCMediaStreamTrackType))type {
   NSParameterAssert(factory);
   NSParameterAssert(nativeMediaTrack);
-  NSParameterAssert(type == RTCMediaStreamTrackTypeVideo);
+  NSParameterAssert(type == RTC_OBJC_TYPE(RTCMediaStreamTrackTypeVideo));
   if (self = [super initWithFactory:factory nativeTrack:nativeMediaTrack type:type]) {
     _adapters = [NSMutableArray array];
     _workerThread = factory.workerThread;

--- a/sdk/objc/api/video_codec/RTCVideoCodecConstants.h
+++ b/sdk/objc/api/video_codec/RTCVideoCodecConstants.h
@@ -12,6 +12,6 @@
 
 #import "RTCMacros.h"
 
-RTC_EXTERN NSString* const kRTCVideoCodecVp8Name;
-RTC_EXTERN NSString* const kRTCVideoCodecVp9Name;
-RTC_EXTERN NSString* const kRTCVideoCodecAv1Name;
+RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecVp8Name);
+RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name);
+RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name);

--- a/sdk/objc/api/video_codec/RTCVideoCodecConstants.mm
+++ b/sdk/objc/api/video_codec/RTCVideoCodecConstants.mm
@@ -13,6 +13,6 @@
 
 #include "media/base/media_constants.h"
 
-NSString *const kRTCVideoCodecVp8Name = @(cricket::kVp8CodecName);
-NSString *const kRTCVideoCodecVp9Name = @(cricket::kVp9CodecName);
-NSString *const kRTCVideoCodecAv1Name = @(cricket::kAv1CodecName);
+NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecVp8Name) = @(cricket::kVp8CodecName);
+NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name) = @(cricket::kVp9CodecName);
+NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name) = @(cricket::kAv1CodecName);

--- a/sdk/objc/base/RTCEncodedImage.h
+++ b/sdk/objc/base/RTCEncodedImage.h
@@ -17,16 +17,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Represents an encoded frame's type. */
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCFrameType)) {
-  RTCFrameTypeEmptyFrame = 0,
-  RTCFrameTypeAudioFrameSpeech = 1,
-  RTCFrameTypeAudioFrameCN = 2,
-  RTCFrameTypeVideoFrameKey = 3,
-  RTCFrameTypeVideoFrameDelta = 4,
+  RTC_OBJC_TYPE(RTCFrameTypeEmptyFrame) = 0,
+  RTC_OBJC_TYPE(RTCFrameTypeAudioFrameSpeech) = 1,
+  RTC_OBJC_TYPE(RTCFrameTypeAudioFrameCN) = 2,
+  RTC_OBJC_TYPE(RTCFrameTypeVideoFrameKey) = 3,
+  RTC_OBJC_TYPE(RTCFrameTypeVideoFrameDelta) = 4,
 };
 
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCVideoContentType)) {
-  RTCVideoContentTypeUnspecified,
-  RTCVideoContentTypeScreenshare,
+  RTC_OBJC_TYPE(RTCVideoContentTypeUnspecified),
+  RTC_OBJC_TYPE(RTCVideoContentTypeScreenshare),
 };
 
 /** Represents an encoded frame. Corresponds to webrtc::EncodedImage. */
@@ -43,7 +43,7 @@ RTC_OBJC_EXPORT
 @property(nonatomic, assign) int64_t encodeStartMs;
 @property(nonatomic, assign) int64_t encodeFinishMs;
 @property(nonatomic, assign) RTC_OBJC_TYPE(RTCFrameType) frameType;
-@property(nonatomic, assign) RTCVideoRotation rotation;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCVideoRotation) rotation;
 @property(nonatomic, strong) NSNumber *qp;
 @property(nonatomic, assign) RTC_OBJC_TYPE(RTCVideoContentType) contentType;
 

--- a/sdk/objc/base/RTCEncodedImage.h
+++ b/sdk/objc/base/RTCEncodedImage.h
@@ -16,7 +16,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Represents an encoded frame's type. */
-typedef NS_ENUM(NSUInteger, RTCFrameType) {
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCFrameType)) {
   RTCFrameTypeEmptyFrame = 0,
   RTCFrameTypeAudioFrameSpeech = 1,
   RTCFrameTypeAudioFrameCN = 2,
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSUInteger, RTCFrameType) {
   RTCFrameTypeVideoFrameDelta = 4,
 };
 
-typedef NS_ENUM(NSUInteger, RTCVideoContentType) {
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCVideoContentType)) {
   RTCVideoContentTypeUnspecified,
   RTCVideoContentTypeScreenshare,
 };
@@ -42,10 +42,10 @@ RTC_OBJC_EXPORT
 @property(nonatomic, assign) uint8_t flags;
 @property(nonatomic, assign) int64_t encodeStartMs;
 @property(nonatomic, assign) int64_t encodeFinishMs;
-@property(nonatomic, assign) RTCFrameType frameType;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCFrameType) frameType;
 @property(nonatomic, assign) RTCVideoRotation rotation;
 @property(nonatomic, strong) NSNumber *qp;
-@property(nonatomic, assign) RTCVideoContentType contentType;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCVideoContentType) contentType;
 
 @end
 

--- a/sdk/objc/base/RTCLogging.h
+++ b/sdk/objc/base/RTCLogging.h
@@ -23,14 +23,14 @@ typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCLoggingSeverity)) {
 
 // Wrapper for C++ RTC_LOG(sev) macros.
 // Logs the log string to the webrtc logstream for the given severity.
-RTC_EXTERN void RTCLogEx(RTC_OBJC_TYPE(RTCLoggingSeverity) severity, NSString* log_string);
+RTC_EXTERN void RTC_OBJC_TYPE(RTCLogEx)(RTC_OBJC_TYPE(RTCLoggingSeverity) severity, NSString* log_string);
 
 // Wrapper for rtc::LogMessage::LogToDebug.
 // Sets the minimum severity to be logged to console.
-RTC_EXTERN void RTCSetMinDebugLogLevel(RTC_OBJC_TYPE(RTCLoggingSeverity) severity);
+RTC_EXTERN void RTC_OBJC_TYPE(RTCSetMinDebugLogLevel)(RTC_OBJC_TYPE(RTCLoggingSeverity) severity);
 
 // Returns the filename with the path prefix removed.
-RTC_EXTERN NSString* RTCFileName(const char* filePath);
+RTC_EXTERN NSString* RTC_OBJC_TYPE(RTCFileName)(const char* filePath);
 
 // Some convenience macros.
 

--- a/sdk/objc/base/RTCLogging.h
+++ b/sdk/objc/base/RTCLogging.h
@@ -14,20 +14,20 @@
 
 // Subset of rtc::LoggingSeverity.
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCLoggingSeverity)) {
-  RTCLoggingSeverityVerbose,
-  RTCLoggingSeverityInfo,
-  RTCLoggingSeverityWarning,
-  RTCLoggingSeverityError,
-  RTCLoggingSeverityNone,
+  RTC_OBJC_TYPE(RTCLoggingSeverityVerbose),
+  RTC_OBJC_TYPE(RTCLoggingSeverityInfo),
+  RTC_OBJC_TYPE(RTCLoggingSeverityWarning),
+  RTC_OBJC_TYPE(RTCLoggingSeverityError),
+  RTC_OBJC_TYPE(RTCLoggingSeverityNone),
 };
 
 // Wrapper for C++ RTC_LOG(sev) macros.
 // Logs the log string to the webrtc logstream for the given severity.
-RTC_EXTERN void RTCLogEx(RTCLoggingSeverity severity, NSString* log_string);
+RTC_EXTERN void RTCLogEx(RTC_OBJC_TYPE(RTCLoggingSeverity) severity, NSString* log_string);
 
 // Wrapper for rtc::LogMessage::LogToDebug.
 // Sets the minimum severity to be logged to console.
-RTC_EXTERN void RTCSetMinDebugLogLevel(RTCLoggingSeverity severity);
+RTC_EXTERN void RTCSetMinDebugLogLevel(RTC_OBJC_TYPE(RTCLoggingSeverity) severity);
 
 // Returns the filename with the path prefix removed.
 RTC_EXTERN NSString* RTCFileName(const char* filePath);
@@ -47,13 +47,13 @@ RTC_EXTERN NSString* RTCFileName(const char* filePath);
     RTCLogEx(severity, log_string);                             \
   } while (false)
 
-#define RTCLogVerbose(format, ...) RTCLogFormat(RTCLoggingSeverityVerbose, format, ##__VA_ARGS__)
+#define RTCLogVerbose(format, ...) RTCLogFormat(RTC_OBJC_TYPE(RTCLoggingSeverityVerbose), format, ##__VA_ARGS__)
 
-#define RTCLogInfo(format, ...) RTCLogFormat(RTCLoggingSeverityInfo, format, ##__VA_ARGS__)
+#define RTCLogInfo(format, ...) RTCLogFormat(RTC_OBJC_TYPE(RTCLoggingSeverityInfo), format, ##__VA_ARGS__)
 
-#define RTCLogWarning(format, ...) RTCLogFormat(RTCLoggingSeverityWarning, format, ##__VA_ARGS__)
+#define RTCLogWarning(format, ...) RTCLogFormat(RTC_OBJC_TYPE(RTCLoggingSeverityWarning), format, ##__VA_ARGS__)
 
-#define RTCLogError(format, ...) RTCLogFormat(RTCLoggingSeverityError, format, ##__VA_ARGS__)
+#define RTCLogError(format, ...) RTCLogFormat(RTC_OBJC_TYPE(RTCLoggingSeverityError), format, ##__VA_ARGS__)
 
 #if !defined(NDEBUG)
 #define RTCLogDebug(format, ...) RTCLogInfo(format, ##__VA_ARGS__)

--- a/sdk/objc/base/RTCLogging.h
+++ b/sdk/objc/base/RTCLogging.h
@@ -13,7 +13,7 @@
 #import "RTCMacros.h"
 
 // Subset of rtc::LoggingSeverity.
-typedef NS_ENUM(NSInteger, RTCLoggingSeverity) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCLoggingSeverity)) {
   RTCLoggingSeverityVerbose,
   RTCLoggingSeverityInfo,
   RTCLoggingSeverityWarning,

--- a/sdk/objc/base/RTCLogging.h
+++ b/sdk/objc/base/RTCLogging.h
@@ -34,17 +34,17 @@ RTC_EXTERN NSString* RTC_OBJC_TYPE(RTCFileName)(const char* filePath);
 
 // Some convenience macros.
 
-#define RTCLogString(format, ...)                    \
-  [NSString stringWithFormat:@"(%@:%d %s): " format, \
-                             RTCFileName(__FILE__),  \
-                             __LINE__,               \
-                             __FUNCTION__,           \
+#define RTCLogString(format, ...)                                  \
+  [NSString stringWithFormat:@"(%@:%d %s): " format,               \
+                             RTC_OBJC_TYPE(RTCFileName)(__FILE__), \
+                             __LINE__,                             \
+                             __FUNCTION__,                         \
                              ##__VA_ARGS__]
 
 #define RTCLogFormat(severity, format, ...)                     \
   do {                                                          \
     NSString* log_string = RTCLogString(format, ##__VA_ARGS__); \
-    RTCLogEx(severity, log_string);                             \
+    RTC_OBJC_TYPE(RTCLogEx)(severity, log_string);              \
   } while (false)
 
 #define RTCLogVerbose(format, ...) RTCLogFormat(RTC_OBJC_TYPE(RTCLoggingSeverityVerbose), format, ##__VA_ARGS__)

--- a/sdk/objc/base/RTCLogging.mm
+++ b/sdk/objc/base/RTCLogging.mm
@@ -30,12 +30,12 @@ rtc::LoggingSeverity RTC_OBJC_TYPE(RTCGetNativeLoggingSeverity)(RTC_OBJC_TYPE(RT
 void RTC_OBJC_TYPE(RTCLogEx)(RTC_OBJC_TYPE(RTCLoggingSeverity) severity, NSString* log_string) {
   if (log_string.length) {
     const char* utf8_string = log_string.UTF8String;
-    RTC_LOG_V(RTCGetNativeLoggingSeverity(severity)) << utf8_string;
+    RTC_LOG_V(RTC_OBJC_TYPE(RTCGetNativeLoggingSeverity)(severity)) << utf8_string;
   }
 }
 
 void RTC_OBJC_TYPE(RTCSetMinDebugLogLevel)(RTC_OBJC_TYPE(RTCLoggingSeverity) severity) {
-  rtc::LogMessage::LogToDebug(RTCGetNativeLoggingSeverity(severity));
+  rtc::LogMessage::LogToDebug(RTC_OBJC_TYPE(RTCGetNativeLoggingSeverity)(severity));
 }
 
 NSString* RTC_OBJC_TYPE(RTCFileName)(const char* file_path) {

--- a/sdk/objc/base/RTCLogging.mm
+++ b/sdk/objc/base/RTCLogging.mm
@@ -12,29 +12,29 @@
 
 #include "rtc_base/logging.h"
 
-rtc::LoggingSeverity RTCGetNativeLoggingSeverity(RTCLoggingSeverity severity) {
+rtc::LoggingSeverity RTCGetNativeLoggingSeverity(RTC_OBJC_TYPE(RTCLoggingSeverity) severity) {
   switch (severity) {
-    case RTCLoggingSeverityVerbose:
+    case RTC_OBJC_TYPE(RTCLoggingSeverityVerbose):
       return rtc::LS_VERBOSE;
-    case RTCLoggingSeverityInfo:
+    case RTC_OBJC_TYPE(RTCLoggingSeverityInfo):
       return rtc::LS_INFO;
-    case RTCLoggingSeverityWarning:
+    case RTC_OBJC_TYPE(RTCLoggingSeverityWarning):
       return rtc::LS_WARNING;
-    case RTCLoggingSeverityError:
+    case RTC_OBJC_TYPE(RTCLoggingSeverityError):
       return rtc::LS_ERROR;
-    case RTCLoggingSeverityNone:
+    case RTC_OBJC_TYPE(RTCLoggingSeverityNone):
       return rtc::LS_NONE;
   }
 }
 
-void RTCLogEx(RTCLoggingSeverity severity, NSString* log_string) {
+void RTCLogEx(RTC_OBJC_TYPE(RTCLoggingSeverity) severity, NSString* log_string) {
   if (log_string.length) {
     const char* utf8_string = log_string.UTF8String;
     RTC_LOG_V(RTCGetNativeLoggingSeverity(severity)) << utf8_string;
   }
 }
 
-void RTCSetMinDebugLogLevel(RTCLoggingSeverity severity) {
+void RTCSetMinDebugLogLevel(RTC_OBJC_TYPE(RTCLoggingSeverity) severity) {
   rtc::LogMessage::LogToDebug(RTCGetNativeLoggingSeverity(severity));
 }
 

--- a/sdk/objc/base/RTCLogging.mm
+++ b/sdk/objc/base/RTCLogging.mm
@@ -12,7 +12,7 @@
 
 #include "rtc_base/logging.h"
 
-rtc::LoggingSeverity RTCGetNativeLoggingSeverity(RTC_OBJC_TYPE(RTCLoggingSeverity) severity) {
+rtc::LoggingSeverity RTC_OBJC_TYPE(RTCGetNativeLoggingSeverity)(RTC_OBJC_TYPE(RTCLoggingSeverity) severity) {
   switch (severity) {
     case RTC_OBJC_TYPE(RTCLoggingSeverityVerbose):
       return rtc::LS_VERBOSE;
@@ -27,18 +27,18 @@ rtc::LoggingSeverity RTCGetNativeLoggingSeverity(RTC_OBJC_TYPE(RTCLoggingSeverit
   }
 }
 
-void RTCLogEx(RTC_OBJC_TYPE(RTCLoggingSeverity) severity, NSString* log_string) {
+void RTC_OBJC_TYPE(RTCLogEx)(RTC_OBJC_TYPE(RTCLoggingSeverity) severity, NSString* log_string) {
   if (log_string.length) {
     const char* utf8_string = log_string.UTF8String;
     RTC_LOG_V(RTCGetNativeLoggingSeverity(severity)) << utf8_string;
   }
 }
 
-void RTCSetMinDebugLogLevel(RTC_OBJC_TYPE(RTCLoggingSeverity) severity) {
+void RTC_OBJC_TYPE(RTCSetMinDebugLogLevel)(RTC_OBJC_TYPE(RTCLoggingSeverity) severity) {
   rtc::LogMessage::LogToDebug(RTCGetNativeLoggingSeverity(severity));
 }
 
-NSString* RTCFileName(const char* file_path) {
+NSString* RTC_OBJC_TYPE(RTCFileName)(const char* file_path) {
   NSString* ns_file_path =
       [[NSString alloc] initWithBytesNoCopy:const_cast<char*>(file_path)
                                      length:strlen(file_path)

--- a/sdk/objc/base/RTCMacros.h
+++ b/sdk/objc/base/RTCMacros.h
@@ -41,12 +41,18 @@
 #define RTC_OBJC_TYPE_PREFIX
 #endif
 
+#ifndef RTC_CONSTANT_TYPE_PREFIX
+#define RTC_CONSTANT_TYPE_PREFIX k
+#endif
+
 // RCT_OBJC_TYPE
 //
 // Macro used internally to declare API types. Declaring an API type without
 // using this macro will not include the declared type in the set of types
 // that will be affected by the configurable RTC_OBJC_TYPE_PREFIX.
 #define RTC_OBJC_TYPE(type_name) RTC_SYMBOL_CONCAT(RTC_OBJC_TYPE_PREFIX, type_name)
+
+#define RTC_CONSTANT_TYPE(type_name) RTC_SYMBOL_CONCAT(RTC_CONSTANT_TYPE_PREFIX, type_name)
 
 #if defined(__cplusplus)
 #define RTC_EXTERN extern "C" RTC_OBJC_EXPORT

--- a/sdk/objc/base/RTCVideoEncoderSettings.h
+++ b/sdk/objc/base/RTCVideoEncoderSettings.h
@@ -15,8 +15,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCVideoCodecMode)) {
-  RTCVideoCodecModeRealtimeVideo,
-  RTCVideoCodecModeScreensharing,
+  RTC_OBJC_TYPE(RTCVideoCodecModeRealtimeVideo),
+  RTC_OBJC_TYPE(RTCVideoCodecModeScreensharing),
 };
 
 /** Settings for encoder. Corresponds to webrtc::VideoCodec. */

--- a/sdk/objc/base/RTCVideoEncoderSettings.h
+++ b/sdk/objc/base/RTCVideoEncoderSettings.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSUInteger, RTCVideoCodecMode) {
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCVideoCodecMode)) {
   RTCVideoCodecModeRealtimeVideo,
   RTCVideoCodecModeScreensharing,
 };
@@ -35,7 +35,7 @@ RTC_OBJC_EXPORT
 @property(nonatomic, assign) uint32_t maxFramerate;
 
 @property(nonatomic, assign) unsigned int qpMax;
-@property(nonatomic, assign) RTCVideoCodecMode mode;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCVideoCodecMode) mode;
 
 @end
 

--- a/sdk/objc/base/RTCVideoFrame.h
+++ b/sdk/objc/base/RTCVideoFrame.h
@@ -16,10 +16,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCVideoRotation)) {
-  RTCVideoRotation_0 = 0,
-  RTCVideoRotation_90 = 90,
-  RTCVideoRotation_180 = 180,
-  RTCVideoRotation_270 = 270,
+  RTC_OBJC_TYPE(RTCVideoRotation_0) = 0,
+  RTC_OBJC_TYPE(RTCVideoRotation_90) = 90,
+  RTC_OBJC_TYPE(RTCVideoRotation_180) = 180,
+  RTC_OBJC_TYPE(RTCVideoRotation_270) = 270,
 };
 
 @protocol RTC_OBJC_TYPE
@@ -34,7 +34,7 @@ RTC_OBJC_EXPORT
 
 /** Height without rotation applied. */
 @property(nonatomic, readonly) int height;
-@property(nonatomic, readonly) RTCVideoRotation rotation;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCVideoRotation) rotation;
 
 /** Timestamp in nanoseconds. */
 @property(nonatomic, readonly) int64_t timeStampNs;
@@ -51,7 +51,7 @@ RTC_OBJC_EXPORT
  *  Deprecated - initialize with a RTCCVPixelBuffer instead
  */
 - (instancetype)initWithPixelBuffer:(CVPixelBufferRef)pixelBuffer
-                           rotation:(RTCVideoRotation)rotation
+                           rotation:(RTC_OBJC_TYPE(RTCVideoRotation))rotation
                         timeStampNs:(int64_t)timeStampNs
     DEPRECATED_MSG_ATTRIBUTE("use initWithBuffer instead");
 
@@ -66,14 +66,14 @@ RTC_OBJC_EXPORT
                          cropHeight:(int)cropHeight
                               cropX:(int)cropX
                               cropY:(int)cropY
-                           rotation:(RTCVideoRotation)rotation
+                           rotation:(RTC_OBJC_TYPE(RTCVideoRotation))rotation
                         timeStampNs:(int64_t)timeStampNs
     DEPRECATED_MSG_ATTRIBUTE("use initWithBuffer instead");
 
 /** Initialize an RTCVideoFrame from a frame buffer, rotation, and timestamp.
  */
 - (instancetype)initWithBuffer:(id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)>)frameBuffer
-                      rotation:(RTCVideoRotation)rotation
+                      rotation:(RTC_OBJC_TYPE(RTCVideoRotation))rotation
                    timeStampNs:(int64_t)timeStampNs;
 
 /** Return a frame that is guaranteed to be I420, i.e. it is possible to access

--- a/sdk/objc/base/RTCVideoFrame.h
+++ b/sdk/objc/base/RTCVideoFrame.h
@@ -15,7 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSInteger, RTCVideoRotation) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCVideoRotation)) {
   RTCVideoRotation_0 = 0,
   RTCVideoRotation_90 = 90,
   RTCVideoRotation_180 = 180,

--- a/sdk/objc/base/RTCVideoFrame.mm
+++ b/sdk/objc/base/RTCVideoFrame.mm
@@ -14,7 +14,7 @@
 #import "RTCVideoFrameBuffer.h"
 
 @implementation RTC_OBJC_TYPE (RTCVideoFrame) {
-  RTCVideoRotation _rotation;
+  RTC_OBJC_TYPE(RTCVideoRotation) _rotation;
   int64_t _timeStampNs;
 }
 
@@ -29,7 +29,7 @@
   return _buffer.height;
 }
 
-- (RTCVideoRotation)rotation {
+- (RTC_OBJC_TYPE(RTCVideoRotation) )rotation {
   return _rotation;
 }
 
@@ -44,7 +44,7 @@
 }
 
 - (instancetype)initWithPixelBuffer:(CVPixelBufferRef)pixelBuffer
-                           rotation:(RTCVideoRotation)rotation
+                           rotation:(RTC_OBJC_TYPE(RTCVideoRotation))rotation
                         timeStampNs:(int64_t)timeStampNs {
   // Deprecated.
   return nil;
@@ -57,14 +57,14 @@
                          cropHeight:(int)cropHeight
                               cropX:(int)cropX
                               cropY:(int)cropY
-                           rotation:(RTCVideoRotation)rotation
+                           rotation:(RTC_OBJC_TYPE(RTCVideoRotation))rotation
                         timeStampNs:(int64_t)timeStampNs {
   // Deprecated.
   return nil;
 }
 
 - (instancetype)initWithBuffer:(id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)>)buffer
-                      rotation:(RTCVideoRotation)rotation
+                      rotation:(RTC_OBJC_TYPE(RTCVideoRotation))rotation
                    timeStampNs:(int64_t)timeStampNs {
   if (self = [super init]) {
     _buffer = buffer;

--- a/sdk/objc/components/audio/RTCAudioSession.h
+++ b/sdk/objc/components/audio/RTCAudioSession.h
@@ -15,11 +15,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const kRTCAudioSessionErrorDomain;
+extern NSString *const RTC_CONSTANT_TYPE(RTCAudioSessionErrorDomain);
 /** Method that requires lock was called without lock. */
-extern NSInteger const kRTCAudioSessionErrorLockRequired;
+extern NSInteger const RTC_CONSTANT_TYPE(RTCAudioSessionErrorLockRequired);
 /** Unknown configuration error occurred. */
-extern NSInteger const kRTCAudioSessionErrorConfiguration;
+extern NSInteger const RTC_CONSTANT_TYPE(RTCAudioSessionErrorConfiguration);
 
 @class RTC_OBJC_TYPE(RTCAudioSession);
 @class RTC_OBJC_TYPE(RTCAudioSessionConfiguration);

--- a/sdk/objc/components/audio/RTCAudioSession.mm
+++ b/sdk/objc/components/audio/RTCAudioSession.mm
@@ -26,10 +26,10 @@
 #error ABSL_HAVE_THREAD_LOCAL should be defined for MacOS / iOS Targets.
 #endif
 
-NSString *const kRTCAudioSessionErrorDomain = @"org.webrtc.RTC_OBJC_TYPE(RTCAudioSession)";
-NSInteger const kRTCAudioSessionErrorLockRequired = -1;
-NSInteger const kRTCAudioSessionErrorConfiguration = -2;
-NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
+NSString *const RTC_CONSTANT_TYPE(RTCAudioSessionErrorDomain) = @"org.webrtc.RTC_OBJC_TYPE(RTCAudioSession)";
+NSInteger const RTC_CONSTANT_TYPE(RTCAudioSessionErrorLockRequired) = -1;
+NSInteger const RTC_CONSTANT_TYPE(RTCAudioSessionErrorConfiguration) = -2;
+NSString * const RTC_CONSTANT_TYPE(RTCAudioSessionOutputVolumeSelector) = @"outputVolume";
 
 namespace {
 // Since webrtc::Mutex is not a reentrant lock and cannot check if the mutex is locked,
@@ -110,7 +110,7 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
                    name:UIApplicationDidBecomeActiveNotification
                  object:nil];
     [_session addObserver:self
-               forKeyPath:kRTCAudioSessionOutputVolumeSelector
+               forKeyPath:RTC_CONSTANT_TYPE(RTCAudioSessionOutputVolumeSelector)
                   options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
                   context:(__bridge void *)RTC_OBJC_TYPE(RTCAudioSession).class];
 
@@ -122,7 +122,7 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [_session removeObserver:self
-                forKeyPath:kRTCAudioSessionOutputVolumeSelector
+                forKeyPath:RTC_CONSTANT_TYPE(RTCAudioSessionOutputVolumeSelector)
                    context:(__bridge void *)RTC_OBJC_TYPE(RTCAudioSession).class];
   RTCLog(@"RTC_OBJC_TYPE(RTCAudioSession) (%p): dealloc.", self);
 }
@@ -623,8 +623,8 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
 + (NSError *)lockError {
   NSDictionary *userInfo =
       @{NSLocalizedDescriptionKey : @"Must call lockForConfiguration before calling this method."};
-  NSError *error = [[NSError alloc] initWithDomain:kRTCAudioSessionErrorDomain
-                                              code:kRTCAudioSessionErrorLockRequired
+  NSError *error = [[NSError alloc] initWithDomain:RTC_CONSTANT_TYPE(RTCAudioSessionErrorDomain)
+                                              code:RTC_CONSTANT_TYPE(RTCAudioSessionErrorLockRequired)
                                           userInfo:userInfo];
   return error;
 }
@@ -794,8 +794,8 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
   NSDictionary* userInfo = @{
     NSLocalizedDescriptionKey: description,
   };
-  return [[NSError alloc] initWithDomain:kRTCAudioSessionErrorDomain
-                                    code:kRTCAudioSessionErrorConfiguration
+  return [[NSError alloc] initWithDomain:RTC_CONSTANT_TYPE(RTCAudioSessionErrorDomain)
+                                    code:RTC_CONSTANT_TYPE(RTCAudioSessionErrorConfiguration)
                                 userInfo:userInfo];
 }
 
@@ -881,7 +881,7 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
     SEL sel = @selector(audioSession:audioUnitStartFailedWithError:);
     if ([delegate respondsToSelector:sel]) {
       [delegate audioSession:self
-          audioUnitStartFailedWithError:[NSError errorWithDomain:kRTCAudioSessionErrorDomain
+          audioUnitStartFailedWithError:[NSError errorWithDomain:RTC_CONSTANT_TYPE(RTCAudioSessionErrorDomain)
                                                             code:error
                                                         userInfo:nil]];
     }

--- a/sdk/objc/components/audio/RTCAudioSessionConfiguration.h
+++ b/sdk/objc/components/audio/RTCAudioSessionConfiguration.h
@@ -15,9 +15,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-RTC_EXTERN const int kRTCAudioSessionPreferredNumberOfChannels;
-RTC_EXTERN const double kRTCAudioSessionHighPerformanceSampleRate;
-RTC_EXTERN const double kRTCAudioSessionHighPerformanceIOBufferDuration;
+RTC_EXTERN const int RTC_CONSTANT_TYPE(RTCAudioSessionPreferredNumberOfChannels);
+RTC_EXTERN const double RTC_CONSTANT_TYPE(RTCAudioSessionHighPerformanceSampleRate);
+RTC_EXTERN const double RTC_CONSTANT_TYPE(RTCAudioSessionHighPerformanceIOBufferDuration);
 
 // Struct to hold configuration values.
 RTC_OBJC_EXPORT

--- a/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
+++ b/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
@@ -22,13 +22,13 @@
 // audio unit. Hence, we will not hit a RTC_CHECK in
 // VerifyAudioParametersForActiveAudioSession() for a mismatch between the
 // preferred number of channels and the actual number of channels.
-const int kRTCAudioSessionPreferredNumberOfChannels = 1;
+const int RTC_CONSTANT_TYPE(RTCAudioSessionPreferredNumberOfChannels) = 1;
 
 // Preferred hardware sample rate (unit is in Hertz). The client sample rate
 // will be set to this value as well to avoid resampling the the audio unit's
 // format converter. Note that, some devices, e.g. BT headsets, only supports
 // 8000Hz as native sample rate.
-const double kRTCAudioSessionHighPerformanceSampleRate = 48000.0;
+const double RTC_CONSTANT_TYPE(RTCAudioSessionHighPerformanceSampleRate) = 48000.0;
 
 // Use a hardware I/O buffer size (unit is in seconds) that matches the 10ms
 // size used by WebRTC. The exact actual size will differ between devices.
@@ -38,7 +38,7 @@ const double kRTCAudioSessionHighPerformanceSampleRate = 48000.0;
 // buffers used by WebRTC. It is beneficial for the performance if the native
 // size is as an even multiple of 10ms as possible since it results in "clean"
 // callback sequence without bursts of callbacks back to back.
-const double kRTCAudioSessionHighPerformanceIOBufferDuration = 0.02;
+const double RTC_CONSTANT_TYPE(RTCAudioSessionHighPerformanceIOBufferDuration) = 0.02;
 
 static RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *gWebRTCConfiguration = nil;
 
@@ -68,15 +68,15 @@ static RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *gWebRTCConfiguration = nil;
 
     // Use best sample rate and buffer duration if the CPU has more than one
     // core.
-    _sampleRate = kRTCAudioSessionHighPerformanceSampleRate;
-    _ioBufferDuration = kRTCAudioSessionHighPerformanceIOBufferDuration;
+    _sampleRate = RTC_CONSTANT_TYPE(RTCAudioSessionHighPerformanceSampleRate);
+    _ioBufferDuration = RTC_CONSTANT_TYPE(RTCAudioSessionHighPerformanceIOBufferDuration);
 
     // We try to use mono in both directions to save resources and format
     // conversions in the audio unit. Some devices does only support stereo;
     // e.g. wired headset on iPhone 6.
     // TODO(henrika): add support for stereo if needed.
-    _inputNumberOfChannels = kRTCAudioSessionPreferredNumberOfChannels;
-    _outputNumberOfChannels = kRTCAudioSessionPreferredNumberOfChannels;
+    _inputNumberOfChannels = RTC_CONSTANT_TYPE(RTCAudioSessionPreferredNumberOfChannels);
+    _outputNumberOfChannels = RTC_CONSTANT_TYPE(RTCAudioSessionPreferredNumberOfChannels);
   }
   return self;
 }

--- a/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
+++ b/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
@@ -48,7 +48,7 @@ const int64_t kNanosecondsPerSecond = 1000000000;
   AVCaptureSession *_captureSession;
   FourCharCode _preferredOutputPixelFormat;
   FourCharCode _outputPixelFormat;
-  RTCVideoRotation _rotation;
+  RTC_OBJC_TYPE(RTCVideoRotation) _rotation;
 
 #if TARGET_WATCH_DEVICE_ROTATION
   UIInterfaceOrientation _orientation;
@@ -97,7 +97,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
 
 #if TARGET_WATCH_DEVICE_ROTATION
     _orientation = UIInterfaceOrientationPortrait;
-    _rotation = RTCVideoRotation_90;
+    _rotation = RTC_OBJC_TYPE(RTCVideoRotation_90);
     [center addObserver:self
                selector:@selector(deviceOrientationDidChange:)
                    name:UIDeviceOrientationDidChangeNotification
@@ -201,7 +201,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
              completionHandler:(nullable void (^)(NSError *_Nullable error))completionHandler {
   _willBeRunning = YES;
   [RTC_OBJC_TYPE(RTCDispatcher)
-      dispatchAsyncOnType:RTCDispatcherTypeCaptureSession
+      dispatchAsyncOnType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)
                     block:^{
                       RTCLogInfo("startCaptureWithDevice %@ @ %ld fps", format, (long)fps);
 
@@ -245,7 +245,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
 - (void)stopCaptureWithCompletionHandler:(nullable void (^)(void))completionHandler {
   _willBeRunning = NO;
   [RTC_OBJC_TYPE(RTCDispatcher)
-      dispatchAsyncOnType:RTCDispatcherTypeCaptureSession
+      dispatchAsyncOnType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)
                     block:^{
                       RTCLogInfo("Stop");
 
@@ -320,24 +320,24 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
   }
   switch (_orientation) {
     case UIInterfaceOrientationPortrait:
-      _rotation = RTCVideoRotation_90;
+      _rotation = RTC_OBJC_TYPE(RTCVideoRotation_90);
       break;
     case UIInterfaceOrientationPortraitUpsideDown:
-      _rotation = RTCVideoRotation_270;
+      _rotation = RTC_OBJC_TYPE(RTCVideoRotation_270);
       break;
     case UIInterfaceOrientationLandscapeLeft:
-      _rotation = usingFrontCamera ? RTCVideoRotation_0 : RTCVideoRotation_180;
+      _rotation = usingFrontCamera ? RTC_OBJC_TYPE(RTCVideoRotation_0) : RTC_OBJC_TYPE(RTCVideoRotation_180);
       break;
     case UIInterfaceOrientationLandscapeRight:
-      _rotation = usingFrontCamera ? RTCVideoRotation_180 : RTCVideoRotation_0;
+      _rotation = usingFrontCamera ? RTC_OBJC_TYPE(RTCVideoRotation_180) : RTC_OBJC_TYPE(RTCVideoRotation_0);
       break;
     case UIInterfaceOrientationUnknown:
-      _rotation = RTCVideoRotation_0;
+      _rotation = RTC_OBJC_TYPE(RTCVideoRotation_0);
       break;
   }
 #else
   // No rotation on Mac.
-  _rotation = RTCVideoRotation_0;
+  _rotation = RTC_OBJC_TYPE(RTCVideoRotation_0);
 #endif
 
   RTC_OBJC_TYPE(RTCCVPixelBuffer) *rtcPixelBuffer =
@@ -398,7 +398,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
   NSError *error = [notification.userInfo objectForKey:AVCaptureSessionErrorKey];
   RTCLogError(@"Capture session runtime error: %@", error);
 
-  [RTC_OBJC_TYPE(RTCDispatcher) dispatchAsyncOnType:RTCDispatcherTypeCaptureSession
+  [RTC_OBJC_TYPE(RTCDispatcher) dispatchAsyncOnType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)
                                               block:^{
 #if TARGET_OS_IPHONE && !TARGET_OS_MACCATALYST
                                                 if (error.code == AVErrorMediaServicesWereReset) {
@@ -415,7 +415,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
 - (void)handleCaptureSessionDidStartRunning:(NSNotification *)notification {
   RTCLog(@"Capture session started.");
 
-  [RTC_OBJC_TYPE(RTCDispatcher) dispatchAsyncOnType:RTCDispatcherTypeCaptureSession
+  [RTC_OBJC_TYPE(RTCDispatcher) dispatchAsyncOnType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)
                                               block:^{
                                                 // If we successfully restarted after an unknown
                                                 // error, allow future retries on fatal errors.
@@ -429,7 +429,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
 
 - (void)handleFatalError {
   [RTC_OBJC_TYPE(RTCDispatcher)
-      dispatchAsyncOnType:RTCDispatcherTypeCaptureSession
+      dispatchAsyncOnType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)
                     block:^{
                       if (!self.hasRetriedOnFatalError) {
                         RTCLogWarning(@"Attempting to recover from fatal capture error.");
@@ -442,7 +442,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
 }
 
 - (void)handleNonFatalError {
-  [RTC_OBJC_TYPE(RTCDispatcher) dispatchAsyncOnType:RTCDispatcherTypeCaptureSession
+  [RTC_OBJC_TYPE(RTCDispatcher) dispatchAsyncOnType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)
                                               block:^{
                                                 RTCLog(@"Restarting capture session after error.");
                                                 if (self.isRunning) {
@@ -457,7 +457,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
 
 - (void)handleApplicationDidBecomeActive:(NSNotification *)notification {
   [RTC_OBJC_TYPE(RTCDispatcher)
-      dispatchAsyncOnType:RTCDispatcherTypeCaptureSession
+      dispatchAsyncOnType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)
                     block:^{
                       if (self.isRunning && !self.captureSession.isRunning) {
                         RTCLog(@"Restarting capture session on active.");
@@ -607,7 +607,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
 #pragma mark - Private, called inside capture queue
 
 - (void)updateDeviceCaptureFormat:(AVCaptureDeviceFormat *)format fps:(NSInteger)fps {
-  NSAssert([RTC_OBJC_TYPE(RTCDispatcher) isOnQueueForType:RTCDispatcherTypeCaptureSession],
+  NSAssert([RTC_OBJC_TYPE(RTCDispatcher) isOnQueueForType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)],
            @"updateDeviceCaptureFormat must be called on the capture queue.");
   @try {
     _currentDevice.activeFormat = format;
@@ -621,7 +621,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
 }
 
 - (void)updateZoomFactor {
-  NSAssert([RTC_OBJC_TYPE(RTCDispatcher) isOnQueueForType:RTCDispatcherTypeCaptureSession],
+  NSAssert([RTC_OBJC_TYPE(RTCDispatcher) isOnQueueForType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)],
            @"updateZoomFactor must be called on the capture queue.");
 
 #if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_VISION
@@ -631,7 +631,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
 }
 
 - (void)reconfigureCaptureSessionInput {
-  NSAssert([RTC_OBJC_TYPE(RTCDispatcher) isOnQueueForType:RTCDispatcherTypeCaptureSession],
+  NSAssert([RTC_OBJC_TYPE(RTCDispatcher) isOnQueueForType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)],
            @"reconfigureCaptureSessionInput must be called on the capture queue.");
   NSError *error = nil;
   AVCaptureDeviceInput *input = [[AVCaptureDeviceInput alloc] initWithDevice:_currentDevice
@@ -669,7 +669,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
 
 #if TARGET_WATCH_DEVICE_ROTATION
 - (void)updateOrientation {
-  NSAssert([RTC_OBJC_TYPE(RTCDispatcher) isOnQueueForType:RTCDispatcherTypeMain],
+  NSAssert([RTC_OBJC_TYPE(RTCDispatcher) isOnQueueForType:RTC_OBJC_TYPE(RTCDispatcherTypeMain)],
            @"Retrieving device orientation must be called on the main queue.");
 
   // Must be called on the main queue.
@@ -677,7 +677,7 @@ static NSUInteger _sharedMultiCamSessionCount = 0;
       (UIWindowScene *)[UIApplication sharedApplication].connectedScenes.anyObject;
   UIInterfaceOrientation newOrientation = windowScene.interfaceOrientation;
 
-  [RTC_OBJC_TYPE(RTCDispatcher) dispatchAsyncOnType:RTCDispatcherTypeCaptureSession
+  [RTC_OBJC_TYPE(RTCDispatcher) dispatchAsyncOnType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)
                                               block:^{
                                                 // Must be called on the capture queue
                                                 self->_orientation = newOrientation;

--- a/sdk/objc/components/capturer/RTCDesktopCapturer+Private.h
+++ b/sdk/objc/components/capturer/RTCDesktopCapturer+Private.h
@@ -21,8 +21,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 RTC_OBJC_EXPORT
-@protocol RTC_OBJC_TYPE
-(DesktopCapturerDelegate)<NSObject>
+@protocol RTC_OBJC_TYPE(RTCDesktopCapturerPrivateDelegate)<NSObject>
 -(void)didCaptureVideoFrame:(RTC_OBJC_TYPE(RTCVideoFrame) *) frame;
 -(void)didSourceCaptureStart;
 -(void)didSourceCapturePaused;

--- a/sdk/objc/components/capturer/RTCDesktopCapturer.h
+++ b/sdk/objc/components/capturer/RTCDesktopCapturer.h
@@ -26,8 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class RTC_OBJC_TYPE(RTCDesktopCapturer);
 
 RTC_OBJC_EXPORT
-@protocol RTC_OBJC_TYPE
-(RTCDesktopCapturerDelegate)<NSObject>
+@protocol RTC_OBJC_TYPE(RTCDesktopCapturerDelegate)<NSObject>
 -(void)didSourceCaptureStart:(RTC_OBJC_TYPE(RTCDesktopCapturer) *) capturer;
 
 -(void)didSourceCapturePaused:(RTC_OBJC_TYPE(RTCDesktopCapturer) *) capturer;

--- a/sdk/objc/components/capturer/RTCDesktopCapturer.mm
+++ b/sdk/objc/components/capturer/RTCDesktopCapturer.mm
@@ -35,7 +35,7 @@
 - (instancetype)initWithSource:(RTC_OBJC_TYPE(RTCDesktopSource) *)source delegate:(__weak id<RTC_OBJC_TYPE(RTCDesktopCapturerDelegate)>)delegate captureDelegate:(__weak id<RTC_OBJC_TYPE(RTCVideoCapturerDelegate)>)captureDelegate {
     if (self = [super initWithDelegate:captureDelegate]) {
       webrtc::DesktopType captureType = webrtc::kScreen;
-      if(source.sourceType == RTCDesktopSourceTypeWindow) {
+      if(source.sourceType == RTC_OBJC_TYPE(RTCDesktopSourceTypeWindow)) {
           captureType = webrtc::kWindow;
       }
       _nativeCapturer = std::make_shared<webrtc::ObjCDesktopCapturer>(captureType, source.nativeMediaSource->id(), self);

--- a/sdk/objc/components/capturer/RTCDesktopMediaList.h
+++ b/sdk/objc/components/capturer/RTCDesktopMediaList.h
@@ -38,9 +38,9 @@ RTC_OBJC_EXPORT
 RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCDesktopMediaList) : NSObject
 
--(instancetype)initWithType:(RTCDesktopSourceType)type delegate:(__weak id<RTC_OBJC_TYPE(RTCDesktopMediaListDelegate)>)delegate;
+-(instancetype)initWithType:(RTC_OBJC_TYPE(RTCDesktopSourceType))type delegate:(__weak id<RTC_OBJC_TYPE(RTCDesktopMediaListDelegate)>)delegate;
 
-@property(nonatomic, readonly) RTCDesktopSourceType sourceType;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCDesktopSourceType) sourceType;
 
 - (int32_t)UpdateSourceList:(BOOL)forceReload  updateAllThumbnails:(BOOL)updateThumbnail;
 

--- a/sdk/objc/components/capturer/RTCDesktopMediaList.mm
+++ b/sdk/objc/components/capturer/RTCDesktopMediaList.mm
@@ -20,7 +20,7 @@
 #import "RTCDesktopMediaList+Private.h"
 
 @implementation RTC_OBJC_TYPE(RTCDesktopMediaList) {
-     RTCDesktopSourceType _sourceType;
+     RTC_OBJC_TYPE(RTCDesktopSourceType) _sourceType;
      NSMutableArray<RTC_OBJC_TYPE(RTCDesktopSource) *>* _sources;
      __weak id<RTC_OBJC_TYPE(RTCDesktopMediaListDelegate)> _delegate;
 }
@@ -28,10 +28,10 @@
 @synthesize sourceType = _sourceType;
 @synthesize nativeMediaList = _nativeMediaList;
 
-- (instancetype)initWithType:(RTCDesktopSourceType)type delegate:(__weak id<RTC_OBJC_TYPE(RTCDesktopMediaListDelegate)>)delegate{
+- (instancetype)initWithType:(RTC_OBJC_TYPE(RTCDesktopSourceType))type delegate:(__weak id<RTC_OBJC_TYPE(RTCDesktopMediaListDelegate)>)delegate{
     if (self = [super init]) {
         webrtc::DesktopType captureType = webrtc::kScreen;
-        if(type == RTCDesktopSourceTypeWindow) {
+        if(type == RTC_OBJC_TYPE(RTCDesktopSourceTypeWindow)) {
             captureType = webrtc::kWindow;
         }
         _nativeMediaList = std::make_shared<webrtc::ObjCDesktopMediaList>(captureType, self);

--- a/sdk/objc/components/capturer/RTCDesktopSource+Private.h
+++ b/sdk/objc/components/capturer/RTCDesktopSource+Private.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RTC_OBJC_TYPE(RTCDesktopSource) ()
 
 - (instancetype)initWithNativeSource:(webrtc::MediaSource*) nativeSource 
-                          sourceType:(RTCDesktopSourceType) sourceType;
+                          sourceType:(RTC_OBJC_TYPE(RTCDesktopSourceType)) sourceType;
 
 @property(nonatomic, readonly)webrtc::MediaSource* nativeMediaSource;
 

--- a/sdk/objc/components/capturer/RTCDesktopSource.h
+++ b/sdk/objc/components/capturer/RTCDesktopSource.h
@@ -20,8 +20,8 @@
 #import "RTCMacros.h"
 
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCDesktopSourceType)) {
-  RTCDesktopSourceTypeScreen,
-  RTCDesktopSourceTypeWindow,
+  RTC_OBJC_TYPE(RTCDesktopSourceTypeScreen),
+  RTC_OBJC_TYPE(RTCDesktopSourceTypeWindow),
 };
 
 RTC_OBJC_EXPORT

--- a/sdk/objc/components/capturer/RTCDesktopSource.h
+++ b/sdk/objc/components/capturer/RTCDesktopSource.h
@@ -19,7 +19,7 @@
 
 #import "RTCMacros.h"
 
-typedef NS_ENUM(NSInteger, RTCDesktopSourceType) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCDesktopSourceType)) {
   RTCDesktopSourceTypeScreen,
   RTCDesktopSourceTypeWindow,
 };
@@ -33,7 +33,7 @@ RTC_OBJC_EXPORT
 
 @property(nonatomic, readonly) NSImage *thumbnail;
 
-@property(nonatomic, readonly) RTCDesktopSourceType sourceType;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCDesktopSourceType) sourceType;
 
 -( NSImage *)UpdateThumbnail;
 

--- a/sdk/objc/components/capturer/RTCDesktopSource.mm
+++ b/sdk/objc/components/capturer/RTCDesktopSource.mm
@@ -23,7 +23,7 @@
     NSString *_sourceId;
     NSString *_name;
     NSImage *_thumbnail;
-    RTCDesktopSourceType _sourceType;
+    RTC_OBJC_TYPE(RTCDesktopSourceType) _sourceType;
 }
 
 @synthesize sourceId = _sourceId;
@@ -33,7 +33,7 @@
 @synthesize nativeMediaSource = _nativeMediaSource;
 
 - (instancetype)initWithNativeSource:(webrtc::MediaSource*)nativeSource 
-                          sourceType:(RTCDesktopSourceType) sourceType {
+                          sourceType:(RTC_OBJC_TYPE(RTCDesktopSourceType)) sourceType {
     if (self = [super init]) {
         _nativeMediaSource = nativeSource;
         _sourceId = [NSString stringWithUTF8String:std::to_string(nativeSource->id()).c_str()];

--- a/sdk/objc/components/capturer/RTCFileVideoCapturer.m
+++ b/sdk/objc/components/capturer/RTCFileVideoCapturer.m
@@ -15,7 +15,7 @@
 #import "components/video_frame_buffer/RTCCVPixelBuffer.h"
 #include "rtc_base/system/gcd_helpers.h"
 
-NSString *const kRTCFileVideoCapturerErrorDomain =
+NSString *const RTC_CONSTANT_TYPE(RTCFileVideoCapturerErrorDomain) =
     @"org.webrtc.RTC_OBJC_TYPE(RTCFileVideoCapturer)";
 
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCFileVideoCapturerErrorCode)) {
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCFileVideoCapturerStatus)) {
                             onError:(RTCFileVideoCapturerErrorBlock)errorBlock {
   if (_status == RTC_OBJC_TYPE(RTCFileVideoCapturerStatusStarted)) {
     NSError *error =
-        [NSError errorWithDomain:kRTCFileVideoCapturerErrorDomain
+        [NSError errorWithDomain:RTC_CONSTANT_TYPE(RTCFileVideoCapturerErrorDomain)
                             code:RTC_OBJC_TYPE(RTCFileVideoCapturerErrorCode_CapturerRunning)
                         userInfo:@{NSUnderlyingErrorKey : @"Capturer has been started."}];
 
@@ -63,7 +63,7 @@ typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCFileVideoCapturerStatus)) {
     if (!pathForFile) {
       NSString *errorString =
           [NSString stringWithFormat:@"File %@ not found in bundle", nameOfFile];
-      NSError *error = [NSError errorWithDomain:kRTCFileVideoCapturerErrorDomain
+      NSError *error = [NSError errorWithDomain:RTC_CONSTANT_TYPE(RTCFileVideoCapturerErrorDomain)
                                            code:RTC_OBJC_TYPE(RTCFileVideoCapturerErrorCode_FileNotFound)
                                        userInfo:@{NSUnderlyingErrorKey : errorString}];
       errorBlock(error);

--- a/sdk/objc/components/capturer/RTCFileVideoCapturer.m
+++ b/sdk/objc/components/capturer/RTCFileVideoCapturer.m
@@ -18,15 +18,15 @@
 NSString *const kRTCFileVideoCapturerErrorDomain =
     @"org.webrtc.RTC_OBJC_TYPE(RTCFileVideoCapturer)";
 
-typedef NS_ENUM(NSInteger, RTCFileVideoCapturerErrorCode) {
-  RTCFileVideoCapturerErrorCode_CapturerRunning = 2000,
-  RTCFileVideoCapturerErrorCode_FileNotFound
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCFileVideoCapturerErrorCode)) {
+  RTC_OBJC_TYPE(RTCFileVideoCapturerErrorCode_CapturerRunning) = 2000,
+  RTC_OBJC_TYPE(RTCFileVideoCapturerErrorCode_FileNotFound)
 };
 
-typedef NS_ENUM(NSInteger, RTCFileVideoCapturerStatus) {
-  RTCFileVideoCapturerStatusNotInitialized,
-  RTCFileVideoCapturerStatusStarted,
-  RTCFileVideoCapturerStatusStopped
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCFileVideoCapturerStatus)) {
+  RTC_OBJC_TYPE(RTCFileVideoCapturerStatusNotInitialized),
+  RTC_OBJC_TYPE(RTCFileVideoCapturerStatusStarted),
+  RTC_OBJC_TYPE(RTCFileVideoCapturerStatusStopped)
 };
 
 @interface RTC_OBJC_TYPE (RTCFileVideoCapturer)
@@ -37,7 +37,7 @@ typedef NS_ENUM(NSInteger, RTCFileVideoCapturerStatus) {
 @implementation RTC_OBJC_TYPE (RTCFileVideoCapturer) {
   AVAssetReader *_reader;
   AVAssetReaderTrackOutput *_outTrack;
-  RTCFileVideoCapturerStatus _status;
+  RTC_OBJC_TYPE(RTCFileVideoCapturerStatus) _status;
   dispatch_queue_t _frameQueue;
 }
 
@@ -46,16 +46,16 @@ typedef NS_ENUM(NSInteger, RTCFileVideoCapturerStatus) {
 
 - (void)startCapturingFromFileNamed:(NSString *)nameOfFile
                             onError:(RTCFileVideoCapturerErrorBlock)errorBlock {
-  if (_status == RTCFileVideoCapturerStatusStarted) {
+  if (_status == RTC_OBJC_TYPE(RTCFileVideoCapturerStatusStarted)) {
     NSError *error =
         [NSError errorWithDomain:kRTCFileVideoCapturerErrorDomain
-                            code:RTCFileVideoCapturerErrorCode_CapturerRunning
+                            code:RTC_OBJC_TYPE(RTCFileVideoCapturerErrorCode_CapturerRunning)
                         userInfo:@{NSUnderlyingErrorKey : @"Capturer has been started."}];
 
     errorBlock(error);
     return;
   } else {
-    _status = RTCFileVideoCapturerStatusStarted;
+    _status = RTC_OBJC_TYPE(RTCFileVideoCapturerStatusStarted);
   }
 
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSInteger, RTCFileVideoCapturerStatus) {
       NSString *errorString =
           [NSString stringWithFormat:@"File %@ not found in bundle", nameOfFile];
       NSError *error = [NSError errorWithDomain:kRTCFileVideoCapturerErrorDomain
-                                           code:RTCFileVideoCapturerErrorCode_FileNotFound
+                                           code:RTC_OBJC_TYPE(RTCFileVideoCapturerErrorCode_FileNotFound)
                                        userInfo:@{NSUnderlyingErrorKey : errorString}];
       errorBlock(error);
       return;
@@ -101,7 +101,7 @@ typedef NS_ENUM(NSInteger, RTCFileVideoCapturerStatus) {
   [self readNextBuffer];
 }
 - (void)stopCapture {
-  _status = RTCFileVideoCapturerStatusStopped;
+  _status = RTC_OBJC_TYPE(RTCFileVideoCapturerStatusStopped);
   RTCLog(@"File capturer stopped.");
 }
 
@@ -129,7 +129,7 @@ typedef NS_ENUM(NSInteger, RTCFileVideoCapturerStatus) {
 }
 
 - (void)readNextBuffer {
-  if (_status == RTCFileVideoCapturerStatusStopped) {
+  if (_status == RTC_OBJC_TYPE(RTCFileVideoCapturerStatusStopped)) {
     [_reader cancelReading];
     _reader = nil;
     return;

--- a/sdk/objc/components/network/RTCNetworkMonitor.mm
+++ b/sdk/objc/components/network/RTCNetworkMonitor.mm
@@ -101,7 +101,7 @@ rtc::AdapterType AdapterTypeFromInterfaceType(nw_interface_type_t interfaceType)
       });
       nw_path_monitor_set_queue(
           _pathMonitor,
-          [RTC_OBJC_TYPE(RTCDispatcher) dispatchQueueForType:RTCDispatcherTypeNetworkMonitor]);
+          [RTC_OBJC_TYPE(RTCDispatcher) dispatchQueueForType:RTC_OBJC_TYPE(RTCDispatcherTypeNetworkMonitor)]);
       nw_path_monitor_start(_pathMonitor);
     }
   }

--- a/sdk/objc/components/renderer/metal/RTCMTLRenderer.mm
+++ b/sdk/objc/components/renderer/metal/RTCMTLRenderer.mm
@@ -36,7 +36,7 @@ static inline void getCubeVertexData(int cropX,
                                      int cropHeight,
                                      size_t frameWidth,
                                      size_t frameHeight,
-                                     RTCVideoRotation rotation,
+                                     RTC_OBJC_TYPE(RTCVideoRotation) rotation,
                                      float *buffer) {
   // The computed values are the adjusted texture coordinates, in [0..1].
   // For the left and top, 0.0 means no cropping and e.g. 0.2 means we're skipping 20% of the
@@ -51,28 +51,28 @@ static inline void getCubeVertexData(int cropX,
   // These arrays map the view coordinates to texture coordinates, taking cropping and rotation
   // into account. The first two columns are view coordinates, the last two are texture coordinates.
   switch (rotation) {
-    case RTCVideoRotation_0: {
+    case RTC_OBJC_TYPE(RTCVideoRotation_0): {
       float values[16] = {-1.0, -1.0, cropLeft, cropBottom,
                            1.0, -1.0, cropRight, cropBottom,
                           -1.0,  1.0, cropLeft, cropTop,
                            1.0,  1.0, cropRight, cropTop};
       memcpy(buffer, &values, sizeof(values));
     } break;
-    case RTCVideoRotation_90: {
+    case RTC_OBJC_TYPE(RTCVideoRotation_90): {
       float values[16] = {-1.0, -1.0, cropRight, cropBottom,
                            1.0, -1.0, cropRight, cropTop,
                           -1.0,  1.0, cropLeft, cropBottom,
                            1.0,  1.0, cropLeft, cropTop};
       memcpy(buffer, &values, sizeof(values));
     } break;
-    case RTCVideoRotation_180: {
+    case RTC_OBJC_TYPE(RTCVideoRotation_180): {
       float values[16] = {-1.0, -1.0, cropRight, cropTop,
                            1.0, -1.0, cropLeft, cropTop,
                           -1.0,  1.0, cropRight, cropBottom,
                            1.0,  1.0, cropLeft, cropBottom};
       memcpy(buffer, &values, sizeof(values));
     } break;
-    case RTCVideoRotation_270: {
+    case RTC_OBJC_TYPE(RTCVideoRotation_270): {
       float values[16] = {-1.0, -1.0, cropLeft, cropTop,
                            1.0, -1.0, cropLeft, cropBottom,
                           -1.0, 1.0, cropRight, cropTop,
@@ -109,7 +109,7 @@ static const NSInteger kMaxInflightBuffers = 1;
   int _oldCropHeight;
   int _oldCropX;
   int _oldCropY;
-  RTCVideoRotation _oldRotation;
+  RTC_OBJC_TYPE(RTCVideoRotation) _oldRotation;
 }
 
 @synthesize rotationOverride = _rotationOverride;
@@ -173,7 +173,7 @@ static const NSInteger kMaxInflightBuffers = 1;
 
 - (BOOL)setupTexturesForFrame:(nonnull RTC_OBJC_TYPE(RTCVideoFrame) *)frame {
   // Apply rotation override if set.
-  RTCVideoRotation rotation;
+  RTC_OBJC_TYPE(RTCVideoRotation) rotation;
   NSValue *rotationOverride = self.rotationOverride;
   if (rotationOverride) {
 #if defined(__IPHONE_11_0) && defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && \

--- a/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
+++ b/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
@@ -221,9 +221,9 @@
   [self setNeedsLayout];
 }
 
-- (RTCVideoRotation)videoRotation {
+- (RTC_OBJC_TYPE(RTCVideoRotation) )videoRotation {
   if (self.rotationOverride) {
-    RTCVideoRotation rotation;
+    RTC_OBJC_TYPE(RTCVideoRotation) rotation;
     if (@available(iOS 11, macos 10.13, *)) {
       [self.rotationOverride getValue:&rotation size:sizeof(rotation)];
     } else {
@@ -238,12 +238,12 @@
 - (CGSize)drawableSize {
   // Flip width/height if the rotations are not the same.
   CGSize videoFrameSize = self.videoFrameSize;
-  RTCVideoRotation videoRotation = [self videoRotation];
+  RTC_OBJC_TYPE(RTCVideoRotation) videoRotation = [self videoRotation];
 
   BOOL useLandscape =
-      (videoRotation == RTCVideoRotation_0) || (videoRotation == RTCVideoRotation_180);
-  BOOL sizeIsLandscape = (self.videoFrame.rotation == RTCVideoRotation_0) ||
-      (self.videoFrame.rotation == RTCVideoRotation_180);
+      (videoRotation == RTC_OBJC_TYPE(RTCVideoRotation_0)) || (videoRotation == RTC_OBJC_TYPE(RTCVideoRotation_180));
+  BOOL sizeIsLandscape = (self.videoFrame.rotation == RTC_OBJC_TYPE(RTCVideoRotation_0)) ||
+      (self.videoFrame.rotation == RTC_OBJC_TYPE(RTCVideoRotation_180));
 
   CGSize size;
   if (useLandscape == sizeIsLandscape) {

--- a/sdk/objc/components/renderer/opengl/RTCShader.h
+++ b/sdk/objc/components/renderer/opengl/RTCShader.h
@@ -10,7 +10,7 @@
 
 #import "base/RTCVideoFrame.h"
 
-RTC_EXTERN const char kRTCVertexShaderSource[];
+RTC_EXTERN const char RTC_CONSTANT_TYPE(RTCVertexShaderSource)[];
 
 RTC_EXTERN GLuint RTC_OBJC_TYPE(RTCCreateShader)(GLenum type, const GLchar* source);
 RTC_EXTERN GLuint RTC_OBJC_TYPE(RTCCreateProgram)(GLuint vertexShader, GLuint fragmentShader);

--- a/sdk/objc/components/renderer/opengl/RTCShader.h
+++ b/sdk/objc/components/renderer/opengl/RTCShader.h
@@ -12,10 +12,10 @@
 
 RTC_EXTERN const char kRTCVertexShaderSource[];
 
-RTC_EXTERN GLuint RTCCreateShader(GLenum type, const GLchar* source);
-RTC_EXTERN GLuint RTCCreateProgram(GLuint vertexShader, GLuint fragmentShader);
+RTC_EXTERN GLuint RTC_OBJC_TYPE(RTCCreateShader)(GLenum type, const GLchar* source);
+RTC_EXTERN GLuint RTC_OBJC_TYPE(RTCCreateProgram)(GLuint vertexShader, GLuint fragmentShader);
 RTC_EXTERN GLuint
-RTCCreateProgramFromFragmentSource(const char fragmentShaderSource[]);
-RTC_EXTERN BOOL RTCCreateVertexBuffer(GLuint* vertexBuffer,
+RTC_OBJC_TYPE(RTCCreateProgramFromFragmentSource)(const char fragmentShaderSource[]);
+RTC_EXTERN BOOL RTC_OBJC_TYPE(RTCCreateVertexBuffer)(GLuint* vertexBuffer,
                                       GLuint* vertexArray);
-RTC_EXTERN void RTCSetVertexData(RTCVideoRotation rotation);
+RTC_EXTERN void RTC_OBJC_TYPE(RTCSetVertexData)(RTCVideoRotation rotation);

--- a/sdk/objc/components/renderer/opengl/RTCShader.mm
+++ b/sdk/objc/components/renderer/opengl/RTCShader.mm
@@ -150,16 +150,16 @@ void RTCSetVertexData(RTCVideoRotation rotation) {
   // Rotate the UV coordinates.
   int rotation_offset;
   switch (rotation) {
-    case RTCVideoRotation_0:
+    case RTC_OBJC_TYPE(RTCVideoRotation_0):
       rotation_offset = 0;
       break;
-    case RTCVideoRotation_90:
+    case RTC_OBJC_TYPE(RTCVideoRotation_90):
       rotation_offset = 1;
       break;
-    case RTCVideoRotation_180:
+    case RTC_OBJC_TYPE(RTCVideoRotation_180):
       rotation_offset = 2;
       break;
-    case RTCVideoRotation_270:
+    case RTC_OBJC_TYPE(RTCVideoRotation_270):
       rotation_offset = 3;
       break;
   }

--- a/sdk/objc/components/renderer/opengl/RTCShader.mm
+++ b/sdk/objc/components/renderer/opengl/RTCShader.mm
@@ -22,7 +22,7 @@
 #include "rtc_base/logging.h"
 
 // Vertex shader doesn't do anything except pass coordinates through.
-const char kRTCVertexShaderSource[] =
+const char RTC_CONSTANT_TYPE(RTCVertexShaderSource)[] =
   SHADER_VERSION
   VERTEX_SHADER_IN " vec2 position;\n"
   VERTEX_SHADER_IN " vec2 texcoord;\n"
@@ -84,7 +84,7 @@ GLuint RTC_OBJC_TYPE(RTCCreateProgram)(GLuint vertexShader, GLuint fragmentShade
 // Creates and links a shader program with the given fragment shader source and
 // a plain vertex shader. Returns the program handle or 0 on error.
 GLuint RTC_OBJC_TYPE(RTCCreateProgramFromFragmentSource)(const char fragmentShaderSource[]) {
-  GLuint vertexShader = RTCCreateShader(GL_VERTEX_SHADER, kRTCVertexShaderSource);
+  GLuint vertexShader = RTCCreateShader(GL_VERTEX_SHADER, RTC_CONSTANT_TYPE(RTCVertexShaderSource));
   RTC_CHECK(vertexShader) << "failed to create vertex shader";
   GLuint fragmentShader =
       RTCCreateShader(GL_FRAGMENT_SHADER, fragmentShaderSource);

--- a/sdk/objc/components/renderer/opengl/RTCShader.mm
+++ b/sdk/objc/components/renderer/opengl/RTCShader.mm
@@ -34,7 +34,7 @@ const char kRTCVertexShaderSource[] =
 
 // Compiles a shader of the given `type` with GLSL source `source` and returns
 // the shader handle or 0 on error.
-GLuint RTCCreateShader(GLenum type, const GLchar *source) {
+GLuint RTC_OBJC_TYPE(RTCCreateShader)(GLenum type, const GLchar *source) {
   GLuint shader = glCreateShader(type);
   if (!shader) {
     return 0;
@@ -61,7 +61,7 @@ GLuint RTCCreateShader(GLenum type, const GLchar *source) {
 
 // Links a shader program with the given vertex and fragment shaders and
 // returns the program handle or 0 on error.
-GLuint RTCCreateProgram(GLuint vertexShader, GLuint fragmentShader) {
+GLuint RTC_OBJC_TYPE(RTCCreateProgram)(GLuint vertexShader, GLuint fragmentShader) {
   if (vertexShader == 0 || fragmentShader == 0) {
     return 0;
   }
@@ -83,7 +83,7 @@ GLuint RTCCreateProgram(GLuint vertexShader, GLuint fragmentShader) {
 
 // Creates and links a shader program with the given fragment shader source and
 // a plain vertex shader. Returns the program handle or 0 on error.
-GLuint RTCCreateProgramFromFragmentSource(const char fragmentShaderSource[]) {
+GLuint RTC_OBJC_TYPE(RTCCreateProgramFromFragmentSource)(const char fragmentShaderSource[]) {
   GLuint vertexShader = RTCCreateShader(GL_VERTEX_SHADER, kRTCVertexShaderSource);
   RTC_CHECK(vertexShader) << "failed to create vertex shader";
   GLuint fragmentShader =
@@ -120,7 +120,7 @@ GLuint RTCCreateProgramFromFragmentSource(const char fragmentShaderSource[]) {
   return program;
 }
 
-BOOL RTCCreateVertexBuffer(GLuint *vertexBuffer, GLuint *vertexArray) {
+BOOL RTC_OBJC_TYPE(RTCCreateVertexBuffer)(GLuint *vertexBuffer, GLuint *vertexArray) {
   glGenBuffers(1, vertexBuffer);
   if (*vertexBuffer == 0) {
     glDeleteVertexArrays(1, vertexArray);
@@ -132,7 +132,7 @@ BOOL RTCCreateVertexBuffer(GLuint *vertexBuffer, GLuint *vertexArray) {
 }
 
 // Set vertex data to the currently bound vertex buffer.
-void RTCSetVertexData(RTCVideoRotation rotation) {
+void RTC_OBJC_TYPE(RTCSetVertexData)(RTCVideoRotation rotation) {
   // When modelview and projection matrices are identity (default) the world is
   // contained in the square around origin with unit size 2. Drawing to these
   // coordinates is equivalent to drawing to the entire screen. The texture is

--- a/sdk/objc/components/renderer/opengl/RTCVideoViewShading.h
+++ b/sdk/objc/components/renderer/opengl/RTCVideoViewShading.h
@@ -24,13 +24,13 @@ RTC_OBJC_EXPORT
 
     /** Callback for I420 frames. Each plane is given as a texture. */
     - (void)applyShadingForFrameWithWidth : (int)width height : (int)height rotation
-    : (RTCVideoRotation)rotation yPlane : (GLuint)yPlane uPlane : (GLuint)uPlane vPlane
+    : (RTC_OBJC_TYPE(RTCVideoRotation))rotation yPlane : (GLuint)yPlane uPlane : (GLuint)uPlane vPlane
     : (GLuint)vPlane;
 
 /** Callback for NV12 frames. Each plane is given as a texture. */
 - (void)applyShadingForFrameWithWidth:(int)width
                                height:(int)height
-                             rotation:(RTCVideoRotation)rotation
+                             rotation:(RTC_OBJC_TYPE(RTCVideoRotation))rotation
                                yPlane:(GLuint)yPlane
                               uvPlane:(GLuint)uvPlane;
 

--- a/sdk/objc/components/video_codec/RTCCodecSpecificInfoH264.h
+++ b/sdk/objc/components/video_codec/RTCCodecSpecificInfoH264.h
@@ -15,8 +15,8 @@
 
 /** Class for H264 specific config. */
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCH264PacketizationMode)) {
-  RTCH264PacketizationModeNonInterleaved = 0,  // Mode 1 - STAP-A, FU-A is allowed
-  RTCH264PacketizationModeSingleNalUnit        // Mode 0 - only single NALU allowed
+  RTC_OBJC_TYPE(RTCH264PacketizationModeNonInterleaved) = 0,  // Mode 1 - STAP-A, FU-A is allowed
+  RTC_OBJC_TYPE(RTCH264PacketizationModeSingleNalUnit)        // Mode 0 - only single NALU allowed
 };
 
 RTC_OBJC_EXPORT

--- a/sdk/objc/components/video_codec/RTCCodecSpecificInfoH264.h
+++ b/sdk/objc/components/video_codec/RTCCodecSpecificInfoH264.h
@@ -14,7 +14,7 @@
 #import "RTCMacros.h"
 
 /** Class for H264 specific config. */
-typedef NS_ENUM(NSUInteger, RTCH264PacketizationMode) {
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCH264PacketizationMode)) {
   RTCH264PacketizationModeNonInterleaved = 0,  // Mode 1 - STAP-A, FU-A is allowed
   RTCH264PacketizationModeSingleNalUnit        // Mode 0 - only single NALU allowed
 };
@@ -22,6 +22,6 @@ typedef NS_ENUM(NSUInteger, RTCH264PacketizationMode) {
 RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCCodecSpecificInfoH264) : NSObject <RTC_OBJC_TYPE(RTCCodecSpecificInfo)>
 
-@property(nonatomic, assign) RTCH264PacketizationMode packetizationMode;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCH264PacketizationMode) packetizationMode;
 
 @end

--- a/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.m
+++ b/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.m
@@ -25,25 +25,25 @@
 
 - (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
   NSDictionary<NSString *, NSString *> *constrainedHighParams = @{
-    @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedHigh,
+    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };
   RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedHighInfo =
-      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecH264Name
+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecH264Name)
                                                   parameters:constrainedHighParams];
 
   NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
-    @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedBaseline,
+    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };
   RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedBaselineInfo =
-      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecH264Name
+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecH264Name)
                                                   parameters:constrainedBaselineParams];
 
   RTC_OBJC_TYPE(RTCVideoCodecInfo) *vp8Info =
-      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecVp8Name];
+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecVp8Name)];
 
   NSMutableArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *result = [@[
     constrainedHighInfo,
@@ -53,28 +53,28 @@
 
   if ([RTC_OBJC_TYPE(RTCVideoDecoderVP9) isSupported]) {
     [result
-        addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecVp9Name]];
+        addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name)]];
   }
 
 #if defined(RTC_DAV1D_IN_INTERNAL_DECODER_FACTORY)
-  [result addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecAv1Name]];
+  [result addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name)]];
 #endif
 
   return result;
 }
 
 - (id<RTC_OBJC_TYPE(RTCVideoDecoder)>)createDecoder:(RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info {
-  if ([info.name isEqualToString:kRTCVideoCodecH264Name]) {
+  if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecH264Name)]) {
     return [[RTC_OBJC_TYPE(RTCVideoDecoderH264) alloc] init];
-  } else if ([info.name isEqualToString:kRTCVideoCodecVp8Name]) {
+  } else if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecVp8Name)]) {
     return [RTC_OBJC_TYPE(RTCVideoDecoderVP8) vp8Decoder];
-  } else if ([info.name isEqualToString:kRTCVideoCodecVp9Name] &&
+  } else if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name)] &&
              [RTC_OBJC_TYPE(RTCVideoDecoderVP9) isSupported]) {
     return [RTC_OBJC_TYPE(RTCVideoDecoderVP9) vp9Decoder];
   }
 
 #if defined(RTC_DAV1D_IN_INTERNAL_DECODER_FACTORY)
-  if ([info.name isEqualToString:kRTCVideoCodecAv1Name]) {
+  if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name)]) {
     return [RTC_OBJC_TYPE(RTCVideoDecoderAV1) av1Decoder];
   }
 #endif

--- a/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m
+++ b/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m
@@ -27,25 +27,25 @@
 
 + (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
   NSDictionary<NSString *, NSString *> *constrainedHighParams = @{
-    @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedHigh,
+    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };
   RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedHighInfo =
-      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecH264Name
+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecH264Name)
                                                   parameters:constrainedHighParams];
 
   NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
-    @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedBaseline,
+    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };
   RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedBaselineInfo =
-      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecH264Name
+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecH264Name)
                                                   parameters:constrainedBaselineParams];
 
   RTC_OBJC_TYPE(RTCVideoCodecInfo) *vp8Info =
-      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecVp8Name];
+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecVp8Name)];
 
   NSMutableArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *result = [@[
     constrainedHighInfo,
@@ -55,12 +55,12 @@
 
   if ([RTC_OBJC_TYPE(RTCVideoEncoderVP9) isSupported]) {
     [result
-        addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecVp9Name parameters:nil scalabilityModes:[RTC_OBJC_TYPE(RTCVideoEncoderVP9) scalabilityModes]]];
+        addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name) parameters:nil scalabilityModes:[RTC_OBJC_TYPE(RTCVideoEncoderVP9) scalabilityModes]]];
   }
 
 #if defined(RTC_USE_LIBAOM_AV1_ENCODER)
   RTC_OBJC_TYPE(RTCVideoCodecInfo) *av1Info =
-    [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecAv1Name parameters:nil scalabilityModes:[RTC_OBJC_TYPE(RTCVideoEncoderAV1) scalabilityModes]];
+    [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name) parameters:nil scalabilityModes:[RTC_OBJC_TYPE(RTCVideoEncoderAV1) scalabilityModes]];
   [result addObject:av1Info];
 #endif
 
@@ -68,17 +68,17 @@
 }
 
 - (id<RTC_OBJC_TYPE(RTCVideoEncoder)>)createEncoder:(RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info {
-  if ([info.name isEqualToString:kRTCVideoCodecH264Name]) {
+  if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecH264Name)]) {
     return [[RTC_OBJC_TYPE(RTCVideoEncoderH264) alloc] initWithCodecInfo:info];
-  } else if ([info.name isEqualToString:kRTCVideoCodecVp8Name]) {
+  } else if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecVp8Name)]) {
     return [RTC_OBJC_TYPE(RTCVideoEncoderVP8) vp8Encoder];
-  } else if ([info.name isEqualToString:kRTCVideoCodecVp9Name] &&
+  } else if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name)] &&
              [RTC_OBJC_TYPE(RTCVideoEncoderVP9) isSupported]) {
     return [RTC_OBJC_TYPE(RTCVideoEncoderVP9) vp9Encoder];
   }
 
 #if defined(RTC_USE_LIBAOM_AV1_ENCODER)
-  if ([info.name isEqualToString:kRTCVideoCodecAv1Name]) {
+  if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name)]) {
     return [RTC_OBJC_TYPE(RTCVideoEncoderAV1) av1Encoder];
   }
 #endif

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.h
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.h
@@ -20,31 +20,31 @@ RTC_OBJC_EXPORT extern NSString *const kRTCMaxSupportedH264ProfileLevelConstrain
 
 /** H264 Profiles and levels. */
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCH264Profile)) {
-  RTCH264ProfileConstrainedBaseline,
-  RTCH264ProfileBaseline,
-  RTCH264ProfileMain,
-  RTCH264ProfileConstrainedHigh,
-  RTCH264ProfileHigh,
+  RTC_OBJC_TYPE(RTCH264ProfileConstrainedBaseline),
+  RTC_OBJC_TYPE(RTCH264ProfileBaseline),
+  RTC_OBJC_TYPE(RTCH264ProfileMain),
+  RTC_OBJC_TYPE(RTCH264ProfileConstrainedHigh),
+  RTC_OBJC_TYPE(RTCH264ProfileHigh),
 };
 
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCH264Level)) {
-  RTCH264Level1_b = 0,
-  RTCH264Level1 = 10,
-  RTCH264Level1_1 = 11,
-  RTCH264Level1_2 = 12,
-  RTCH264Level1_3 = 13,
-  RTCH264Level2 = 20,
-  RTCH264Level2_1 = 21,
-  RTCH264Level2_2 = 22,
-  RTCH264Level3 = 30,
-  RTCH264Level3_1 = 31,
-  RTCH264Level3_2 = 32,
-  RTCH264Level4 = 40,
-  RTCH264Level4_1 = 41,
-  RTCH264Level4_2 = 42,
-  RTCH264Level5 = 50,
-  RTCH264Level5_1 = 51,
-  RTCH264Level5_2 = 52
+  RTC_OBJC_TYPE(RTCH264Level1_b) = 0,
+  RTC_OBJC_TYPE(RTCH264Level1) = 10,
+  RTC_OBJC_TYPE(RTCH264Level1_1) = 11,
+  RTC_OBJC_TYPE(RTCH264Level1_2) = 12,
+  RTC_OBJC_TYPE(RTCH264Level1_3) = 13,
+  RTC_OBJC_TYPE(RTCH264Level2) = 20,
+  RTC_OBJC_TYPE(RTCH264Level2_1) = 21,
+  RTC_OBJC_TYPE(RTCH264Level2_2) = 22,
+  RTC_OBJC_TYPE(RTCH264Level3) = 30,
+  RTC_OBJC_TYPE(RTCH264Level3_1) = 31,
+  RTC_OBJC_TYPE(RTCH264Level3_2) = 32,
+  RTC_OBJC_TYPE(RTCH264Level4) = 40,
+  RTC_OBJC_TYPE(RTCH264Level4_1) = 41,
+  RTC_OBJC_TYPE(RTCH264Level4_2) = 42,
+  RTC_OBJC_TYPE(RTCH264Level5) = 50,
+  RTC_OBJC_TYPE(RTCH264Level5_1) = 51,
+  RTC_OBJC_TYPE(RTCH264Level5_2) = 52
 };
 
 RTC_OBJC_EXPORT

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.h
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.h
@@ -12,11 +12,11 @@
 
 #import "RTCMacros.h"
 
-RTC_OBJC_EXPORT extern NSString *const kRTCVideoCodecH264Name;
-RTC_OBJC_EXPORT extern NSString *const kRTCLevel31ConstrainedHigh;
-RTC_OBJC_EXPORT extern NSString *const kRTCLevel31ConstrainedBaseline;
-RTC_OBJC_EXPORT extern NSString *const kRTCMaxSupportedH264ProfileLevelConstrainedHigh;
-RTC_OBJC_EXPORT extern NSString *const kRTCMaxSupportedH264ProfileLevelConstrainedBaseline;
+RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecH264Name);
+RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCLevel31ConstrainedHigh);
+RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCLevel31ConstrainedBaseline);
+RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh);
+RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline);
 
 /** H264 Profiles and levels. */
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCH264Profile)) {

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.h
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.h
@@ -19,7 +19,7 @@ RTC_OBJC_EXPORT extern NSString *const kRTCMaxSupportedH264ProfileLevelConstrain
 RTC_OBJC_EXPORT extern NSString *const kRTCMaxSupportedH264ProfileLevelConstrainedBaseline;
 
 /** H264 Profiles and levels. */
-typedef NS_ENUM(NSUInteger, RTCH264Profile) {
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCH264Profile)) {
   RTCH264ProfileConstrainedBaseline,
   RTCH264ProfileBaseline,
   RTCH264ProfileMain,
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSUInteger, RTCH264Profile) {
   RTCH264ProfileHigh,
 };
 
-typedef NS_ENUM(NSUInteger, RTCH264Level) {
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCH264Level)) {
   RTCH264Level1_b = 0,
   RTCH264Level1 = 10,
   RTCH264Level1_1 = 11,
@@ -50,11 +50,11 @@ typedef NS_ENUM(NSUInteger, RTCH264Level) {
 RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCH264ProfileLevelId) : NSObject
 
-@property(nonatomic, readonly) RTCH264Profile profile;
-@property(nonatomic, readonly) RTCH264Level level;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCH264Profile) profile;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCH264Level) level;
 @property(nonatomic, readonly) NSString *hexString;
 
 - (instancetype)initWithHexString:(NSString *)hexString;
-- (instancetype)initWithProfile:(RTCH264Profile)profile level:(RTCH264Level)level;
+- (instancetype)initWithProfile:(RTC_OBJC_TYPE(RTCH264Profile))profile level:(RTC_OBJC_TYPE(RTCH264Level))level;
 
 @end

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
@@ -77,8 +77,8 @@ NSString *MaxSupportedProfileLevelConstrainedHigh() {
 @interface RTC_OBJC_TYPE (RTCH264ProfileLevelId)
 ()
 
-    @property(nonatomic, assign) RTCH264Profile profile;
-@property(nonatomic, assign) RTCH264Level level;
+    @property(nonatomic, assign) RTC_OBJC_TYPE(RTCH264Profile) profile;
+@property(nonatomic, assign) RTC_OBJC_TYPE(RTCH264Level) level;
 @property(nonatomic, strong) NSString *hexString;
 
 @end
@@ -96,14 +96,14 @@ NSString *MaxSupportedProfileLevelConstrainedHigh() {
     absl::optional<webrtc::H264ProfileLevelId> profile_level_id =
         webrtc::ParseH264ProfileLevelId([hexString cStringUsingEncoding:NSUTF8StringEncoding]);
     if (profile_level_id.has_value()) {
-      self.profile = static_cast<RTCH264Profile>(profile_level_id->profile);
-      self.level = static_cast<RTCH264Level>(profile_level_id->level);
+      self.profile = static_cast<RTC_OBJC_TYPE(RTCH264Profile)>(profile_level_id->profile);
+      self.level = static_cast<RTC_OBJC_TYPE(RTCH264Level)>(profile_level_id->level);
     }
   }
   return self;
 }
 
-- (instancetype)initWithProfile:(RTCH264Profile)profile level:(RTCH264Level)level {
+- (instancetype)initWithProfile:(RTC_OBJC_TYPE(RTCH264Profile))profile level:(RTC_OBJC_TYPE(RTCH264Level))level {
   if (self = [super init]) {
     self.profile = profile;
     self.level = level;

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
@@ -26,12 +26,12 @@ NSString *MaxSupportedProfileLevelConstrainedBaseline();
 
 }  // namespace
 
-NSString *const kRTCVideoCodecH264Name = @(cricket::kH264CodecName);
-NSString *const kRTCLevel31ConstrainedHigh = @"640c1f";
-NSString *const kRTCLevel31ConstrainedBaseline = @"42e01f";
-NSString *const kRTCMaxSupportedH264ProfileLevelConstrainedHigh =
+NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecH264Name) = @(cricket::kH264CodecName);
+NSString *const RTC_CONSTANT_TYPE(RTCLevel31ConstrainedHigh) = @"640c1f";
+NSString *const RTC_CONSTANT_TYPE(RTCLevel31ConstrainedBaseline) = @"42e01f";
+NSString *const RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh) =
     MaxSupportedProfileLevelConstrainedHigh();
-NSString *const kRTCMaxSupportedH264ProfileLevelConstrainedBaseline =
+NSString *const RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline) =
     MaxSupportedProfileLevelConstrainedBaseline();
 
 namespace {
@@ -59,7 +59,7 @@ NSString *MaxSupportedProfileLevelConstrainedBaseline() {
     return profile;
   }
 #endif
-  return kRTCLevel31ConstrainedBaseline;
+  return RTC_CONSTANT_TYPE(RTCLevel31ConstrainedBaseline);
 }
 
 NSString *MaxSupportedProfileLevelConstrainedHigh() {
@@ -69,7 +69,7 @@ NSString *MaxSupportedProfileLevelConstrainedHigh() {
     return profile;
   }
 #endif
-  return kRTCLevel31ConstrainedHigh;
+  return RTC_CONSTANT_TYPE(RTCLevel31ConstrainedHigh);
 }
 
 }  // namespace

--- a/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH264.m
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH264.m
@@ -17,10 +17,10 @@
 
 - (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
   NSMutableArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *codecs = [NSMutableArray array];
-  NSString *codecName = kRTCVideoCodecH264Name;
+  NSString *codecName = RTC_CONSTANT_TYPE(RTCVideoCodecH264Name);
 
   NSDictionary<NSString *, NSString *> *constrainedHighParams = @{
-    @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedHigh,
+    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };
@@ -30,7 +30,7 @@
   [codecs addObject:constrainedHighInfo];
 
   NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
-    @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedBaseline,
+    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };

--- a/sdk/objc/components/video_codec/RTCVideoDecoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderH264.mm
@@ -64,7 +64,7 @@ void decompressionOutputCallback(void *decoderRef,
       [[RTC_OBJC_TYPE(RTCCVPixelBuffer) alloc] initWithPixelBuffer:imageBuffer];
   RTC_OBJC_TYPE(RTCVideoFrame) *decodedFrame = [[RTC_OBJC_TYPE(RTCVideoFrame) alloc]
       initWithBuffer:frameBuffer
-            rotation:RTCVideoRotation_0
+            rotation:RTC_OBJC_TYPE(RTCVideoRotation_0)
          timeStampNs:CMTimeGetSeconds(timestamp) * rtc::kNumNanosecsPerSec];
   decodedFrame.timeStamp = decodeParams->timestamp;
   decodeParams->callback(decodedFrame);

--- a/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH264.m
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH264.m
@@ -17,10 +17,10 @@
 
 - (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
   NSMutableArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *codecs = [NSMutableArray array];
-  NSString *codecName = kRTCVideoCodecH264Name;
+  NSString *codecName = RTC_CONSTANT_TYPE(RTCVideoCodecH264Name);
 
   NSDictionary<NSString *, NSString *> *constrainedHighParams = @{
-    @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedHigh,
+    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };
@@ -30,7 +30,7 @@
   [codecs addObject:constrainedHighInfo];
 
   NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
-    @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedBaseline,
+    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -392,7 +392,7 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
     RTC_LOG(LS_INFO) << "Using profile "
                      << CFStringToString(ExtractProfile(
                             *_profile_level_id, _codecMode == RTC_OBJC_TYPE(RTCVideoCodecModeScreensharing)));
-    RTC_CHECK([codecInfo.name isEqualToString:kRTCVideoCodecH264Name]);
+    RTC_CHECK([codecInfo.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecH264Name)]);
   }
   return self;
 }
@@ -404,7 +404,7 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
 - (NSInteger)startEncodeWithSettings:(RTC_OBJC_TYPE(RTCVideoEncoderSettings) *)settings
                        numberOfCores:(int)numberOfCores {
   RTC_DCHECK(settings);
-  RTC_DCHECK([settings.name isEqualToString:kRTCVideoCodecH264Name]);
+  RTC_DCHECK([settings.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecH264Name)]);
 
   _width = settings.width;
   _height = settings.height;

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -45,7 +45,7 @@
     : (CMSampleBufferRef)sampleBuffer codecSpecificInfo
     : (id<RTC_OBJC_TYPE(RTCCodecSpecificInfo)>)codecSpecificInfo width : (int32_t)width height
     : (int32_t)height renderTimeMs : (int64_t)renderTimeMs timestamp : (uint32_t)timestamp rotation
-    : (RTCVideoRotation)rotation;
+    : (RTC_OBJC_TYPE(RTCVideoRotation))rotation;
 
 @end
 
@@ -63,14 +63,14 @@ const int kBitsPerByte = 8;
 
 const OSType kNV12PixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
 
-typedef NS_ENUM(NSInteger, RTCVideoEncodeMode) {
-  Variable = 0,
-  Constant = 1,
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCVideoEncodeMode)) {
+  RTC_OBJC_TYPE(RTCVideoEncodeModeVariable) = 0,
+  RTC_OBJC_TYPE(RTCVideoEncodeModeConstant) = 1,
 };
 
-NSArray *CreateRateLimitArray(uint32_t computedBitrateBps, RTCVideoEncodeMode mode) {
+NSArray *CreateRateLimitArray(uint32_t computedBitrateBps, RTC_OBJC_TYPE(RTCVideoEncodeMode) mode) {
   switch (mode) {
-    case Variable: {
+    case RTC_OBJC_TYPE(RTCVideoEncodeModeVariable): {
       // 5 seconds should be an okay interval for VBR to enforce the long-term
       // limit.
       float avgInterval = 5.0;
@@ -81,7 +81,7 @@ NSArray *CreateRateLimitArray(uint32_t computedBitrateBps, RTCVideoEncodeMode mo
           computedBitrateBps * kLimitToAverageBitRateFactor / kBitsPerByte;
       return @[ @(peakBytesPerSecond), @(peakInterval), @(avgBytesPerSecond), @(avgInterval) ];
     }
-    case Constant: {
+    case RTC_OBJC_TYPE(RTCVideoEncodeModeConstant): {
       // CBR should be enforces with granularity of a second.
       float targetInterval = 1.0;
       int32_t targetBitrate = computedBitrateBps / kBitsPerByte;
@@ -99,7 +99,7 @@ struct RTCFrameEncodeParams {
                        int32_t h,
                        int64_t rtms,
                        uint32_t ts,
-                       RTCVideoRotation r)
+                       RTC_OBJC_TYPE(RTCVideoRotation) r)
       : encoder(e), width(w), height(h), render_time_ms(rtms), timestamp(ts), rotation(r) {
     if (csi) {
       codecSpecificInfo = csi;
@@ -114,7 +114,7 @@ struct RTCFrameEncodeParams {
   int32_t height;
   int64_t render_time_ms;
   uint32_t timestamp;
-  RTCVideoRotation rotation;
+  RTC_OBJC_TYPE(RTCVideoRotation) rotation;
 };
 
 // We receive I420Frames as input, but we need to feed CVPixelBuffers into the
@@ -355,18 +355,18 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
   uint32_t _encoderBitrateBps;
   uint32_t _encoderFrameRate;
   uint32_t _maxAllowedFrameRate;
-  RTCH264PacketizationMode _packetizationMode;
+  RTC_OBJC_TYPE(RTCH264PacketizationMode) _packetizationMode;
   absl::optional<webrtc::H264ProfileLevelId> _profile_level_id;
   RTCVideoEncoderCallback _callback;
   int32_t _width;
   int32_t _height;
   VTCompressionSessionRef _compressionSession;
   CVPixelBufferPoolRef _pixelBufferPool;
-  RTCVideoCodecMode _codecMode;
+  RTC_OBJC_TYPE(RTCVideoCodecMode) _codecMode;
   unsigned int _maxQP;
   unsigned int _minBitrate;
   unsigned int _maxBitrate;
-  RTCVideoEncodeMode _encodeMode;
+  RTC_OBJC_TYPE(RTCVideoEncodeMode) _encodeMode;
 
   webrtc::H264BitstreamParser _h264BitstreamParser;
   std::vector<uint8_t> _frameScaleBuffer;
@@ -384,14 +384,14 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
 - (instancetype)initWithCodecInfo:(RTC_OBJC_TYPE(RTCVideoCodecInfo) *)codecInfo {
   if (self = [super init]) {
     _codecInfo = codecInfo;
-    _packetizationMode = RTCH264PacketizationModeNonInterleaved;
+    _packetizationMode = RTC_OBJC_TYPE(RTCH264PacketizationModeNonInterleaved);
     _profile_level_id =
         webrtc::ParseSdpForH264ProfileLevelId([codecInfo nativeSdpVideoFormat].parameters);
     _previousPresentationTimeStamp = kCMTimeZero;
     RTC_DCHECK(_profile_level_id);
     RTC_LOG(LS_INFO) << "Using profile "
                      << CFStringToString(ExtractProfile(
-                            *_profile_level_id, _codecMode == RTCVideoCodecModeScreensharing));
+                            *_profile_level_id, _codecMode == RTC_OBJC_TYPE(RTCVideoCodecModeScreensharing)));
     RTC_CHECK([codecInfo.name isEqualToString:kRTCVideoCodecH264Name]);
   }
   return self;
@@ -411,7 +411,7 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
   _codecMode = settings.mode;
   _maxQP = settings.qpMax;
 
-  _encodeMode = Variable;                    // Always variable mode for now
+  _encodeMode = RTC_OBJC_TYPE(RTCVideoEncodeModeVariable);                    // Always variable mode for now
   _minBitrate = settings.minBitrate * 1000;  // minBitrate is in kbps.
   _maxBitrate = settings.maxBitrate * 1000;  // maxBitrate is in kbps.
 
@@ -421,7 +421,7 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
                                                (aligned_width * aligned_height));
 
   // We can only set average bitrate on the HW encoder.
-  if (_encodeMode == Constant) {
+  if (_encodeMode == RTC_OBJC_TYPE(RTCVideoEncodeModeConstant)) {
     _targetBitrateBps = _maxBitrate;
   } else {
     _targetBitrateBps = settings.startBitrate * 1000;  // startBitrate is in kbps.
@@ -517,7 +517,7 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
   // Check if we need a keyframe.
   if (!isKeyframeRequired && frameTypes) {
     for (NSNumber *frameType in frameTypes) {
-      if ((RTCFrameType)frameType.intValue == RTCFrameTypeVideoFrameKey) {
+      if ((RTC_OBJC_TYPE(RTCFrameType))frameType.intValue == RTC_OBJC_TYPE(RTCFrameTypeVideoFrameKey)) {
         isKeyframeRequired = YES;
         break;
       }
@@ -752,7 +752,7 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
   // https://developer.apple.com/documentation/videotoolbox/kvtcompressionpropertykey_maxallowedframeqp
   if (@available(iOS 15.0, macOS 12.0, *)) {
     // Only enable for screen sharing and let VideoToolbox do the optimizing as much as possible.
-    if (_codecMode == RTCVideoCodecModeScreensharing) {
+    if (_codecMode == RTC_OBJC_TYPE(RTCVideoCodecModeScreensharing)) {
       RTC_LOG(LS_INFO) << "Configuring VideoToolbox to use maxQP: " << kHighH264QpThreshold
                        << " mode: " << _codecMode;
       SetVTSessionProperty(
@@ -762,7 +762,7 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
   SetVTSessionProperty(
       _compressionSession,
       kVTCompressionPropertyKey_ProfileLevel,
-      ExtractProfile(*_profile_level_id, _codecMode == RTCVideoCodecModeScreensharing));
+      ExtractProfile(*_profile_level_id, _codecMode == RTC_OBJC_TYPE(RTCVideoCodecModeScreensharing)));
   SetVTSessionProperty(_compressionSession, kVTCompressionPropertyKey_AllowFrameReordering, false);
 
   // [self updateEncoderBitrateAndFrameRate];
@@ -857,7 +857,7 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
                  height:(int32_t)height
            renderTimeMs:(int64_t)renderTimeMs
               timestamp:(uint32_t)timestamp
-               rotation:(RTCVideoRotation)rotation {
+               rotation:(RTC_OBJC_TYPE(RTCVideoRotation))rotation {
   RTCVideoEncoderCallback callback = _callback;
   if (!callback) {
     return;
@@ -897,13 +897,13 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
                                          }];
   frame.encodedWidth = width;
   frame.encodedHeight = height;
-  frame.frameType = isKeyframe ? RTCFrameTypeVideoFrameKey : RTCFrameTypeVideoFrameDelta;
+  frame.frameType = isKeyframe ? RTC_OBJC_TYPE(RTCFrameTypeVideoFrameKey) : RTC_OBJC_TYPE(RTCFrameTypeVideoFrameDelta);
   frame.captureTimeMs = renderTimeMs;
   frame.timeStamp = timestamp;
   frame.rotation = rotation;
-  frame.contentType = (_codecMode == RTCVideoCodecModeScreensharing) ?
-      RTCVideoContentTypeScreenshare :
-      RTCVideoContentTypeUnspecified;
+  frame.contentType = (_codecMode == RTC_OBJC_TYPE(RTCVideoCodecModeScreensharing)) ?
+      RTC_OBJC_TYPE(RTCVideoContentTypeScreenshare) :
+      RTC_OBJC_TYPE(RTCVideoContentTypeUnspecified);
   frame.flags = webrtc::VideoSendTiming::kInvalid;
 
   _h264BitstreamParser.ParseBitstream(*buffer);

--- a/sdk/objc/helpers/RTCCameraPreviewView.m
+++ b/sdk/objc/helpers/RTCCameraPreviewView.m
@@ -55,16 +55,16 @@
   }
   _captureSession = captureSession;
   [RTC_OBJC_TYPE(RTCDispatcher)
-      dispatchAsyncOnType:RTCDispatcherTypeMain
+      dispatchAsyncOnType:RTC_OBJC_TYPE(RTCDispatcherTypeMain)
                     block:^{
                       AVCaptureVideoPreviewLayer *previewLayer = [self previewLayer];
                       [RTC_OBJC_TYPE(RTCDispatcher)
-                          dispatchAsyncOnType:RTCDispatcherTypeCaptureSession
+                          dispatchAsyncOnType:RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession)
                                         block:^{
                                           previewLayer.session = captureSession;
 #if !TARGET_OS_TV
                                           [RTC_OBJC_TYPE(RTCDispatcher)
-                                              dispatchAsyncOnType:RTCDispatcherTypeMain
+                                              dispatchAsyncOnType:RTC_OBJC_TYPE(RTCDispatcherTypeMain)
                                                             block:^{
                                                               [self setCorrectVideoOrientation];
                                                             }];

--- a/sdk/objc/helpers/RTCDispatcher+Private.h
+++ b/sdk/objc/helpers/RTCDispatcher+Private.h
@@ -13,6 +13,6 @@
 @interface RTC_OBJC_TYPE (RTCDispatcher)
 ()
 
-    + (dispatch_queue_t)dispatchQueueForType : (RTCDispatcherQueueType)dispatchType;
+    + (dispatch_queue_t)dispatchQueueForType : (RTC_OBJC_TYPE(RTCDispatcherQueueType))dispatchType;
 
 @end

--- a/sdk/objc/helpers/RTCDispatcher.h
+++ b/sdk/objc/helpers/RTCDispatcher.h
@@ -12,7 +12,7 @@
 
 #import "RTCMacros.h"
 
-typedef NS_ENUM(NSInteger, RTCDispatcherQueueType) {
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCDispatcherQueueType)) {
   // Main dispatcher queue.
   RTCDispatcherTypeMain,
   // Used for starting/stopping AVCaptureSession, and assigning
@@ -36,11 +36,11 @@ RTC_OBJC_EXPORT
  *  @param dispatchType The queue type to dispatch on.
  *  @param block The block to dispatch asynchronously.
  */
-+ (void)dispatchAsyncOnType:(RTCDispatcherQueueType)dispatchType block:(dispatch_block_t)block;
++ (void)dispatchAsyncOnType:(RTC_OBJC_TYPE(RTCDispatcherQueueType))dispatchType block:(dispatch_block_t)block;
 
 /** Returns YES if run on queue for the dispatchType otherwise NO.
  *  Useful for asserting that a method is run on a correct queue.
  */
-+ (BOOL)isOnQueueForType:(RTCDispatcherQueueType)dispatchType;
++ (BOOL)isOnQueueForType:(RTC_OBJC_TYPE(RTCDispatcherQueueType))dispatchType;
 
 @end

--- a/sdk/objc/helpers/RTCDispatcher.h
+++ b/sdk/objc/helpers/RTCDispatcher.h
@@ -14,14 +14,14 @@
 
 typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCDispatcherQueueType)) {
   // Main dispatcher queue.
-  RTCDispatcherTypeMain,
+  RTC_OBJC_TYPE(RTCDispatcherTypeMain),
   // Used for starting/stopping AVCaptureSession, and assigning
   // capture session to AVCaptureVideoPreviewLayer.
-  RTCDispatcherTypeCaptureSession,
+  RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession),
   // Used for operations on AVAudioSession.
-  RTCDispatcherTypeAudioSession,
+  RTC_OBJC_TYPE(RTCDispatcherTypeAudioSession),
   // Used for operations on NWPathMonitor.
-  RTCDispatcherTypeNetworkMonitor,
+  RTC_OBJC_TYPE(RTCDispatcherTypeNetworkMonitor),
 };
 
 /** Dispatcher that asynchronously dispatches blocks to a specific

--- a/sdk/objc/helpers/RTCDispatcher.m
+++ b/sdk/objc/helpers/RTCDispatcher.m
@@ -30,13 +30,13 @@ static dispatch_queue_t kNetworkMonitorQueue = nil;
   });
 }
 
-+ (void)dispatchAsyncOnType:(RTCDispatcherQueueType)dispatchType
++ (void)dispatchAsyncOnType:(RTC_OBJC_TYPE(RTCDispatcherQueueType))dispatchType
                       block:(dispatch_block_t)block {
   dispatch_queue_t queue = [self dispatchQueueForType:dispatchType];
   dispatch_async(queue, block);
 }
 
-+ (BOOL)isOnQueueForType:(RTCDispatcherQueueType)dispatchType {
++ (BOOL)isOnQueueForType:(RTC_OBJC_TYPE(RTCDispatcherQueueType))dispatchType {
   dispatch_queue_t targetQueue = [self dispatchQueueForType:dispatchType];
   const char* targetLabel = dispatch_queue_get_label(targetQueue);
   const char* currentLabel = dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL);
@@ -49,15 +49,15 @@ static dispatch_queue_t kNetworkMonitorQueue = nil;
 
 #pragma mark - Private
 
-+ (dispatch_queue_t)dispatchQueueForType:(RTCDispatcherQueueType)dispatchType {
++ (dispatch_queue_t)dispatchQueueForType:(RTC_OBJC_TYPE(RTCDispatcherQueueType))dispatchType {
   switch (dispatchType) {
-    case RTCDispatcherTypeMain:
+    case RTC_OBJC_TYPE(RTCDispatcherTypeMain):
       return dispatch_get_main_queue();
-    case RTCDispatcherTypeCaptureSession:
+    case RTC_OBJC_TYPE(RTCDispatcherTypeCaptureSession):
       return kCaptureSessionQueue;
-    case RTCDispatcherTypeAudioSession:
+    case RTC_OBJC_TYPE(RTCDispatcherTypeAudioSession):
       return kAudioSessionQueue;
-    case RTCDispatcherTypeNetworkMonitor:
+    case RTC_OBJC_TYPE(RTCDispatcherTypeNetworkMonitor):
       return kNetworkMonitorQueue;
   }
 }

--- a/sdk/objc/helpers/RTCYUVHelper.h
+++ b/sdk/objc/helpers/RTCYUVHelper.h
@@ -32,7 +32,7 @@ RTC_OBJC_EXPORT
         dstStrideV:(int)dstStrideV
              width:(int)width
              height:(int)height
-              mode:(RTCVideoRotation)mode;
+              mode:(RTC_OBJC_TYPE(RTCVideoRotation))mode;
 
 + (int)I420ToNV12:(const uint8_t*)srcY
        srcStrideY:(int)srcStrideY

--- a/sdk/objc/helpers/RTCYUVHelper.mm
+++ b/sdk/objc/helpers/RTCYUVHelper.mm
@@ -28,7 +28,7 @@
         dstStrideV:(int)dstStrideV
              width:(int)width
              height:(int)height
-              mode:(RTCVideoRotation)mode {
+              mode:(RTC_OBJC_TYPE(RTCVideoRotation))mode {
   libyuv::I420Rotate(srcY,
                      srcStrideY,
                      srcU,

--- a/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
+++ b/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
@@ -447,7 +447,7 @@ AudioStreamBasicDescription VoiceProcessingAudioUnit::GetFormat(
   // - linear PCM => noncompressed audio data format with one frame per packet
   // - no need to specify interleaving since only mono is supported
   AudioStreamBasicDescription format;
-  RTC_DCHECK_EQ(1, kRTCAudioSessionPreferredNumberOfChannels);
+  RTC_DCHECK_EQ(1, RTC_CONSTANT_TYPE(RTCAudioSessionPreferredNumberOfChannels));
   format.mSampleRate = sample_rate;
   format.mFormatID = kAudioFormatLinearPCM;
   format.mFormatFlags =
@@ -455,7 +455,7 @@ AudioStreamBasicDescription VoiceProcessingAudioUnit::GetFormat(
   format.mBytesPerPacket = kBytesPerSample;
   format.mFramesPerPacket = 1;  // uncompressed.
   format.mBytesPerFrame = kBytesPerSample;
-  format.mChannelsPerFrame = kRTCAudioSessionPreferredNumberOfChannels;
+  format.mChannelsPerFrame = RTC_CONSTANT_TYPE(RTCAudioSessionPreferredNumberOfChannels);
   format.mBitsPerChannel = 8 * kBytesPerSample;
   return format;
 }

--- a/sdk/objc/native/src/objc_audio_device.h
+++ b/sdk/objc/native/src/objc_audio_device.h
@@ -19,7 +19,7 @@
 #include "modules/audio_device/include/audio_device.h"
 #include "rtc_base/thread.h"
 
-@class RTC_OBJC_TYPE(ObjCAudioDeviceDelegate);
+@class RTC_OBJC_TYPE(RTCObjCAudioDeviceDelegate);
 
 namespace webrtc {
 
@@ -267,7 +267,7 @@ class ObjCAudioDeviceModule : public AudioDeviceModule {
   rtc::BufferT<int16_t> record_audio_buffer_;
 
   // Delegate object provided to RTCAudioDevice during initialization
-  RTC_OBJC_TYPE(ObjCAudioDeviceDelegate)* audio_device_delegate_;
+  RTC_OBJC_TYPE(RTCObjCAudioDeviceDelegate)* audio_device_delegate_;
 };
 
 }  // namespace objc_adm

--- a/sdk/objc/native/src/objc_audio_device.mm
+++ b/sdk/objc/native/src/objc_audio_device.mm
@@ -77,7 +77,7 @@ int32_t ObjCAudioDeviceModule::Init() {
 
   if (![audio_device_ isInitialized]) {
     if (audio_device_delegate_ == nil) {
-      audio_device_delegate_ = [[RTC_OBJC_TYPE(ObjCAudioDeviceDelegate) alloc]
+      audio_device_delegate_ = [[RTC_OBJC_TYPE(RTCObjCAudioDeviceDelegate) alloc]
           initWithAudioDeviceModule:rtc::scoped_refptr<ObjCAudioDeviceModule>(this)
                   audioDeviceThread:thread_];
     }

--- a/sdk/objc/native/src/objc_audio_device_delegate.h
+++ b/sdk/objc/native/src/objc_audio_device_delegate.h
@@ -22,7 +22,7 @@ class ObjCAudioDeviceModule;
 }  // namespace objc_adm
 }  // namespace webrtc
 
-@interface RTC_OBJC_TYPE(ObjCAudioDeviceDelegate) : NSObject <RTC_OBJC_TYPE (RTCAudioDeviceDelegate)>
+@interface RTC_OBJC_TYPE(RTCObjCAudioDeviceDelegate) : NSObject <RTC_OBJC_TYPE (RTCAudioDeviceDelegate)>
 
 - (instancetype)initWithAudioDeviceModule:
                     (rtc::scoped_refptr<webrtc::objc_adm::ObjCAudioDeviceModule>)audioDeviceModule

--- a/sdk/objc/native/src/objc_audio_device_delegate.mm
+++ b/sdk/objc/native/src/objc_audio_device_delegate.mm
@@ -55,7 +55,7 @@ class AudioDeviceDelegateImpl final : public rtc::RefCountedNonVirtual<AudioDevi
 
 }  // namespace
 
-@implementation RTC_OBJC_TYPE(ObjCAudioDeviceDelegate) {
+@implementation RTC_OBJC_TYPE(RTCObjCAudioDeviceDelegate) {
   rtc::scoped_refptr<AudioDeviceDelegateImpl> impl_;
 }
 

--- a/sdk/objc/native/src/objc_desktop_capture.h
+++ b/sdk/objc/native/src/objc_desktop_capture.h
@@ -27,7 +27,7 @@
 #include "rtc_base/thread.h"
 
 @protocol RTC_OBJC_TYPE
-(DesktopCapturerDelegate);
+(RTCDesktopCapturerDelegate);
 
 namespace webrtc {
 
@@ -40,7 +40,7 @@ class ObjCDesktopCapturer : public DesktopCapturer::Callback {
  public:
   ObjCDesktopCapturer(DesktopType type,
     webrtc::DesktopCapturer::SourceId source_id, 
-    id<RTC_OBJC_TYPE(DesktopCapturerDelegate)> delegate);
+    id<RTC_OBJC_TYPE(RTCDesktopCapturerDelegate)> delegate);
   virtual ~ObjCDesktopCapturer();
 
   virtual CaptureState Start(uint32_t fps);
@@ -60,7 +60,7 @@ class ObjCDesktopCapturer : public DesktopCapturer::Callback {
   CaptureState capture_state_ = CS_STOPPED;
   DesktopType type_;
   webrtc::DesktopCapturer::SourceId source_id_;
-  id<RTC_OBJC_TYPE(DesktopCapturerDelegate)> delegate_;
+  id<RTC_OBJC_TYPEDDesktopCapturerDelegate)> delegate_;
   uint32_t capture_delay_ = 1000; // 1s
   webrtc::DesktopCapturer::Result result_ = webrtc::DesktopCapturer::Result::SUCCESS;
 };

--- a/sdk/objc/native/src/objc_desktop_capture.h
+++ b/sdk/objc/native/src/objc_desktop_capture.h
@@ -27,7 +27,7 @@
 #include "rtc_base/thread.h"
 
 @protocol RTC_OBJC_TYPE
-(RTCDesktopCapturerDelegate);
+(RTCDesktopCapturerPrivateDelegate);
 
 namespace webrtc {
 
@@ -39,8 +39,8 @@ class ObjCDesktopCapturer : public DesktopCapturer::Callback {
 
  public:
   ObjCDesktopCapturer(DesktopType type,
-    webrtc::DesktopCapturer::SourceId source_id, 
-    id<RTC_OBJC_TYPE(RTCDesktopCapturerDelegate)> delegate);
+    webrtc::DesktopCapturer::SourceId source_id,
+    id<RTC_OBJC_TYPE(RTCDesktopCapturerPrivateDelegate)> delegate);
   virtual ~ObjCDesktopCapturer();
 
   virtual CaptureState Start(uint32_t fps);
@@ -60,7 +60,7 @@ class ObjCDesktopCapturer : public DesktopCapturer::Callback {
   CaptureState capture_state_ = CS_STOPPED;
   DesktopType type_;
   webrtc::DesktopCapturer::SourceId source_id_;
-  id<RTC_OBJC_TYPEDDesktopCapturerDelegate)> delegate_;
+  id<RTC_OBJC_TYPE(RTCDesktopCapturerPrivateDelegate)> delegate_;
   uint32_t capture_delay_ = 1000; // 1s
   webrtc::DesktopCapturer::Result result_ = webrtc::DesktopCapturer::Result::SUCCESS;
 };

--- a/sdk/objc/native/src/objc_desktop_capture.mm
+++ b/sdk/objc/native/src/objc_desktop_capture.mm
@@ -184,7 +184,7 @@ void ObjCDesktopCapturer::OnCaptureResult(webrtc::DesktopCapturer::Result result
   int64_t timeStampNs = lroundf(timeStampSeconds * NSEC_PER_SEC);
   RTC_OBJC_TYPE(RTCVideoFrame) *videoFrame =
       [[RTC_OBJC_TYPE(RTCVideoFrame) alloc] initWithBuffer:rtcPixelBuffer
-                                                  rotation:RTCVideoRotation_0
+                                                  rotation:RTC_OBJC_TYPE(RTCVideoRotation_0)
                                                timeStampNs:timeStampNs];
   CVPixelBufferRelease(pixelBuffer);
   [delegate_ didCaptureVideoFrame:videoFrame];

--- a/sdk/objc/native/src/objc_desktop_capture.mm
+++ b/sdk/objc/native/src/objc_desktop_capture.mm
@@ -29,7 +29,7 @@ enum { kCaptureDelay = 33, kCaptureMessageId = 1000 };
 
 ObjCDesktopCapturer::ObjCDesktopCapturer(DesktopType type,
                                          webrtc::DesktopCapturer::SourceId source_id,
-                                         id<RTC_OBJC_TYPE(RTCDesktopCapturerDelegate)> delegate)
+                                         id<RTC_OBJC_TYPE(RTCDesktopCapturerPrivateDelegate)> delegate)
     : thread_(rtc::Thread::Create()), source_id_(source_id), delegate_(delegate) {
   RTC_DCHECK(thread_);
   type_ = type;

--- a/sdk/objc/native/src/objc_desktop_capture.mm
+++ b/sdk/objc/native/src/objc_desktop_capture.mm
@@ -29,7 +29,7 @@ enum { kCaptureDelay = 33, kCaptureMessageId = 1000 };
 
 ObjCDesktopCapturer::ObjCDesktopCapturer(DesktopType type,
                                          webrtc::DesktopCapturer::SourceId source_id,
-                                         id<RTC_OBJC_TYPE(DesktopCapturerDelegate)> delegate)
+                                         id<RTC_OBJC_TYPE(RTCDesktopCapturerDelegate)> delegate)
     : thread_(rtc::Thread::Create()), source_id_(source_id), delegate_(delegate) {
   RTC_DCHECK(thread_);
   type_ = type;

--- a/sdk/objc/native/src/objc_video_encoder_factory.mm
+++ b/sdk/objc/native/src/objc_video_encoder_factory.mm
@@ -76,7 +76,7 @@ class ObjCVideoEncoder : public VideoEncoder {
                  const std::vector<VideoFrameType> *frame_types) override {
     NSMutableArray<NSNumber *> *rtcFrameTypes = [NSMutableArray array];
     for (size_t i = 0; i < frame_types->size(); ++i) {
-      [rtcFrameTypes addObject:@(RTCFrameType(frame_types->at(i)))];
+      [rtcFrameTypes addObject:@(RTC_OBJC_TYPE(RTCFrameType)(frame_types->at(i)))];
     }
 
     return [encoder_ encode:ToObjCVideoFrame(frame)

--- a/sdk/objc/native/src/objc_video_frame.mm
+++ b/sdk/objc/native/src/objc_video_frame.mm
@@ -18,7 +18,7 @@ namespace webrtc {
 RTC_OBJC_TYPE(RTCVideoFrame) * ToObjCVideoFrame(const VideoFrame &frame) {
   RTC_OBJC_TYPE(RTCVideoFrame) *videoFrame = [[RTC_OBJC_TYPE(RTCVideoFrame) alloc]
       initWithBuffer:ToObjCVideoFrameBuffer(frame.video_frame_buffer())
-            rotation:RTCVideoRotation(frame.rotation())
+            rotation:RTC_OBJC_TYPE(RTCVideoRotation)(frame.rotation())
          timeStampNs:frame.timestamp_us() * rtc::kNumNanosecsPerMicrosec];
   videoFrame.timeStamp = frame.rtp_timestamp();
 

--- a/sdk/objc/unittests/RTCAudioSessionTest.mm
+++ b/sdk/objc/unittests/RTCAudioSessionTest.mm
@@ -291,8 +291,8 @@
   waitLock.Wait(timeout);
   [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:0 error:&error];
   EXPECT_TRUE(error != nil);
-  EXPECT_EQ(error.domain, kRTCAudioSessionErrorDomain);
-  EXPECT_EQ(error.code, kRTCAudioSessionErrorLockRequired);
+  EXPECT_EQ(error.domain, RTC_CONSTANT_TYPE(RTCAudioSessionErrorDomain));
+  EXPECT_EQ(error.code, RTC_CONSTANT_TYPE(RTCAudioSessionErrorLockRequired));
   waitCleanup.Set();
   thread->Stop();
 

--- a/sdk/objc/unittests/RTCPeerConnectionFactory_xctest.m
+++ b/sdk/objc/unittests/RTCPeerConnectionFactory_xctest.m
@@ -186,7 +186,7 @@
       factory = [[RTC_OBJC_TYPE(RTCPeerConnectionFactory) alloc] init];
       peerConnection =
           [factory peerConnectionWithConfiguration:config constraints:constraints delegate:nil];
-      sender = [peerConnection senderWithKind:kRTCMediaStreamTrackKindVideo streamId:@"stream"];
+      sender = [peerConnection senderWithKind:RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindVideo) streamId:@"stream"];
       XCTAssertNotNil(sender);
       [peerConnection close];
       peerConnection = nil;
@@ -216,10 +216,10 @@
     @autoreleasepool {
       factory = [[RTC_OBJC_TYPE(RTCPeerConnectionFactory) alloc] init];
       pc1 = [factory peerConnectionWithConfiguration:config constraints:constraints delegate:nil];
-      [pc1 senderWithKind:kRTCMediaStreamTrackKindAudio streamId:@"stream"];
+      [pc1 senderWithKind:RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindAudio) streamId:@"stream"];
 
       pc2 = [factory peerConnectionWithConfiguration:config constraints:constraints delegate:nil];
-      [pc2 senderWithKind:kRTCMediaStreamTrackKindAudio streamId:@"stream"];
+      [pc2 senderWithKind:RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindAudio) streamId:@"stream"];
 
       NSTimeInterval negotiationTimeout = 15;
       XCTAssertTrue([self negotiatePeerConnection:pc1
@@ -320,7 +320,7 @@
     config.sdpSemantics = RTCSdpSemanticsUnifiedPlan;
     RTC_OBJC_TYPE(RTCMediaConstraints) *constraints =
         [[RTC_OBJC_TYPE(RTCMediaConstraints) alloc] initWithMandatoryConstraints:@{
-          kRTCMediaConstraintsOfferToReceiveAudio : kRTCMediaConstraintsValueTrue
+          RTC_CONSTANT_TYPE(RTCMediaConstraintsOfferToReceiveAudio) : RTC_CONSTANT_TYPE(RTCMediaConstraintsValueTrue)
         }
                                                              optionalConstraints:nil];
 
@@ -381,7 +381,7 @@
                                                                        decoderFactory:decoder];
 
     RTC_OBJC_TYPE(RTCRtpCapabilities) *capabilities =
-        [factory rtpSenderCapabilitiesForKind:kRTCMediaStreamTrackKindVideo];
+        [factory rtpSenderCapabilitiesForKind:RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindVideo)];
     NSMutableArray<NSString *> *codecNames = [NSMutableArray new];
     for (RTC_OBJC_TYPE(RTCRtpCodecCapability) * codec in capabilities.codecs) {
       [codecNames addObject:codec.name];
@@ -410,7 +410,7 @@
                                                                        decoderFactory:decoder];
 
     RTC_OBJC_TYPE(RTCRtpCapabilities) *capabilities =
-        [factory rtpReceiverCapabilitiesForKind:kRTCMediaStreamTrackKindVideo];
+        [factory rtpReceiverCapabilitiesForKind:RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindVideo)];
     NSMutableArray<NSString *> *codecNames = [NSMutableArray new];
     for (RTC_OBJC_TYPE(RTCRtpCodecCapability) * codec in capabilities.codecs) {
       [codecNames addObject:codec.name];
@@ -454,7 +454,7 @@
     XCTAssertNotNil(tranceiver);
 
     RTC_OBJC_TYPE(RTCRtpCapabilities) *capabilities =
-        [factory rtpReceiverCapabilitiesForKind:kRTCMediaStreamTrackKindVideo];
+        [factory rtpReceiverCapabilitiesForKind:RTC_CONSTANT_TYPE(RTCMediaStreamTrackKindVideo)];
 
     RTC_OBJC_TYPE(RTCRtpCodecCapability) * targetCodec;
     for (RTC_OBJC_TYPE(RTCRtpCodecCapability) * codec in capabilities.codecs) {
@@ -513,7 +513,7 @@
   __weak RTC_OBJC_TYPE(RTCPeerConnection) *weakPC2 = pc2;
   RTC_OBJC_TYPE(RTCMediaConstraints) *sdpConstraints =
       [[RTC_OBJC_TYPE(RTCMediaConstraints) alloc] initWithMandatoryConstraints:@{
-        kRTCMediaConstraintsOfferToReceiveAudio : kRTCMediaConstraintsValueTrue
+        RTC_CONSTANT_TYPE(RTCMediaConstraintsOfferToReceiveAudio) : RTC_CONSTANT_TYPE(RTCMediaConstraintsValueTrue)
       }
                                                            optionalConstraints:nil];
 


### PR DESCRIPTION
Continued from https://github.com/webrtc-sdk/webrtc/pull/100 also prefix enums.
I think this shouldn't break compiling.