### PR TITLE
fix(generate_licenses): add missing licenses for ffmpeg and openh264

### DIFF
--- a/tools_webrtc/libs/generate_licenses.py
+++ b/tools_webrtc/libs/generate_licenses.py
@@ -48,6 +48,7 @@ LIB_TO_LICENSES_DICT = {
         'third_party/android_deps/libs/'
         'com_google_errorprone_error_prone_core/LICENSE'
     ],
+    'ffmpeg': ['third_party/ffmpeg/LICENSE.md'],
     'fiat': ['third_party/boringssl/src/third_party/fiat/LICENSE'],
     'guava': ['third_party/android_deps/libs/com_google_guava_guava/LICENSE'],
     'ijar': ['third_party/ijar/LICENSE'],
@@ -62,6 +63,7 @@ LIB_TO_LICENSES_DICT = {
     'libvpx': ['third_party/libvpx/source/libvpx/LICENSE'],
     'libyuv': ['third_party/libyuv/LICENSE'],
     'nasm': ['third_party/nasm/LICENSE'],
+    'openh264': ['third_party/openh264/src/LICENSE'],
     'opus': ['third_party/opus/src/COPYING'],
     'pffft': ['third_party/pffft/LICENSE'],
     'protobuf': ['third_party/protobuf/LICENSE'],


### PR DESCRIPTION
Doing a custom build with the following command line fails the build during the license generation step because these components were added to the build without their licenses being declared here.

`python tools_webrtc/ios/build_ios_libs.py --build_config release --arch arm64 x64 --extra-gn-args ios_enable_code_signing=false is_component_build=false rtc_include_tests=false is_debug=false enable_dsyms=false rtc_libvpx_build_vp9=true use_goma=false rtc_enable_symbol_export=true rtc_build_examples=false rtc_use_h264=true use_rtti=true use_custom_libcxx=false`


