### PR TITLE
fix: Fixed scalabilityModes is invalid on Apple platforms.

### DIFF
--- a/sdk/objc/base/RTCVideoCodecInfo.m
+++ b/sdk/objc/base/RTCVideoCodecInfo.m
@@ -34,7 +34,7 @@
   if (self) {
     _name = name;
     _parameters = (parameters ? parameters : @{});
-    _scalabilityModes = @[];
+    _scalabilityModes = (scalabilityModes ? scalabilityModes : @[]);
   }
 
   return self;


### PR DESCRIPTION
fixed VP9/AV1 encoder unusable.

We have to apply this patch and publish new binary packages. Otherwise we can't use AV1/VP9 codec in Apple platform.