### PR TITLE
fix(generate_licenses): add missing licenses for ffmpeg and openh264

### DIFF
--- a/tools_webrtc/libs/generate_licenses.py
+++ b/tools_webrtc/libs/generate_licenses.py
@@ -49,6 +49,7 @@ LIB_TO_LICENSES_DICT = {
         'third_party/android_deps/libs/'
         'com_google_errorprone_error_prone_core/LICENSE'
     ],
+    'ffmpeg': ['third_party/ffmpeg/LICENSE.md'],
     'fiat': ['third_party/boringssl/src/third_party/fiat/LICENSE'],
     'guava': ['third_party/android_deps/libs/com_google_guava_guava/LICENSE'],
     'ijar': ['third_party/ijar/LICENSE'],
@@ -63,6 +64,7 @@ LIB_TO_LICENSES_DICT = {
     'libyuv': ['third_party/libyuv/LICENSE'],
     'llvm-libc': ['third_party/llvm-libc/src/LICENSE.TXT'],
     'nasm': ['third_party/nasm/LICENSE'],
+    'openh264': ['third_party/openh264/src/LICENSE'],
     'opus': ['third_party/opus/src/COPYING'],
     'pffft': ['third_party/pffft/LICENSE'],
     'protobuf': ['third_party/protobuf/LICENSE'],


### PR DESCRIPTION
M137 companion of #176 

cc @davidliu 