### PR TITLE
Add H.265 video codec support to WebRTC iOS SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@
 /node_modules
 /libwebrtc
 /args.txt
+/out_ios_libs

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1452,7 +1452,8 @@ if (is_ios || is_mac) {
           "objc/components/video_frame_buffer/RTCCVPixelBuffer.h",
           "objc/helpers/RTCDispatcher.h",
           "objc/helpers/RTCYUVHelper.h",
-          "objc/helpers/UIDevice+RTCDevice.h",]
+          "objc/helpers/UIDevice+RTCDevice.h",
+        ]
 
         if (rtc_use_h265) {
           common_objc_headers += [
@@ -1692,10 +1693,11 @@ if (is_ios || is_mac) {
           "objc/components/video_codec/RTCVideoEncoderH264.h",
           "objc/components/video_frame_buffer/RTCCVPixelBuffer.h",
           "objc/helpers/RTCDispatcher.h",
-          "objc/helpers/RTCYUVHelper.h",]
+          "objc/helpers/RTCYUVHelper.h",
+        ]
 
         if (rtc_use_h265) {
-          common_objc_headers += [
+          sources += [
             "objc/components/video_codec/RTCVideoDecoderFactoryH265.h",
             "objc/components/video_codec/RTCVideoDecoderH265.h",
             "objc/components/video_codec/RTCVideoEncoderFactoryH265.h",
@@ -1703,7 +1705,7 @@ if (is_ios || is_mac) {
           ]
         }
 
-        common_objc_headers += [
+        sources += [
           # Added for Simulcast support
           "objc/components/video_codec/RTCVideoEncoderFactorySimulcast.h",
           "objc/api/video_codec/RTCVideoEncoderSimulcast.h",

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1452,7 +1452,18 @@ if (is_ios || is_mac) {
           "objc/components/video_frame_buffer/RTCCVPixelBuffer.h",
           "objc/helpers/RTCDispatcher.h",
           "objc/helpers/RTCYUVHelper.h",
-          "objc/helpers/UIDevice+RTCDevice.h",
+          "objc/helpers/UIDevice+RTCDevice.h",]
+
+        if (rtc_use_h265) {
+          common_objc_headers += [
+            "objc/components/video_codec/RTCVideoDecoderFactoryH265.h",
+            "objc/components/video_codec/RTCVideoDecoderH265.h", 
+            "objc/components/video_codec/RTCVideoEncoderFactoryH265.h",
+            "objc/components/video_codec/RTCVideoEncoderH265.h",
+          ]
+        }
+
+        common_objc_headers += [
           "objc/api/peerconnection/RTCAudioDeviceModule.h",
           "objc/api/peerconnection/RTCIODevice.h",
           "objc/api/peerconnection/RTCAudioSource.h",
@@ -1681,7 +1692,18 @@ if (is_ios || is_mac) {
           "objc/components/video_codec/RTCVideoEncoderH264.h",
           "objc/components/video_frame_buffer/RTCCVPixelBuffer.h",
           "objc/helpers/RTCDispatcher.h",
-          "objc/helpers/RTCYUVHelper.h",
+          "objc/helpers/RTCYUVHelper.h",]
+
+        if (rtc_use_h265) {
+          common_objc_headers += [
+            "objc/components/video_codec/RTCVideoDecoderFactoryH265.h",
+            "objc/components/video_codec/RTCVideoDecoderH265.h",
+            "objc/components/video_codec/RTCVideoEncoderFactoryH265.h",
+            "objc/components/video_codec/RTCVideoEncoderH265.h",
+          ]
+        }
+
+        common_objc_headers += [
           # Added for Simulcast support
           "objc/components/video_codec/RTCVideoEncoderFactorySimulcast.h",
           "objc/api/video_codec/RTCVideoEncoderSimulcast.h",
@@ -1903,6 +1925,8 @@ if (is_ios || is_mac) {
         "../rtc_base:checks",
         "../rtc_base:logging",
       ]
+
+
     }
 
     rtc_library("videotoolbox_objc") {
@@ -1918,6 +1942,17 @@ if (is_ios || is_mac) {
         "objc/components/video_codec/RTCVideoEncoderH264.h",
         "objc/components/video_codec/RTCVideoEncoderH264.mm",
       ]
+
+      if (rtc_use_h265) {
+        sources += [
+          "objc/components/video_codec/RTCVideoDecoderFactoryH265.h",
+          "objc/components/video_codec/RTCVideoDecoderFactoryH265.mm",
+          "objc/components/video_codec/RTCVideoDecoderH265.h",
+          "objc/components/video_codec/RTCVideoDecoderH265.mm",
+          "objc/components/video_codec/RTCVideoEncoderH265.h",
+          "objc/components/video_codec/RTCVideoEncoderH265.mm",
+        ]
+      }
 
       configs += [
         "..:common_objc",

--- a/sdk/objc/api/video_codec/RTCVideoCodecConstants.mm
+++ b/sdk/objc/api/video_codec/RTCVideoCodecConstants.mm
@@ -16,3 +16,6 @@
 NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecVp8Name) = @(webrtc::kVp8CodecName);
 NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name) = @(webrtc::kVp9CodecName);
 NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name) = @(webrtc::kAv1CodecName);
+#ifdef RTC_ENABLE_H265
+NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecH265Name) = @(webrtc::kH265CodecName);
+#endif

--- a/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.m
+++ b/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.m
@@ -17,6 +17,10 @@
 #import "api/video_codec/RTCVideoDecoderVP9.h"
 #import "base/RTCVideoCodecInfo.h"
 
+#ifdef RTC_ENABLE_H265
+#import "RTCVideoDecoderH265.h"
+#endif
+
 #if defined(RTC_DAV1D_IN_INTERNAL_DECODER_FACTORY)
 #import "api/video_codec/RTCVideoDecoderAV1.h"  // nogncheck
 #endif
@@ -56,6 +60,12 @@
         addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name)]];
   }
 
+#ifdef RTC_ENABLE_H265
+  RTC_OBJC_TYPE(RTCVideoCodecInfo) *h265Info =
+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecH265Name)];
+  [result addObject:h265Info];
+#endif
+
 #if defined(RTC_DAV1D_IN_INTERNAL_DECODER_FACTORY)
   [result addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name)]];
 #endif
@@ -72,6 +82,12 @@
              [RTC_OBJC_TYPE(RTCVideoDecoderVP9) isSupported]) {
     return [RTC_OBJC_TYPE(RTCVideoDecoderVP9) vp9Decoder];
   }
+
+#ifdef RTC_ENABLE_H265
+  if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecH265Name)]) {
+    return [[RTC_OBJC_TYPE(RTCVideoDecoderH265) alloc] init];
+  }
+#endif
 
 #if defined(RTC_DAV1D_IN_INTERNAL_DECODER_FACTORY)
   if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name)]) {

--- a/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m
+++ b/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m
@@ -17,6 +17,10 @@
 #import "api/video_codec/RTCVideoEncoderVP9.h"
 #import "base/RTCVideoCodecInfo.h"
 
+#ifdef RTC_ENABLE_H265
+#import "RTCVideoEncoderH265.h"
+#endif
+
 #if defined(RTC_USE_LIBAOM_AV1_ENCODER)
 #import "api/video_codec/RTCVideoEncoderAV1.h"  // nogncheck
 #endif
@@ -58,6 +62,12 @@
         addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name) parameters:nil scalabilityModes:[RTC_OBJC_TYPE(RTCVideoEncoderVP9) scalabilityModes]]];
   }
 
+#ifdef RTC_ENABLE_H265
+  RTC_OBJC_TYPE(RTCVideoCodecInfo) *h265Info =
+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecH265Name)];
+  [result addObject:h265Info];
+#endif
+
 #if defined(RTC_USE_LIBAOM_AV1_ENCODER)
   RTC_OBJC_TYPE(RTCVideoCodecInfo) *av1Info =
     [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name) parameters:nil scalabilityModes:[RTC_OBJC_TYPE(RTCVideoEncoderAV1) scalabilityModes]];
@@ -76,6 +86,12 @@
              [RTC_OBJC_TYPE(RTCVideoEncoderVP9) isSupported]) {
     return [RTC_OBJC_TYPE(RTCVideoEncoderVP9) vp9Encoder];
   }
+
+#ifdef RTC_ENABLE_H265
+  if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecH265Name)]) {
+    return [[RTC_OBJC_TYPE(RTCVideoEncoderH265) alloc] initWithCodecInfo:info];
+  }
+#endif
 
 #if defined(RTC_USE_LIBAOM_AV1_ENCODER)
   if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name)]) {

--- a/sdk/objc/components/video_codec/RTCH265ProfileTierLevel.h
+++ b/sdk/objc/components/video_codec/RTCH265ProfileTierLevel.h
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2024 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "sdk/objc/base/RTCMacros.h"
+
+#ifdef RTC_ENABLE_H265
+
+RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecH265Name);
+RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCLevel31MainTier);
+RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCMaxSupportedH265ProfileTierLevel);
+
+/** H265 Profiles, Tiers, and Levels. */
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCH265Profile)) {
+  RTC_OBJC_TYPE(RTCH265ProfileMain),
+  RTC_OBJC_TYPE(RTCH265ProfileMain10),
+  RTC_OBJC_TYPE(RTCH265ProfileMainStill),
+  RTC_OBJC_TYPE(RTCH265ProfileRangeExtensions),
+  RTC_OBJC_TYPE(RTCH265ProfileHighThroughput),
+  RTC_OBJC_TYPE(RTCH265ProfileScreenExtended),
+  RTC_OBJC_TYPE(RTCH265ProfileScalableMain),
+  RTC_OBJC_TYPE(RTCH265ProfileScalableMain10),
+  RTC_OBJC_TYPE(RTCH265Profile3dMain),
+};
+
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCH265Tier)) {
+  RTC_OBJC_TYPE(RTCH265TierMain),
+  RTC_OBJC_TYPE(RTCH265TierHigh),
+};
+
+typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCH265Level)) {
+  RTC_OBJC_TYPE(RTCH265Level1) = 30,
+  RTC_OBJC_TYPE(RTCH265Level2) = 60,
+  RTC_OBJC_TYPE(RTCH265Level2_1) = 63,
+  RTC_OBJC_TYPE(RTCH265Level3) = 90,
+  RTC_OBJC_TYPE(RTCH265Level3_1) = 93,
+  RTC_OBJC_TYPE(RTCH265Level4) = 120,
+  RTC_OBJC_TYPE(RTCH265Level4_1) = 123,
+  RTC_OBJC_TYPE(RTCH265Level5) = 150,
+  RTC_OBJC_TYPE(RTCH265Level5_1) = 153,
+  RTC_OBJC_TYPE(RTCH265Level5_2) = 156,
+  RTC_OBJC_TYPE(RTCH265Level6) = 180,
+  RTC_OBJC_TYPE(RTCH265Level6_1) = 183,
+  RTC_OBJC_TYPE(RTCH265Level6_2) = 186,
+};
+
+RTC_OBJC_EXPORT
+@interface RTC_OBJC_TYPE (RTCH265ProfileTierLevel) : NSObject
+
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCH265Profile) profile;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCH265Tier) tier;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCH265Level) level;
+
+- (instancetype)initWithProfile:(RTC_OBJC_TYPE(RTCH265Profile))profile
+                           tier:(RTC_OBJC_TYPE(RTCH265Tier))tier
+                          level:(RTC_OBJC_TYPE(RTCH265Level))level;
+
+@end
+
+#endif  // RTC_ENABLE_H265 

--- a/sdk/objc/components/video_codec/RTCH265ProfileTierLevel.mm
+++ b/sdk/objc/components/video_codec/RTCH265ProfileTierLevel.mm
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2024 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifdef RTC_ENABLE_H265
+
+#import "RTCH265ProfileTierLevel.h"
+
+#include "media/base/media_constants.h"
+
+NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecH265Name) = @(webrtc::kH265CodecName);
+NSString *const RTC_CONSTANT_TYPE(RTCLevel31MainTier) = @"level3.1-main-tier";
+NSString *const RTC_CONSTANT_TYPE(RTCMaxSupportedH265ProfileTierLevel) = @"level5.2-main-tier";
+
+@implementation RTC_OBJC_TYPE (RTCH265ProfileTierLevel)
+
+@synthesize profile = _profile;
+@synthesize tier = _tier;
+@synthesize level = _level;
+
+- (instancetype)initWithProfile:(RTC_OBJC_TYPE(RTCH265Profile))profile
+                           tier:(RTC_OBJC_TYPE(RTCH265Tier))tier
+                          level:(RTC_OBJC_TYPE(RTCH265Level))level {
+  if (self = [super init]) {
+    _profile = profile;
+    _tier = tier;
+    _level = level;
+  }
+  return self;
+}
+
+- (BOOL)isEqual:(id)object {
+  if (self == object) {
+    return YES;
+  }
+  if (![object isKindOfClass:[RTC_OBJC_TYPE(RTCH265ProfileTierLevel) class]]) {
+    return NO;
+  }
+  RTC_OBJC_TYPE(RTCH265ProfileTierLevel) *profile = object;
+  return self.profile == profile.profile && self.tier == profile.tier && self.level == profile.level;
+}
+
+- (NSUInteger)hash {
+  return (NSUInteger)(self.profile ^ self.tier ^ self.level);
+}
+
+- (NSString *)description {
+  return [NSString stringWithFormat:@"RTC_OBJC_TYPE(RTCH265ProfileTierLevel) profile:%lu tier:%lu level:%lu",
+                                    (unsigned long)self.profile, (unsigned long)self.tier, (unsigned long)self.level];
+}
+
+@end
+
+#endif  // RTC_ENABLE_H265 

--- a/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH265.h
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH265.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 The WebRTC project authors. All Rights Reserved.
+ *  Copyright 2024 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
@@ -10,11 +10,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import "RTCVideoDecoderFactory.h"
 #import "sdk/objc/base/RTCMacros.h"
 
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecVp8Name);
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name);
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name);
 #ifdef RTC_ENABLE_H265
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecH265Name);
-#endif
+
+RTC_OBJC_EXPORT
+@interface RTC_OBJC_TYPE (RTCVideoDecoderFactoryH265) : NSObject <RTC_OBJC_TYPE(RTCVideoDecoderFactory)>
+@end
+
+#endif  // RTC_ENABLE_H265 

--- a/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH265.mm
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2024 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifdef RTC_ENABLE_H265
+
+#import "RTCVideoDecoderFactoryH265.h"
+
+#import "RTCVideoDecoderH265.h"
+#import "api/video_codec/RTCVideoCodecConstants.h"
+#import "base/RTCVideoCodecInfo.h"
+
+@implementation RTC_OBJC_TYPE (RTCVideoDecoderFactoryH265)
+
+- (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
+  NSMutableArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *codecs =
+      [NSMutableArray array];
+  NSString *codecName = RTC_CONSTANT_TYPE(RTCVideoCodecH265Name);
+
+  RTC_OBJC_TYPE(RTCVideoCodecInfo) *h265Info =
+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc]
+          initWithName:codecName
+            parameters:@{}];
+  [codecs addObject:h265Info];
+
+  return [codecs copy];
+}
+
+- (id<RTC_OBJC_TYPE(RTCVideoDecoder)>)createDecoder:
+    (RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info {
+  return [[RTC_OBJC_TYPE(RTCVideoDecoderH265) alloc] init];
+}
+
+@end
+
+#endif  // RTC_ENABLE_H265 

--- a/sdk/objc/components/video_codec/RTCVideoDecoderH265.h
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderH265.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 The WebRTC project authors. All Rights Reserved.
+ *  Copyright 2024 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
@@ -10,11 +10,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import "RTCVideoDecoder.h"
 #import "sdk/objc/base/RTCMacros.h"
 
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecVp8Name);
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name);
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name);
 #ifdef RTC_ENABLE_H265
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecH265Name);
-#endif
+
+RTC_OBJC_EXPORT
+@interface RTC_OBJC_TYPE (RTCVideoDecoderH265) : NSObject <RTC_OBJC_TYPE(RTCVideoDecoder)>
+@end
+
+#endif  // RTC_ENABLE_H265 

--- a/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
@@ -1,0 +1,276 @@
+/*
+ *  Copyright (c) 2024 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ *
+ */
+
+#ifdef RTC_ENABLE_H265
+
+#import "RTCVideoDecoderH265.h"
+
+#import <VideoToolbox/VideoToolbox.h>
+
+#import "base/RTCVideoFrame.h"
+#import "base/RTCVideoFrameBuffer.h"
+#import "components/video_frame_buffer/RTCCVPixelBuffer.h"
+#import "helpers.h"
+#import "helpers/scoped_cftyperef.h"
+
+
+
+#include "modules/video_coding/include/video_error_codes.h"
+#include "rtc_base/checks.h"
+#include "rtc_base/logging.h"
+#include "rtc_base/time_utils.h"
+#include "sdk/objc/components/video_codec/nalu_rewriter.h"
+
+// Struct that we pass to the decoder per frame to decode. We receive it again
+// in the decoder callback.
+struct RTCFrameDecodeParams {
+  RTCFrameDecodeParams(RTCVideoDecoderCallback cb, int64_t ts)
+      : callback(cb), timestamp(ts) {}
+  RTCVideoDecoderCallback callback;
+  int64_t timestamp;
+};
+
+@interface RTC_OBJC_TYPE (RTCVideoDecoderH265)
+() - (void)setError : (OSStatus)error;
+@end
+
+// This is the callback function that VideoToolbox calls when decode is
+// complete.
+void h265DecompressionOutputCallback(void *decoderRef,
+                                     void *params,
+                                     OSStatus status,
+                                     VTDecodeInfoFlags infoFlags,
+                                     CVImageBufferRef imageBuffer,
+                                     CMTime timestamp,
+                                     CMTime duration) {
+  std::unique_ptr<RTCFrameDecodeParams> decodeParams(
+      reinterpret_cast<RTCFrameDecodeParams *>(params));
+  if (status != noErr) {
+    RTC_OBJC_TYPE(RTCVideoDecoderH265) *decoder =
+        (__bridge RTC_OBJC_TYPE(RTCVideoDecoderH265) *)decoderRef;
+    [decoder setError:status];
+    RTC_LOG(LS_ERROR) << "Failed to decode frame. Status: " << status;
+    return;
+  }
+  // TODO(tkchin): Handle CVO properly.
+  RTC_OBJC_TYPE(RTCCVPixelBuffer) *frameBuffer =
+      [[RTC_OBJC_TYPE(RTCCVPixelBuffer) alloc] initWithPixelBuffer:imageBuffer];
+  RTC_OBJC_TYPE(
+      RTCVideoFrame) *decodedFrame = [[RTC_OBJC_TYPE(RTCVideoFrame) alloc]
+      initWithBuffer:frameBuffer
+            rotation:RTC_OBJC_TYPE(RTCVideoRotation_0)
+         timeStampNs:CMTimeGetSeconds(timestamp) * webrtc::kNumNanosecsPerSec];
+  decodedFrame.timeStamp = decodeParams->timestamp;
+  decodeParams->callback(decodedFrame);
+}
+
+// Decoder.
+@implementation RTC_OBJC_TYPE (RTCVideoDecoderH265) {
+  CMVideoFormatDescriptionRef _videoFormat;
+  CMMemoryPoolRef _memoryPool;
+  VTDecompressionSessionRef _decompressionSession;
+  RTCVideoDecoderCallback _callback;
+  OSStatus _error;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _memoryPool = CMMemoryPoolCreate(nil);
+  }
+  return self;
+}
+
+- (void)dealloc {
+  CMMemoryPoolInvalidate(_memoryPool);
+  CFRelease(_memoryPool);
+  [self destroyDecompressionSession];
+  [self setVideoFormat:nullptr];
+}
+
+- (NSInteger)startDecodeWithNumberOfCores:(int)numberOfCores {
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (NSInteger)decode:(RTC_OBJC_TYPE(RTCEncodedImage) *)encodedImage
+        missingFrames:(BOOL)missingFrames
+    codecSpecificInfo:(nullable id<RTC_OBJC_TYPE(RTCCodecSpecificInfo)>)info
+         renderTimeMs:(int64_t)renderTimeMs {
+  RTC_DCHECK(encodedImage.buffer);
+
+  if (_error != noErr) {
+    RTC_LOG(LS_WARNING) << "H265Decoder: Last frame decode failed with error: " << _error;
+    _error = noErr;
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  RTC_LOG(LS_INFO) << "H265Decoder: Decoding frame - size: " << encodedImage.buffer.length 
+                   << ", timestamp: " << encodedImage.timeStamp
+                   << ", frame type: " << (encodedImage.frameType == RTCFrameTypeVideoFrameKey ? "key" : "delta");
+
+  // Create format description from input buffer first (similar to H.264 decoder)
+  webrtc::ScopedCFTypeRef<CMVideoFormatDescriptionRef> inputFormat =
+      webrtc::ScopedCF(webrtc::CreateH265VideoFormatDescription(
+          (uint8_t *)encodedImage.buffer.bytes, encodedImage.buffer.length));
+  if (inputFormat) {
+    RTC_LOG(LS_INFO) << "H265Decoder: Successfully created format description";
+    // Check if the video format has changed, and reinitialize decoder if needed.
+    if (!CMFormatDescriptionEqual(inputFormat.get(), _videoFormat)) {
+      RTC_LOG(LS_INFO) << "H265Decoder: Video format changed, resetting decompression session";
+      [self setVideoFormat:inputFormat.get()];
+      int resetDecompressionSessionError = [self resetDecompressionSession];
+      if (resetDecompressionSessionError != WEBRTC_VIDEO_CODEC_OK) {
+        RTC_LOG(LS_ERROR) << "H265Decoder: Failed to reset decompression session: " << resetDecompressionSessionError;
+        return resetDecompressionSessionError;
+      }
+    }
+  } else {
+    RTC_LOG(LS_WARNING) << "H265Decoder: Failed to create format description from input buffer";
+  }
+  if (!_videoFormat) {
+    // We received a frame but we don't have format information so we can't
+    // decode it.
+    // This can happen after backgrounding. We need to wait for the next
+    // vps/sps/pps before we can resume so we request a keyframe by returning an
+    // error.
+    RTC_LOG(LS_WARNING) << "H265Decoder: Missing video format. Frame with vps/sps/pps required.";
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  CMSampleBufferRef sampleBuffer = nullptr;
+  if (!webrtc::H265AnnexBBufferToCMSampleBuffer((uint8_t *)encodedImage.buffer.bytes,
+                                               encodedImage.buffer.length,
+                                               _videoFormat, &sampleBuffer,
+                                               _memoryPool)) {
+    RTC_LOG(LS_ERROR) << "H265Decoder: Failed to convert AnnexB buffer to CMSampleBuffer";
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  RTC_DCHECK(sampleBuffer);
+  CFAutorelease(sampleBuffer);
+  
+  RTC_LOG(LS_INFO) << "H265Decoder: Successfully created CMSampleBuffer";
+  
+  if (!_decompressionSession) {
+    RTC_LOG(LS_ERROR) << "H265Decoder: Decompression session is null";
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+
+  std::unique_ptr<RTCFrameDecodeParams> decodeParams;
+  decodeParams.reset(new RTCFrameDecodeParams(_callback, encodedImage.timeStamp));
+
+  // Pass the decode params to the decode callback in the form of a void*.
+  OSStatus status = VTDecompressionSessionDecodeFrame(
+      _decompressionSession, sampleBuffer, 0, decodeParams.release(), nullptr);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "H265Decoder: VTDecompressionSessionDecodeFrame failed with status: " << status;
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  
+  RTC_LOG(LS_INFO) << "H265Decoder: Successfully submitted frame for decoding";
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (void)setCallback:(RTCVideoDecoderCallback)callback {
+  _callback = callback;
+}
+
+- (NSInteger)releaseDecoder {
+  // Need to invalidate the session so that callbacks no longer occur and it
+  // is safe to null the callback.
+  [self destroyDecompressionSession];
+  [self setVideoFormat:nullptr];
+  _callback = nullptr;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (NSString *)implementationName {
+  return @"VideoToolbox";
+}
+
+#pragma mark - Private
+
+- (int)resetDecompressionSession {
+  [self destroyDecompressionSession];
+
+  // Set keys for OpenGL and IOSurface compatibilty, which makes the encoder
+  // create pixel buffers with GPU backed memory. The intent here is to pass
+  // the pixel buffers directly so we avoid a texture upload later during
+  // rendering. This currently is moot because we are converting back to an
+  // I420 frame after decode, but eventually we will be able to plumb
+  // CVPixelBuffers directly to the renderer.
+  NSDictionary *attributes = @{
+#if defined(WEBRTC_IOS) && (TARGET_OS_MACCATALYST || TARGET_OS_SIMULATOR)
+    (NSString *)kCVPixelBufferMetalCompatibilityKey : @(YES),
+#elif defined(WEBRTC_IOS) && !defined(TARGET_OS_VISION)
+    (NSString *)kCVPixelBufferOpenGLESCompatibilityKey : @(YES),
+#elif defined(WEBRTC_MAC) && !defined(WEBRTC_ARCH_ARM64)
+    (NSString *)kCVPixelBufferOpenGLCompatibilityKey : @(YES),
+#endif
+#if !(TARGET_OS_SIMULATOR)
+    (NSString *)kCVPixelBufferIOSurfacePropertiesKey : @{},
+#endif
+    (NSString *)kCVPixelBufferPixelFormatTypeKey :
+        @(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange),
+  };
+
+  VTDecompressionOutputCallbackRecord record = {
+      h265DecompressionOutputCallback, (__bridge void *)self,
+  };
+  OSStatus status = VTDecompressionSessionCreate(
+      nullptr, _videoFormat, nullptr, (__bridge CFDictionaryRef)attributes, &record, &_decompressionSession);
+  if (status != noErr) {
+    [self destroyDecompressionSession];
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  [self configureDecompressionSession];
+
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (void)configureDecompressionSession {
+  RTC_DCHECK(_decompressionSession);
+#if defined(WEBRTC_IOS)
+  VTSessionSetProperty(_decompressionSession,
+                       kVTDecompressionPropertyKey_RealTime, kCFBooleanTrue);
+#endif
+}
+
+- (void)destroyDecompressionSession {
+  if (_decompressionSession) {
+#if defined(WEBRTC_IOS)
+    VTDecompressionSessionWaitForAsynchronousFrames(_decompressionSession);
+#endif
+    VTDecompressionSessionInvalidate(_decompressionSession);
+    CFRelease(_decompressionSession);
+    _decompressionSession = nullptr;
+  }
+}
+
+- (void)setVideoFormat:(CMVideoFormatDescriptionRef)videoFormat {
+  if (_videoFormat == videoFormat) {
+    return;
+  }
+  if (_videoFormat) {
+    CFRelease(_videoFormat);
+  }
+  _videoFormat = videoFormat;
+  if (_videoFormat) {
+    CFRetain(_videoFormat);
+  }
+}
+
+- (void)setError:(OSStatus)error {
+  _error = error;
+}
+
+@end
+
+#endif  // RTC_ENABLE_H265 

--- a/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH265.h
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH265.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2024 The WebRTC project authors. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license
+ * that can be found in the LICENSE file in the root of the source
+ * tree. An additional intellectual property rights grant can be found
+ * in the file PATENTS.  All contributing project authors may
+ * be found in the AUTHORS file in the root of the source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "RTCVideoEncoderFactory.h"
+#import "sdk/objc/base/RTCMacros.h"
+
+RTC_OBJC_EXPORT
+@interface RTC_OBJC_TYPE (RTCVideoEncoderFactoryH265) : NSObject <RTC_OBJC_TYPE(RTCVideoEncoderFactory)>
+@end

--- a/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH265.mm
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2024 The WebRTC project authors. All Rights Reserved.
+ *
+ * Use of this source code is governed by a BSD-style license
+ * that can be found in the LICENSE file in the root of the source
+ * tree. An additional intellectual property rights grant can be found
+ * in the file PATENTS.  All contributing project authors may
+ * be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifdef RTC_ENABLE_H265
+
+#import "RTCVideoEncoderFactoryH265.h"
+
+#import "RTCVideoEncoderH265.h"
+#import "api/video_codec/RTCVideoCodecConstants.h"
+#import "base/RTCVideoCodecInfo.h"
+
+@implementation RTC_OBJC_TYPE (RTCVideoEncoderFactoryH265)
+
++ (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
+  NSMutableArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *codecs =
+      [NSMutableArray array];
+  NSString *codecName = RTC_CONSTANT_TYPE(RTCVideoCodecH265Name);
+
+  RTC_OBJC_TYPE(RTCVideoCodecInfo) *h265Info =
+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc]
+          initWithName:codecName
+            parameters:@{}];
+  [codecs addObject:h265Info];
+
+  return [codecs copy];
+}
+
+- (id<RTC_OBJC_TYPE(RTCVideoEncoder)>)createEncoder:
+    (RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info {
+  if ([info.name isEqualToString:RTC_CONSTANT_TYPE(RTCVideoCodecH265Name)]) {
+    return [[RTC_OBJC_TYPE(RTCVideoEncoderH265) alloc] initWithCodecInfo:info];
+  }
+  return nil;
+}
+
+@end
+
+#endif  // RTC_ENABLE_H265

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH265.h
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH265.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 The WebRTC project authors. All Rights Reserved.
+ *  Copyright 2024 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
@@ -10,11 +10,17 @@
 
 #import <Foundation/Foundation.h>
 
+#import "RTCVideoCodecInfo.h"
+#import "RTCVideoEncoder.h"
 #import "sdk/objc/base/RTCMacros.h"
 
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecVp8Name);
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecVp9Name);
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecAv1Name);
 #ifdef RTC_ENABLE_H265
-RTC_EXTERN NSString* const RTC_CONSTANT_TYPE(RTCVideoCodecH265Name);
-#endif
+
+RTC_OBJC_EXPORT
+@interface RTC_OBJC_TYPE (RTCVideoEncoderH265) : NSObject <RTC_OBJC_TYPE(RTCVideoEncoder)>
+
+- (instancetype)initWithCodecInfo:(RTC_OBJC_TYPE(RTCVideoCodecInfo) *)codecInfo;
+
+@end
+
+#endif  // RTC_ENABLE_H265 

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm
@@ -1,0 +1,535 @@
+/*
+ *  Copyright (c) 2024 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ *
+ */
+
+#ifdef RTC_ENABLE_H265
+
+#import "RTCVideoEncoderH265.h"
+
+#import <VideoToolbox/VideoToolbox.h>
+#include <vector>
+
+#if defined(WEBRTC_IOS)
+#import "helpers/UIDevice+RTCDevice.h"
+#endif
+#import "api/peerconnection/RTCVideoCodecInfo+Private.h"
+#import "base/RTCCodecSpecificInfo.h"
+#import "base/RTCI420Buffer.h"
+#import "base/RTCVideoEncoder.h"
+#import "base/RTCVideoFrame.h"
+#import "base/RTCVideoFrameBuffer.h"
+#import "components/video_frame_buffer/RTCCVPixelBuffer.h"
+#import "helpers.h"
+
+#include "api/video_codecs/h265_profile_tier_level.h"
+#include "common_video/include/bitrate_adjuster.h"
+#include "modules/video_coding/include/video_error_codes.h"
+#include "rtc_base/buffer.h"
+#include "rtc_base/logging.h"
+#include "rtc_base/time_utils.h"
+#include "sdk/objc/components/video_codec/nalu_rewriter.h"
+#include "third_party/libyuv/include/libyuv/convert_from.h"
+
+@interface RTC_OBJC_TYPE (RTCVideoEncoderH265)
+()
+
+    - (void)frameWasEncoded : (OSStatus)status flags
+    : (VTEncodeInfoFlags)infoFlags sampleBuffer
+    : (CMSampleBufferRef)sampleBuffer codecSpecificInfo
+    : (id<RTC_OBJC_TYPE(RTCCodecSpecificInfo)>)codecSpecificInfo width : (int32_t)width height
+    : (int32_t)height renderTimeMs : (int64_t)renderTimeMs timestamp : (uint32_t)timestamp rotation
+    : (RTC_OBJC_TYPE(RTCVideoRotation))rotation;
+
+@end
+
+namespace {  // anonymous namespace
+
+// The ratio between kVTCompressionPropertyKey_DataRateLimits and
+// kVTCompressionPropertyKey_AverageBitRate. The data rate limit is set higher
+// than the average bit rate to avoid undershooting the target.
+const float kLimitToAverageBitRateFactor = 10.0f;
+// These thresholds are adapted for H.265 - typically higher quality than H.264
+const int kLowH265QpThreshold = 26;
+const int kHighH265QpThreshold = 36;
+const int kBitsPerByte = 8;
+
+const OSType kNV12PixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
+
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCVideoEncodeMode)) {
+  RTC_OBJC_TYPE(RTCVideoEncodeModeVariable) = 0,
+  RTC_OBJC_TYPE(RTCVideoEncodeModeConstant) = 1,
+};
+
+NSArray *CreateRateLimitArray(uint32_t computedBitrateBps, RTC_OBJC_TYPE(RTCVideoEncodeMode) mode) {
+  switch (mode) {
+    case RTC_OBJC_TYPE(RTCVideoEncodeModeVariable): {
+      // 5 seconds should be an okay interval for VBR to enforce the long-term
+      // limit.
+      float avgInterval = 5.0;
+      uint32_t avgBytesPerSecond = computedBitrateBps / kBitsPerByte * avgInterval;
+      // And the peak bitrate is measured per-second in a way similar to CBR.
+      float peakInterval = 1.0;
+      uint32_t peakBytesPerSecond =
+          computedBitrateBps * kLimitToAverageBitRateFactor / kBitsPerByte;
+      return @[ @(peakBytesPerSecond), @(peakInterval), @(avgBytesPerSecond), @(avgInterval) ];
+    }
+    case RTC_OBJC_TYPE(RTCVideoEncodeModeConstant): {
+      // CBR should be enforces with granularity of a second.
+      float targetInterval = 1.0;
+      int32_t targetBitrate = computedBitrateBps / kBitsPerByte;
+      return @[ @(targetBitrate), @(targetInterval) ];
+    }
+  }
+}
+
+// Struct that we pass to the encoder per frame to encode. We receive it again
+// in the encoder callback.
+struct RTCFrameEncodeParams {
+  RTCFrameEncodeParams(RTC_OBJC_TYPE(RTCVideoEncoderH265) * e,
+                       id<RTC_OBJC_TYPE(RTCCodecSpecificInfo)> csi,
+                       int32_t w,
+                       int32_t h,
+                       int64_t rtms,
+                       uint32_t ts,
+                       RTC_OBJC_TYPE(RTCVideoRotation) r)
+      : encoder(e), codecSpecificInfo(csi), width(w), height(h), render_time_ms(rtms), timestamp(ts), rotation(r) {}
+
+  __weak RTC_OBJC_TYPE(RTCVideoEncoderH265) * encoder;
+  id<RTC_OBJC_TYPE(RTCCodecSpecificInfo)> codecSpecificInfo;
+  int32_t width;
+  int32_t height;
+  int64_t render_time_ms;
+  uint32_t timestamp;
+  RTC_OBJC_TYPE(RTCVideoRotation) rotation;
+};
+
+// We receive I420Frames as input, but we need to feed CVPixelBuffers into the
+// encoder. This performs the copy and format conversion.
+// TODO(tkchin): See if encoder will accept i420 frames and compare performance.
+bool CopyVideoFrameToNV12PixelBuffer(id<RTC_OBJC_TYPE(RTCI420Buffer)> frameBuffer,
+                                     CVPixelBufferRef pixelBuffer) {
+  RTC_DCHECK(pixelBuffer);
+  RTC_DCHECK_EQ(CVPixelBufferGetPixelFormatType(pixelBuffer), kNV12PixelFormat);
+  RTC_DCHECK_EQ(CVPixelBufferGetHeightOfPlane(pixelBuffer, 0), frameBuffer.height);
+  RTC_DCHECK_EQ(CVPixelBufferGetWidthOfPlane(pixelBuffer, 0), frameBuffer.width);
+
+  CVReturn cvRet = CVPixelBufferLockBaseAddress(pixelBuffer, 0);
+  if (cvRet != kCVReturnSuccess) {
+    RTC_LOG(LS_ERROR) << "Failed to lock base address: " << cvRet;
+    return false;
+  }
+
+  uint8_t* dstY = reinterpret_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0));
+  int dstStrideY = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0);
+  uint8_t* dstUV = reinterpret_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1));
+  int dstStrideUV = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 1);
+
+  // Convert I420 to NV12.
+  int ret = libyuv::I420ToNV12(frameBuffer.dataY, frameBuffer.strideY,
+                               frameBuffer.dataU, frameBuffer.strideU,
+                               frameBuffer.dataV, frameBuffer.strideV,
+                               dstY, dstStrideY, dstUV, dstStrideUV,
+                               frameBuffer.width, frameBuffer.height);
+  CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+  if (ret) {
+    RTC_LOG(LS_ERROR) << "Error converting I420 VideoFrame to NV12 :" << ret;
+    return false;
+  }
+  return true;
+}
+
+CVPixelBufferRef CreatePixelBuffer(CVPixelBufferPoolRef pixel_buffer_pool,
+                                   int32_t width,
+                                   int32_t height) {
+  if (!pixel_buffer_pool) {
+    RTC_LOG(LS_ERROR) << "Failed to get pixel buffer pool.";
+    return nullptr;
+  }
+  CVPixelBufferRef pixel_buffer;
+  CVReturn ret = CVPixelBufferPoolCreatePixelBuffer(nullptr, pixel_buffer_pool, &pixel_buffer);
+  if (ret != kCVReturnSuccess) {
+    RTC_LOG(LS_ERROR) << "Failed to create pixel buffer: " << ret;
+    // We probably want to drop frames here, since failure probably means
+    // that the pool is empty.
+    return nullptr;
+  }
+  return pixel_buffer;
+}
+
+// This is the callback function that VideoToolbox calls when encode is
+// complete.
+void compressionOutputCallback(void* encoder,
+                               void* params,
+                               OSStatus status,
+                               VTEncodeInfoFlags infoFlags,
+                               CMSampleBufferRef sampleBuffer) {
+  std::unique_ptr<RTCFrameEncodeParams> encodeParams(
+      reinterpret_cast<RTCFrameEncodeParams*>(params));
+  [encodeParams->encoder frameWasEncoded:status
+                                   flags:infoFlags
+                            sampleBuffer:sampleBuffer
+                       codecSpecificInfo:encodeParams->codecSpecificInfo
+                                   width:encodeParams->width
+                                  height:encodeParams->height
+                            renderTimeMs:encodeParams->render_time_ms
+                               timestamp:encodeParams->timestamp
+                                rotation:encodeParams->rotation];
+}
+
+}  // namespace
+
+@implementation RTC_OBJC_TYPE (RTCVideoEncoderH265) {
+  RTC_OBJC_TYPE(RTCVideoCodecInfo) * _codecInfo;
+  std::unique_ptr<webrtc::BitrateAdjuster> _bitrateAdjuster;
+  uint32_t _targetBitrateBps;
+  uint32_t _encoderBitrateBps;
+  uint32_t _encoderFramerate;
+  RTC_OBJC_TYPE(RTCVideoEncoderCallback) _callback;
+  int32_t _width;
+  int32_t _height;
+  VTCompressionSessionRef _compressionSession;
+  CVPixelBufferPoolRef _pixelBufferPool;
+  RTCVideoEncoderQpThresholds* _qpThresholds;
+}
+
+// .m files support the new boxing syntax.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
+- (instancetype)initWithCodecInfo:(RTC_OBJC_TYPE(RTCVideoCodecInfo)*)codecInfo {
+  if ((self = [super init])) {
+    _codecInfo = codecInfo;
+    _bitrateAdjuster.reset(new webrtc::BitrateAdjuster(.5, .95));
+    _encoderFramerate = 30;
+    _compressionSession = nullptr;
+    _pixelBufferPool = nullptr;
+    RTC_LOG(LS_INFO) << "RTCVideoEncoderH265 initialized.";
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [self destroyCompressionSession];
+  [self setPixelBufferPool:nullptr];
+}
+
+- (NSInteger)startEncodeWithSettings:(RTC_OBJC_TYPE(RTCVideoEncoderSettings)*)settings
+                       numberOfCores:(int)numberOfCores {
+  RTC_DCHECK(settings);
+  RTC_DCHECK([settings isKindOfClass:[RTC_OBJC_TYPE(RTCVideoEncoderSettings) class]]);
+  _width = settings.width;
+  _height = settings.height;
+  _targetBitrateBps = settings.startBitrate;
+  _bitrateAdjuster->SetTargetBitrateBps(_targetBitrateBps);
+  _qpThresholds = settings.qpMax > 0 ? [[RTCVideoEncoderQpThresholds alloc]
+                                                   initWithThresholdsLow:kLowH265QpThreshold
+                                                                    high:settings.qpMax]
+                                              : [[RTCVideoEncoderQpThresholds alloc]
+                                                    initWithThresholdsLow:kLowH265QpThreshold
+                                                                     high:kHighH265QpThreshold];
+
+  // We can only set average bitrate on the HW encoder.
+  _encoderBitrateBps = _bitrateAdjuster->GetAdjustedBitrateBps();
+
+  // TODO(tkchin): Try setting payload size via
+  // kVTCompressionPropertyKey_MaxH264SliceBytes.
+
+  return [self resetCompressionSession];
+}
+
+- (NSInteger)encode:(RTC_OBJC_TYPE(RTCVideoFrame)*)frame
+    codecSpecificInfo:(nullable id<RTC_OBJC_TYPE(RTCCodecSpecificInfo)>)info
+           frameTypes:(NSArray<NSNumber*>*)frameTypes {
+  if (!_callback || !_compressionSession) {
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+  BOOL isKeyframeRequired = NO;
+
+  // Get a pixel buffer from the pool and copy frame data over.
+  CVPixelBufferRef pixelBuffer = CreatePixelBuffer(_pixelBufferPool, _width, _height);
+  if (!pixelBuffer) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  if (!CopyVideoFrameToNV12PixelBuffer([frame.buffer toI420], pixelBuffer)) {
+    CFRelease(pixelBuffer);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  // Check if we need a keyframe.
+  if (frameTypes) {
+    for (NSNumber* frameType in frameTypes) {
+      if ((RTCFrameType)frameType.intValue == RTCFrameTypeVideoFrameKey) {
+        isKeyframeRequired = YES;
+        break;
+      }
+    }
+  }
+
+  CMTime presentationTimeStamp = CMTimeMake(frame.timeStampNs / 1000, 1000000);
+  CFDictionaryRef frameProperties = nullptr;
+  if (isKeyframeRequired) {
+    CFTypeRef keys[] = {kVTEncodeFrameOptionKey_ForceKeyFrame};
+    CFTypeRef values[] = {kCFBooleanTrue};
+    frameProperties = CFDictionaryCreate(nullptr, keys, values, 1, &kCFTypeDictionaryKeyCallBacks,
+                                         &kCFTypeDictionaryValueCallBacks);
+  }
+
+  std::unique_ptr<RTCFrameEncodeParams> encodeParams;
+  encodeParams.reset(new RTCFrameEncodeParams(self, info, _width, _height, frame.timeStampNs / webrtc::kNumNanosecsPerMillisec,
+                                              frame.timeStamp, frame.rotation));
+
+  // Update the bitrate if needed.
+  [self setBitrateBps:_bitrateAdjuster->GetAdjustedBitrateBps() framerate:_encoderFramerate];
+
+  OSStatus status = VTCompressionSessionEncodeFrame(_compressionSession, pixelBuffer,
+                                                    presentationTimeStamp, kCMTimeInvalid,
+                                                    frameProperties, encodeParams.release(), nullptr);
+  if (frameProperties) {
+    CFRelease(frameProperties);
+  }
+  CFRelease(pixelBuffer);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to encode frame with code: " << status;
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (void)setCallback:(RTC_OBJC_TYPE(RTCVideoEncoderCallback))callback {
+  _callback = callback;
+}
+
+- (int)setBitrate:(uint32_t)bitrateKbit framerate:(uint32_t)framerate {
+  _targetBitrateBps = 1000 * bitrateKbit;
+  _bitrateAdjuster->SetTargetBitrateBps(_targetBitrateBps);
+  [self setBitrateBps:_bitrateAdjuster->GetAdjustedBitrateBps() framerate:framerate];
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (NSInteger)releaseEncoder {
+  [self destroyCompressionSession];
+  [self setPixelBufferPool:nullptr];
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (NSString *)implementationName {
+  return @"VideoToolbox";
+}
+
+- (BOOL)applyAlignmentToAllSimulcastLayers {
+  return NO;
+}
+
+- (BOOL)supportsNativeHandle {
+  return YES;
+}
+
+- (NSInteger)resolutionAlignment {
+  return 1;
+}
+
+- (nullable RTC_OBJC_TYPE(RTCVideoEncoderQpThresholds) *)scalingSettings {
+  return _qpThresholds;
+}
+
+#pragma mark - Private
+
+- (NSInteger)resetCompressionSession {
+  [self destroyCompressionSession];
+  [self setPixelBufferPool:nullptr];
+
+  // Set source image buffer attributes. These attributes will be present on
+  // buffers that we receive from the encoder's pixel buffer pool.
+  const size_t attributesSize = 3;
+  CFTypeRef keys[attributesSize] = {
+#if defined(WEBRTC_IOS)
+    kCVPixelBufferOpenGLESCompatibilityKey,
+#elif defined(WEBRTC_MAC)
+    kCVPixelBufferOpenGLCompatibilityKey,
+#endif
+    kCVPixelBufferIOSurfacePropertiesKey,
+    kCVPixelBufferPixelFormatTypeKey
+  };
+  CFDictionaryRef ioSurfaceValue = CFDictionaryCreate(
+      nullptr, nullptr, nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+  int64_t pixelFormatType = kNV12PixelFormat;
+  CFNumberRef pixelFormat = CFNumberCreate(nullptr, kCFNumberLongType, &pixelFormatType);
+  CFTypeRef values[attributesSize] = {kCFBooleanTrue, ioSurfaceValue, pixelFormat};
+  CFDictionaryRef sourceAttributes = CFDictionaryCreate(
+      nullptr, keys, values, attributesSize, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+  CFRelease(ioSurfaceValue);
+  CFRelease(pixelFormat);
+
+  CFDictionaryRef encoderSpecs = nullptr;
+#if defined(WEBRTC_MAC) && !defined(WEBRTC_IOS)
+  // Currently hw accl is supported above 360p on mac, below 360p
+  // the compression session will be created with hw accl disabled.
+  encoderSpecs = CFDictionaryCreate(nullptr, nullptr, nullptr, 0, &kCFTypeDictionaryKeyCallBacks,
+                                    &kCFTypeDictionaryValueCallBacks);
+#endif
+
+  OSStatus status = VTCompressionSessionCreate(
+      nullptr,  // use default allocator
+      _width,
+      _height,
+      kCMVideoCodecType_HEVC,  // Use HEVC/H.265
+      encoderSpecs,  // use hardware accelerated encoder if available
+      sourceAttributes,
+      nullptr,  // use default compressed data allocator
+      compressionOutputCallback,
+      (__bridge void*)self,
+      &_compressionSession);
+  if (encoderSpecs) {
+    CFRelease(encoderSpecs);
+  }
+  CFRelease(sourceAttributes);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to create compression session: " << status;
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+#if defined(WEBRTC_MAC) && !defined(WEBRTC_IOS)
+  CFBooleanRef hwaccl_enabled = nullptr;
+  status = VTSessionCopyProperty(_compressionSession,
+                                 kVTCompressionPropertyKey_UsingHardwareAcceleratedVideoEncoder,
+                                 kCFAllocatorDefault, &hwaccl_enabled);
+  if (status == noErr && (CFBooleanGetValue(hwaccl_enabled))) {
+    RTC_LOG(LS_INFO) << "Compression session created with hw accl enabled";
+  } else {
+    RTC_LOG(LS_INFO) << "Compression session created with hw accl disabled";
+  }
+  if (hwaccl_enabled) {
+    CFRelease(hwaccl_enabled);
+  }
+#endif
+
+  [self configureCompressionSession];
+
+  // The pixel buffer pool is dependent on the compression session so if the
+  // compression session is reset, the pixel buffer pool should be reset as
+  // well.
+  CVPixelBufferPoolRef pixelBufferPool =
+      VTCompressionSessionGetPixelBufferPool(_compressionSession);
+  [self setPixelBufferPool:pixelBufferPool];
+
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (void)configureCompressionSession {
+  RTC_DCHECK(_compressionSession);
+  SetVTSessionProperty(_compressionSession, kVTCompressionPropertyKey_RealTime, true);
+  SetVTSessionProperty(_compressionSession, kVTCompressionPropertyKey_ProfileLevel,
+                       kVTProfileLevel_HEVC_Main_AutoLevel);
+  SetVTSessionProperty(_compressionSession, kVTCompressionPropertyKey_AllowFrameReordering, false);
+  [self setBitrateBps:_encoderBitrateBps framerate:_encoderFramerate];
+}
+
+- (void)destroyCompressionSession {
+  if (_compressionSession) {
+    VTCompressionSessionInvalidate(_compressionSession);
+    CFRelease(_compressionSession);
+    _compressionSession = nullptr;
+  }
+}
+
+- (void)setPixelBufferPool:(CVPixelBufferPoolRef)pixelBufferPool {
+  if (_pixelBufferPool == pixelBufferPool) {
+    return;
+  }
+  if (_pixelBufferPool) {
+    CFRelease(_pixelBufferPool);
+  }
+  _pixelBufferPool = pixelBufferPool;
+  if (_pixelBufferPool) {
+    CFRetain(_pixelBufferPool);
+  }
+}
+
+- (void)setBitrateBps:(uint32_t)bitrateBps framerate:(uint32_t)framerate {
+  if (_encoderBitrateBps != bitrateBps || _encoderFramerate != framerate) {
+    SetVTSessionProperty(_compressionSession, kVTCompressionPropertyKey_AverageBitRate, bitrateBps);
+    SetVTSessionProperty(_compressionSession, kVTCompressionPropertyKey_ExpectedFrameRate, framerate);
+
+    // TODO(tkchin): Add a helper method to set array value.
+    NSArray* dataRateLimits = CreateRateLimitArray(bitrateBps, RTC_OBJC_TYPE(RTCVideoEncodeModeVariable));
+    CFArrayRef cfArray = (__bridge CFArrayRef)dataRateLimits;
+    SetVTSessionProperty(_compressionSession, kVTCompressionPropertyKey_DataRateLimits, cfArray);
+    _encoderBitrateBps = bitrateBps;
+    _encoderFramerate = framerate;
+  }
+}
+
+- (void)frameWasEncoded:(OSStatus)status
+                  flags:(VTEncodeInfoFlags)infoFlags
+           sampleBuffer:(CMSampleBufferRef)sampleBuffer
+      codecSpecificInfo:(id<RTC_OBJC_TYPE(RTCCodecSpecificInfo)>)codecSpecificInfo
+                  width:(int32_t)width
+                 height:(int32_t)height
+           renderTimeMs:(int64_t)renderTimeMs
+              timestamp:(uint32_t)timestamp
+               rotation:(RTC_OBJC_TYPE(RTCVideoRotation))rotation {
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "H265 encode failed.";
+    return;
+  }
+  if (infoFlags & kVTEncodeInfo_FrameDropped) {
+    RTC_LOG(LS_INFO) << "H265 encode dropped frame.";
+    return;
+  }
+
+  BOOL isKeyframe = NO;
+  CFArrayRef attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, false);
+  if (attachments != nullptr && CFArrayGetCount(attachments)) {
+    CFDictionaryRef attachment =
+        static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(attachments, 0));
+    isKeyframe = !CFDictionaryContainsKey(attachment, kCMSampleAttachmentKey_NotSync);
+  }
+
+  if (isKeyframe) {
+    RTC_LOG(LS_INFO) << "Generated keyframe";
+  }
+
+  __block std::unique_ptr<rtc::Buffer> buffer = std::make_unique<rtc::Buffer>();
+  if (!webrtc::H265CMSampleBufferToAnnexBBuffer(sampleBuffer, isKeyframe, buffer.get())) {
+    return;
+  }
+  RTC_OBJC_TYPE(RTCEncodedImage)* frame = [[RTC_OBJC_TYPE(RTCEncodedImage) alloc] init];
+  frame.buffer = [NSData dataWithBytes:buffer->data() length:buffer->size()];
+  frame.encodedWidth = width;
+  frame.encodedHeight = height;
+  frame.frameType = isKeyframe ? RTCFrameTypeVideoFrameKey : RTCFrameTypeVideoFrameDelta;
+  frame.captureTimeMs = renderTimeMs;
+  frame.timeStamp = timestamp;
+  frame.rotation = rotation;
+  frame.contentType = (rotation == RTC_OBJC_TYPE(RTCVideoRotation_0) ||
+                       rotation == RTC_OBJC_TYPE(RTCVideoRotation_180))
+                          ? RTCVideoContentTypeUnspecified
+                          : RTCVideoContentTypeScreenshare;
+  frame.flags = webrtc::VideoSendTiming::kInvalid;
+
+  _bitrateAdjuster->Update(frame.buffer.length);
+
+  BOOL sendEncodedFrame = YES;
+  
+  // Check if we need to drop for quality reasons.
+  if (_qpThresholds) {
+    // TODO: Parse H.265 QP from the encoded frame similar to H.264
+    // For now, we'll skip QP-based dropping for H.265
+  }
+
+  if (sendEncodedFrame) {
+    _callback(frame, codecSpecificInfo);
+  }
+}
+
+#pragma clang diagnostic pop
+
+@end
+
+#endif  // RTC_ENABLE_H265 

--- a/sdk/objc/components/video_codec/nalu_rewriter.cc
+++ b/sdk/objc/components/video_codec/nalu_rewriter.cc
@@ -19,6 +19,10 @@
 #include "rtc_base/checks.h"
 #include "rtc_base/logging.h"
 
+#ifdef RTC_ENABLE_H265
+#include "common_video/h265/h265_common.h"
+#endif
+
 namespace webrtc {
 
 using H264::kAud;
@@ -325,5 +329,290 @@ bool AvccBufferWriter::WriteNalu(const uint8_t* data, size_t data_size) {
 size_t AvccBufferWriter::BytesRemaining() const {
   return length_ - offset_;
 }
+
+#ifdef RTC_ENABLE_H265
+
+bool H265CMSampleBufferToAnnexBBuffer(CMSampleBufferRef avcc_sample_buffer,
+                                      bool is_keyframe,
+                                      Buffer* annexb_buffer) {
+  RTC_DCHECK(avcc_sample_buffer);
+  RTC_DCHECK(annexb_buffer);
+
+  // Get format description from the sample buffer.
+  CMVideoFormatDescriptionRef description =
+      CMSampleBufferGetFormatDescription(avcc_sample_buffer);
+  if (description == nullptr) {
+    RTC_LOG(LS_ERROR) << "Failed to get sample buffer's description.";
+    return false;
+  }
+
+  // Get parameter set information.
+  int nalu_header_size = 0;
+  size_t param_set_count = 0;
+  OSStatus status = CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+      description, 0, nullptr, nullptr, &param_set_count, &nalu_header_size);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to get parameter set.";
+    return false;
+  }
+  RTC_CHECK_EQ(nalu_header_size, kAvccHeaderByteSize);
+  RTC_DCHECK_EQ(param_set_count, 3);
+
+  // Get the actual data.
+  CMBlockBufferRef block_buffer =
+      CMSampleBufferGetDataBuffer(avcc_sample_buffer);
+  if (block_buffer == nullptr) {
+    RTC_LOG(LS_ERROR) << "Failed to get sample buffer's data.";
+    return false;
+  }
+  size_t block_buffer_size = CMBlockBufferGetDataLength(block_buffer);
+  uint8_t* block_buffer_data = nullptr;
+  status = CMBlockBufferGetDataPointer(block_buffer, 0, nullptr, nullptr,
+                                       reinterpret_cast<char**>(&block_buffer_data));
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to get block buffer's data.";
+    return false;
+  }
+
+  // 1. If this is a keyframe, write parameter sets first.
+  if (is_keyframe) {
+    // Write VPS.
+    const uint8_t* param_set = nullptr;
+    size_t param_set_size = 0;
+    status = CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+        description, 0, &param_set, &param_set_size, nullptr, nullptr);
+    if (status != noErr) {
+      RTC_LOG(LS_ERROR) << "Failed to get VPS.";
+      return false;
+    }
+    annexb_buffer->AppendData(kAnnexBHeaderBytes, sizeof(kAnnexBHeaderBytes));
+    annexb_buffer->AppendData(param_set, param_set_size);
+
+    // Write SPS.
+    status = CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+        description, 1, &param_set, &param_set_size, nullptr, nullptr);
+    if (status != noErr) {
+      RTC_LOG(LS_ERROR) << "Failed to get SPS.";
+      return false;
+    }
+    annexb_buffer->AppendData(kAnnexBHeaderBytes, sizeof(kAnnexBHeaderBytes));
+    annexb_buffer->AppendData(param_set, param_set_size);
+
+    // Write PPS.
+    status = CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+        description, 2, &param_set, &param_set_size, nullptr, nullptr);
+    if (status != noErr) {
+      RTC_LOG(LS_ERROR) << "Failed to get PPS.";
+      return false;
+    }
+    annexb_buffer->AppendData(kAnnexBHeaderBytes, sizeof(kAnnexBHeaderBytes));
+    annexb_buffer->AppendData(param_set, param_set_size);
+  }
+
+  // 2. Write the sample buffer's data with proper start codes.
+  size_t bytes_remaining = block_buffer_size;
+  uint8_t* data_ptr = block_buffer_data;
+  while (bytes_remaining > 0) {
+    // The size type here must match `nalu_header_size`, we expect 4 bytes.
+    // Read the length of the next NALU from the sample buffer.
+    uint32_t nalu_size = 0;
+    if (bytes_remaining < kAvccHeaderByteSize) {
+      RTC_LOG(LS_ERROR) << "Failed to read complete NALU size.";
+      return false;
+    }
+    nalu_size = CFSwapInt32BigToHost(*reinterpret_cast<uint32_t*>(data_ptr));
+    data_ptr += kAvccHeaderByteSize;
+    bytes_remaining -= kAvccHeaderByteSize;
+
+    if (bytes_remaining < nalu_size) {
+      RTC_LOG(LS_ERROR) << "Failed to read complete NALU.";
+      return false;
+    }
+
+    // Replace length header with start code.
+    annexb_buffer->AppendData(kAnnexBHeaderBytes, sizeof(kAnnexBHeaderBytes));
+    annexb_buffer->AppendData(data_ptr, nalu_size);
+
+    data_ptr += nalu_size;
+    bytes_remaining -= nalu_size;
+  }
+
+  return true;
+}
+
+bool H265AnnexBBufferToCMSampleBuffer(const uint8_t* annexb_buffer,
+                                      size_t annexb_buffer_size,
+                                      CMVideoFormatDescriptionRef video_format,
+                                      CMSampleBufferRef* out_sample_buffer,
+                                      CMMemoryPoolRef memory_pool) {
+  RTC_DCHECK(annexb_buffer);
+  RTC_DCHECK(out_sample_buffer);
+  RTC_DCHECK(video_format);
+  *out_sample_buffer = nullptr;
+
+  RTC_LOG(LS_INFO) << "H265SampleBuffer: Converting AnnexB buffer size " << annexb_buffer_size << " to CMSampleBuffer";
+
+  // For H.265, we need to parse NALUs manually and skip parameter sets
+  std::vector<webrtc::H265::NaluIndex> nalu_indices = webrtc::H265::FindNaluIndices(annexb_buffer, annexb_buffer_size);
+  
+  RTC_LOG(LS_INFO) << "H265SampleBuffer: Found " << nalu_indices.size() << " NALUs";
+  
+  // Calculate total size of non-parameter-set NALUs
+  size_t output_size = 0;
+  std::vector<webrtc::H265::NaluIndex> frame_nalus;
+  
+  for (const auto& nalu : nalu_indices) {
+    if (annexb_buffer_size > nalu.payload_start_offset) {
+      webrtc::H265::NaluType nalu_type = webrtc::H265::ParseNaluType(annexb_buffer[nalu.payload_start_offset]);
+      
+      // Skip parameter sets (VPS, SPS, PPS) as they're already in the format description
+      if (nalu_type != webrtc::H265::kVps && 
+          nalu_type != webrtc::H265::kSps && 
+          nalu_type != webrtc::H265::kPps) {
+        frame_nalus.push_back(nalu);
+        output_size += nalu.payload_size + kAvccHeaderByteSize;
+        RTC_LOG(LS_VERBOSE) << "H265SampleBuffer: Including NALU type " << static_cast<int>(nalu_type) 
+                           << " size " << nalu.payload_size;
+      } else {
+        RTC_LOG(LS_VERBOSE) << "H265SampleBuffer: Skipping parameter set NALU type " << static_cast<int>(nalu_type);
+      }
+    }
+  }
+
+  RTC_LOG(LS_INFO) << "H265SampleBuffer: Will include " << frame_nalus.size() << " frame NALUs, total size: " << output_size;
+
+  if (frame_nalus.empty()) {
+    RTC_LOG(LS_WARNING) << "H265SampleBuffer: No frame NALUs found, only parameter sets";
+    return false;
+  }
+
+  // Allocate memory as a block buffer.
+  CMBlockBufferRef data = nullptr;
+  CFAllocatorRef block_allocator = CMMemoryPoolGetAllocator(memory_pool);
+  OSStatus status = CMBlockBufferCreateWithMemoryBlock(
+      kCFAllocatorDefault, nullptr, output_size, block_allocator,
+      nullptr, 0, output_size, kCMBlockBufferAssureMemoryNowFlag, &data);
+  if (status != kCMBlockBufferNoErr) {
+    RTC_LOG(LS_ERROR) << "H265SampleBuffer: Failed to create block buffer, status: " << status;
+    return false;
+  }
+
+  // Make sure block buffer is contiguous.
+  status = CMBlockBufferAssureBlockMemory(data);
+  if (status != kCMBlockBufferNoErr) {
+    RTC_LOG(LS_ERROR) << "Failed to make block buffer contiguous.";
+    CFRelease(data);
+    return false;
+  }
+
+  // Get a raw pointer to the data.
+  uint8_t* data_ptr = nullptr;
+  status = CMBlockBufferGetDataPointer(data, 0, nullptr, nullptr,
+                                       reinterpret_cast<char**>(&data_ptr));
+  if (status != kCMBlockBufferNoErr) {
+    RTC_LOG(LS_ERROR) << "Failed to get block buffer data pointer.";
+    CFRelease(data);
+    return false;
+  }
+
+  // Write Avcc NALUs into block buffer (excluding parameter sets).
+  AvccBufferWriter writer(data_ptr, output_size);
+  for (size_t i = 0; i < frame_nalus.size(); ++i) {
+    const auto& nalu = frame_nalus[i];
+    const uint8_t* nalu_data_ptr = annexb_buffer + nalu.payload_start_offset;
+    size_t nalu_data_size = nalu.payload_size;
+    if (!writer.WriteNalu(nalu_data_ptr, nalu_data_size)) {
+      RTC_LOG(LS_ERROR) << "H265SampleBuffer: Failed to write NALU " << i 
+                        << ", type: " << static_cast<int>(H265::ParseNaluType(*nalu_data_ptr))
+                        << ", size: " << nalu_data_size;
+      CFRelease(data);
+      return false;
+    }
+  }
+
+  // Create sample buffer.
+  status = CMSampleBufferCreate(kCFAllocatorDefault, data, true, nullptr,
+                                nullptr, video_format, 1, 0, nullptr, 0,
+                                nullptr, out_sample_buffer);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "H265SampleBuffer: Failed to create sample buffer, status: " << status 
+                      << ", output_size: " << output_size;
+    CFRelease(data);
+    return false;
+  }
+  CFRelease(data);
+  RTC_LOG(LS_INFO) << "H265SampleBuffer: Successfully created sample buffer with " 
+                   << frame_nalus.size() << " NALUs, total size: " << output_size;
+  return true;
+}
+
+CMVideoFormatDescriptionRef CreateH265VideoFormatDescription(
+    const uint8_t* annexb_buffer,
+    size_t annexb_buffer_size) {
+  RTC_LOG(LS_INFO) << "H265FormatDesc: Creating format description from buffer size: " << annexb_buffer_size;
+  
+  const uint8_t* param_set_ptrs[3] = {};
+  size_t param_set_sizes[3] = {};
+  bool found_vps = false, found_sps = false, found_pps = false;
+
+  // Parse H.265 NALUs manually
+  std::vector<webrtc::H265::NaluIndex> nalu_indices = webrtc::H265::FindNaluIndices(annexb_buffer, annexb_buffer_size);
+  
+  RTC_LOG(LS_INFO) << "H265FormatDesc: Found " << nalu_indices.size() << " NALUs in buffer";
+  
+  // Collect VPS, SPS, PPS (order doesn't matter)
+  for (const auto& nalu : nalu_indices) {
+    if (annexb_buffer_size > nalu.payload_start_offset) {
+      webrtc::H265::NaluType nalu_type = webrtc::H265::ParseNaluType(annexb_buffer[nalu.payload_start_offset]);
+      
+      RTC_LOG(LS_VERBOSE) << "H265FormatDesc: Processing NALU type: " << static_cast<int>(nalu_type) 
+                          << " size: " << nalu.payload_size;
+      
+      if (nalu_type == webrtc::H265::kVps && !found_vps) {
+        param_set_ptrs[0] = annexb_buffer + nalu.payload_start_offset;
+        param_set_sizes[0] = nalu.payload_size;
+        found_vps = true;
+        RTC_LOG(LS_INFO) << "H265FormatDesc: Found VPS, size: " << nalu.payload_size;
+      } else if (nalu_type == webrtc::H265::kSps && !found_sps) {
+        param_set_ptrs[1] = annexb_buffer + nalu.payload_start_offset;
+        param_set_sizes[1] = nalu.payload_size;
+        found_sps = true;
+        RTC_LOG(LS_INFO) << "H265FormatDesc: Found SPS, size: " << nalu.payload_size;
+      } else if (nalu_type == webrtc::H265::kPps && !found_pps) {
+        param_set_ptrs[2] = annexb_buffer + nalu.payload_start_offset;
+        param_set_sizes[2] = nalu.payload_size;
+        found_pps = true;
+        RTC_LOG(LS_INFO) << "H265FormatDesc: Found PPS, size: " << nalu.payload_size;
+      }
+      
+      // Break early if we found all parameter sets
+      if (found_vps && found_sps && found_pps) {
+        break;
+      }
+    }
+  }
+  
+  // Check if we found all required parameter sets
+  if (!found_vps || !found_sps || !found_pps) {
+    RTC_LOG(LS_WARNING) << "H265FormatDesc: Failed to find all required parameter sets (VPS/SPS/PPS). Found: VPS=" 
+                        << found_vps << ", SPS=" << found_sps << ", PPS=" << found_pps;
+    return nullptr;
+  }
+
+  // Create video format description.
+  CMVideoFormatDescriptionRef description = nullptr;
+  OSStatus status = CMVideoFormatDescriptionCreateFromHEVCParameterSets(
+      kCFAllocatorDefault, 3, param_set_ptrs, param_set_sizes, kAvccHeaderByteSize,
+      nullptr, &description);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "H265FormatDesc: Failed to create video format description, status: " << status;
+    return nullptr;
+  }
+  
+  RTC_LOG(LS_INFO) << "H265FormatDesc: Successfully created video format description";
+  return description;
+}
+
+#endif  // RTC_ENABLE_H265
 
 }  // namespace webrtc

--- a/sdk/objc/components/video_codec/nalu_rewriter.h
+++ b/sdk/objc/components/video_codec/nalu_rewriter.h
@@ -108,6 +108,23 @@ class AvccBufferWriter final {
   const size_t length_;
 };
 
+#ifdef RTC_ENABLE_H265
+// H.265/HEVC versions of the above functions
+bool H265CMSampleBufferToAnnexBBuffer(CMSampleBufferRef avcc_sample_buffer,
+                                      bool is_keyframe,
+                                      webrtc::Buffer* annexb_buffer);
+
+bool H265AnnexBBufferToCMSampleBuffer(const uint8_t* annexb_buffer,
+                                      size_t annexb_buffer_size,
+                                      CMVideoFormatDescriptionRef video_format,
+                                      CMSampleBufferRef* out_sample_buffer,
+                                      CMMemoryPoolRef memory_pool);
+
+CMVideoFormatDescriptionRef CreateH265VideoFormatDescription(
+    const uint8_t* annexb_buffer,
+    size_t annexb_buffer_size);
+#endif  // RTC_ENABLE_H265
+
 }  // namespace webrtc
 
 #endif  // SDK_OBJC_FRAMEWORK_CLASSES_VIDEOTOOLBOX_NALU_REWRITER_H_


### PR DESCRIPTION
- Introduced RTCVideoEncoderFactoryH265 and RTCVideoEncoderH265 classes for H.265 encoding.
- Implemented methods to support H.265 codec, including codec creation and encoding.
- Added functionality to convert between CMSampleBuffer and Annex B format for H.265.
- Enhanced nalu_rewriter to handle H.265 specific NALU parsing and conversion.
- Updated existing files to integrate H.265 support, ensuring compatibility with the WebRTC framework.
- Added necessary logging for debugging and tracking encoding processes.