### PR TITLE
Ensure ClearChannel is called

### DIFF
--- a/pc/rtp_transceiver.cc
+++ b/pc/rtp_transceiver.cc
@@ -188,8 +188,8 @@ RtpTransceiver::~RtpTransceiver() {
   // TODO(tommi): On Android, when running PeerConnectionClientTest (e.g.
   // PeerConnectionClientTest#testCameraSwitch), the instance doesn't get
   // deleted on `thread_`. See if we can fix that.
+  RTC_DCHECK_RUN_ON(thread_);
   if (!stopped_) {
-    RTC_DCHECK_RUN_ON(thread_);
     StopInternal();
   }
 

--- a/pc/rtp_transceiver.cc
+++ b/pc/rtp_transceiver.cc
@@ -391,7 +391,6 @@ void RtpTransceiver::DeleteChannel() {
     // be.
     channel_to_delete.reset();
   });
-  channel_ = nullptr;
 }
 
 void RtpTransceiver::AddSender(

--- a/pc/rtp_transceiver.cc
+++ b/pc/rtp_transceiver.cc
@@ -391,6 +391,7 @@ void RtpTransceiver::DeleteChannel() {
     // be.
     channel_to_delete.reset();
   });
+  channel_ = nullptr;
 }
 
 void RtpTransceiver::AddSender(

--- a/pc/sdp_offer_answer.cc
+++ b/pc/sdp_offer_answer.cc
@@ -5182,6 +5182,10 @@ void SdpOfferAnswerHandler::RemoveStoppedTransceivers() {
       RTC_LOG(LS_INFO)
           << "Dropping stopped transceiver that was never associated";
     }
+    // Ensure channel teardown before dropping the last reference.
+    if (transceiver->internal()->channel()) {
+      transceiver->internal()->ClearChannel();
+    }
     transceivers()->Remove(transceiver);
   }
 }

--- a/pc/sdp_offer_answer.cc
+++ b/pc/sdp_offer_answer.cc
@@ -5184,6 +5184,7 @@ void SdpOfferAnswerHandler::RemoveStoppedTransceivers() {
     }
     // Ensure channel teardown before dropping the last reference.
     if (transceiver->internal()->channel()) {
+      RTC_LOG(LS_INFO) << "Clearing channel before removing transceiver";
       transceiver->internal()->ClearChannel();
     }
     transceivers()->Remove(transceiver);


### PR DESCRIPTION
Avoids crash at transceiver deinit that channel is not cleaned up.
