### PR TITLE
Audio engine input / output availability

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -121,6 +121,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool output_enabled = false;
     bool output_running = false;
 
+    bool output_allowed = true;
+    bool input_allowed = true;
+
     // Output will be enabled when input is enabled
     bool input_follow_mode = true;
     bool input_enabled_persistent_mode = false;
@@ -146,6 +149,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool operator==(const EngineState& rhs) const {
       return input_enabled == rhs.input_enabled && input_running == rhs.input_running &&
              output_enabled == rhs.output_enabled && output_running == rhs.output_running &&
+             input_allowed == rhs.input_allowed && output_allowed == rhs.output_allowed &&
              input_follow_mode == rhs.input_follow_mode &&
              input_enabled_persistent_mode == rhs.input_enabled_persistent_mode &&
              input_muted == rhs.input_muted && is_interrupted == rhs.is_interrupted &&
@@ -164,32 +168,28 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool IsOutputInputLinked() const { return input_follow_mode && voice_processing_enabled; }
 
     bool IsOutputEnabled() const {
-      return IsOutputInputLinked() ? (IsInputEnabled() || output_enabled) : output_enabled;
+      bool result = IsOutputInputLinked() ? (IsInputEnabled() || output_enabled) : output_enabled;
+      return output_allowed && result;
     }
 
     bool IsOutputRunning() const {
-      return IsOutputInputLinked() ? (IsInputRunning() || output_running) : output_running;
+      bool result = IsOutputInputLinked() ? (IsInputRunning() || output_running) : output_running;
+      return output_allowed && result;
     }
 
     bool IsInputEnabled() const {
-      return !(mute_mode == MuteMode::RestartEngine && input_muted) &&
-             (input_enabled || input_enabled_persistent_mode);
+      bool result = !(mute_mode == MuteMode::RestartEngine && input_muted) &&
+                    (input_enabled || input_enabled_persistent_mode);
+      return input_allowed && result;
     }
 
     bool IsInputRunning() const {
-      return !(mute_mode == MuteMode::RestartEngine && input_muted) && input_running;
+      bool result = !(mute_mode == MuteMode::RestartEngine && input_muted) && input_running;
+      return input_allowed && result;
     }
 
     bool IsAnyEnabled() const { return IsInputEnabled() || IsOutputEnabled(); }
     bool IsAnyRunning() const { return IsInputRunning() || IsOutputRunning(); }
-
-    bool IsAllEnabled() const {
-      return IsOutputInputLinked() ? IsInputEnabled() : IsInputEnabled() && output_enabled;
-    }
-
-    bool IsAllRunning() const {
-      return IsOutputInputLinked() ? input_running : input_running && output_running;
-    }
 
     bool IsOutputDefaultDevice() const {
 #if TARGET_OS_OSX
@@ -331,6 +331,8 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   int32_t InitAndStartRecording();
 
+  int32_t ModifyEngineState(std::function<EngineState(EngineState)> state_transform);
+
  private:
   struct EngineStateUpdate {
     EngineState prev;
@@ -411,7 +413,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   EngineState engine_state_ RTC_GUARDED_BY(thread_);
 
   bool IsMicrophonePermissionGranted();
-  int32_t ModifyEngineState(std::function<EngineState(EngineState)> state_transform);
+
   int32_t ApplyDeviceEngineState(EngineStateUpdate state);
   int32_t ApplyManualEngineState(EngineStateUpdate state);
 

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -121,8 +121,8 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool output_enabled = false;
     bool output_running = false;
 
-    bool output_allowed = true;
-    bool input_allowed = true;
+    bool output_available = true;
+    bool input_available = true;
 
     // Output will be enabled when input is enabled
     bool input_follow_mode = true;
@@ -149,7 +149,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool operator==(const EngineState& rhs) const {
       return input_enabled == rhs.input_enabled && input_running == rhs.input_running &&
              output_enabled == rhs.output_enabled && output_running == rhs.output_running &&
-             input_allowed == rhs.input_allowed && output_allowed == rhs.output_allowed &&
+             input_available == rhs.input_available && output_available == rhs.output_available &&
              input_follow_mode == rhs.input_follow_mode &&
              input_enabled_persistent_mode == rhs.input_enabled_persistent_mode &&
              input_muted == rhs.input_muted && is_interrupted == rhs.is_interrupted &&
@@ -169,23 +169,23 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
     bool IsOutputEnabled() const {
       bool result = IsOutputInputLinked() ? (IsInputEnabled() || output_enabled) : output_enabled;
-      return output_allowed && result;
+      return output_available && result;
     }
 
     bool IsOutputRunning() const {
       bool result = IsOutputInputLinked() ? (IsInputRunning() || output_running) : output_running;
-      return output_allowed && result;
+      return output_available && result;
     }
 
     bool IsInputEnabled() const {
       bool result = !(mute_mode == MuteMode::RestartEngine && input_muted) &&
                     (input_enabled || input_enabled_persistent_mode);
-      return input_allowed && result;
+      return input_available && result;
     }
 
     bool IsInputRunning() const {
       bool result = !(mute_mode == MuteMode::RestartEngine && input_muted) && input_running;
-      return input_allowed && result;
+      return input_available && result;
     }
 
     bool IsAnyEnabled() const { return IsInputEnabled() || IsOutputEnabled(); }
@@ -303,6 +303,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   int32_t SetEngineState(EngineState enable);
   int32_t GetEngineState(EngineState* enabled);
 
+  int32_t SetEngineAvailability(bool input_available, bool output_available);
+  int32_t EngineAvailability(bool* input_available, bool* output_available);
+
   int32_t SetObserver(AudioDeviceObserver* observer) override;
 
   int32_t SetManualRenderingMode(bool enable);
@@ -330,8 +333,6 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   int32_t VoiceProcessingAGCEnabled(bool* enabled);
 
   int32_t InitAndStartRecording();
-
-  int32_t ModifyEngineState(std::function<EngineState(EngineState)> state_transform);
 
  private:
   struct EngineStateUpdate {
@@ -413,6 +414,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   EngineState engine_state_ RTC_GUARDED_BY(thread_);
 
   bool IsMicrophonePermissionGranted();
+  int32_t ModifyEngineState(std::function<EngineState(EngineState)> state_transform);
 
   int32_t ApplyDeviceEngineState(EngineStateUpdate state);
   int32_t ApplyManualEngineState(EngineStateUpdate state);

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1111,6 +1111,33 @@ int32_t AudioEngineDevice::SetVoiceProcessingAGCEnabled(bool enable) {
   return result;
 }
 
+int32_t AudioEngineDevice::SetEngineAvailability(bool input_available, bool output_available) {
+  RTC_DCHECK_RUN_ON(thread_);
+  LOGI() << "SetEngineAvailability: " << input_available << " " << output_available;
+
+  int32_t result =
+      ModifyEngineState([input_available, output_available](EngineState state) -> EngineState {
+        state.input_available = input_available;
+        state.output_available = output_available;
+        return state;
+      });
+
+  return result;
+}
+
+int32_t AudioEngineDevice::EngineAvailability(bool* input_available, bool* output_available) {
+  RTC_DCHECK_RUN_ON(thread_);
+
+  if (input_available == nullptr || output_available == nullptr) {
+    return -1;
+  }
+
+  *input_available = engine_state_.input_available;
+  *output_available = engine_state_.output_available;
+
+  return 0;
+}
+
 int32_t AudioEngineDevice::ManualRenderingMode(bool* enabled) {
   LOGI() << "ManualRenderingMode";
   RTC_DCHECK_RUN_ON(thread_);

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -41,13 +41,18 @@ typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCAudioEngineMuteMode)) {
 };
 
 typedef struct {
-  bool outputEnabled;
-  bool outputRunning;
-  bool inputEnabled;
-  bool inputRunning;
-  bool inputMuted;
+  BOOL outputEnabled;
+  BOOL outputRunning;
+  BOOL inputEnabled;
+  BOOL inputRunning;
+  BOOL inputMuted;
   RTC_OBJC_TYPE(RTCAudioEngineMuteMode) muteMode;
 } RTC_OBJC_TYPE(RTCAudioEngineState);
+
+typedef struct {
+  BOOL isInputAllowed;
+  BOOL isOutputAllowed;
+} RTC_OBJC_TYPE(RTCAudioEngineIOPermissions);
 
 RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCAudioEngineInputMixerNodeKey);
 
@@ -141,6 +146,8 @@ RTC_OBJC_EXPORT
 
 - (NSInteger)initAndStartRecording;
 
+- (NSInteger)setAudioEngineIOPermissions:(RTC_OBJC_TYPE(RTCAudioEngineIOPermissions))permissions;
+
 // For testing purposes
 @property(nonatomic, readonly) BOOL isPlayoutInitialized;
 @property(nonatomic, readonly) BOOL isRecordingInitialized;
@@ -184,6 +191,8 @@ RTC_OBJC_EXPORT
 /// Indicates whether Automatic Gain Control (AGC) is enabled. Requires Voice-Processing I/O to be
 /// enabled. Enabled by default when VPIO is enabled.
 @property(nonatomic, assign, getter=isVoiceProcessingAGCEnabled) BOOL voiceProcessingAGCEnabled;
+
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCAudioEngineIOPermissions) audioEngineIOPermissions;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -50,9 +50,9 @@ typedef struct {
 } RTC_OBJC_TYPE(RTCAudioEngineState);
 
 typedef struct {
-  BOOL isInputAllowed;
-  BOOL isOutputAllowed;
-} RTC_OBJC_TYPE(RTCAudioEngineIOPermissions);
+  BOOL isInputAvailable;
+  BOOL isOutputAvailable;
+} RTC_OBJC_TYPE(RTCAudioEngineAvailability);
 
 RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCAudioEngineInputMixerNodeKey);
 
@@ -146,7 +146,7 @@ RTC_OBJC_EXPORT
 
 - (NSInteger)initAndStartRecording;
 
-- (NSInteger)setAudioEngineIOPermissions:(RTC_OBJC_TYPE(RTCAudioEngineIOPermissions))permissions;
+- (NSInteger)setEngineAvailability:(RTC_OBJC_TYPE(RTCAudioEngineAvailability))availability;
 
 // For testing purposes
 @property(nonatomic, readonly) BOOL isPlayoutInitialized;
@@ -192,7 +192,7 @@ RTC_OBJC_EXPORT
 /// enabled. Enabled by default when VPIO is enabled.
 @property(nonatomic, assign, getter=isVoiceProcessingAGCEnabled) BOOL voiceProcessingAGCEnabled;
 
-@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCAudioEngineIOPermissions) audioEngineIOPermissions;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCAudioEngineAvailability) engineAvailability;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -381,33 +381,27 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 
 #pragma mark - Unique to AudioEngineDevice
 
-- (NSInteger)setAudioEngineIOPermissions:(RTC_OBJC_TYPE(RTCAudioEngineIOPermissions))permissions {
+- (NSInteger)setEngineAvailability:(RTC_OBJC_TYPE(RTCAudioEngineAvailability))availability {
   webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
-  return _workerThread->BlockingCall([module, permissions] {
-    int32_t result =
-        module->ModifyEngineState([permissions](webrtc::AudioEngineDevice::EngineState state)
-                                      -> webrtc::AudioEngineDevice::EngineState {
-          state.input_allowed = permissions.isInputAllowed;
-          state.output_allowed = permissions.isOutputAllowed;
-          return state;
-        });
-
-    return result;
+  return _workerThread->BlockingCall([module, availability] {
+    return module->SetEngineAvailability(availability.isInputAvailable,
+                                         availability.isOutputAvailable);
   });
 }
 
-- (RTC_OBJC_TYPE(RTCAudioEngineIOPermissions))audioEngineIOPermissions {
+- (RTC_OBJC_TYPE(RTCAudioEngineAvailability))engineAvailability {
   webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineIOPermissions)(YES, YES);
+  if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineAvailability)(NO, NO);
 
   return _workerThread->BlockingCall([module] {
-    webrtc::AudioEngineDevice::EngineState state = {};
-    int32_t result = module->GetEngineState(&state);
-    if (result != 0) return RTC_OBJC_TYPE(RTCAudioEngineIOPermissions)(YES, YES);
+    bool input_available = false;
+    bool output_available = false;
+    int32_t result = module->EngineAvailability(&input_available, &output_available);
+    if (result != 0) return RTC_OBJC_TYPE(RTCAudioEngineAvailability)(NO, NO);
 
-    return RTC_OBJC_TYPE(RTCAudioEngineIOPermissions)(state.input_allowed, state.output_allowed);
+    return RTC_OBJC_TYPE(RTCAudioEngineAvailability)(input_available, output_available);
   });
 }
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -381,6 +381,36 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 
 #pragma mark - Unique to AudioEngineDevice
 
+- (NSInteger)setAudioEngineIOPermissions:(RTC_OBJC_TYPE(RTCAudioEngineIOPermissions))permissions {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return -1;
+
+  return _workerThread->BlockingCall([module, permissions] {
+    int32_t result =
+        module->ModifyEngineState([permissions](webrtc::AudioEngineDevice::EngineState state)
+                                      -> webrtc::AudioEngineDevice::EngineState {
+          state.input_allowed = permissions.isInputAllowed;
+          state.output_allowed = permissions.isOutputAllowed;
+          return state;
+        });
+
+    return result;
+  });
+}
+
+- (RTC_OBJC_TYPE(RTCAudioEngineIOPermissions))audioEngineIOPermissions {
+  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineIOPermissions)(YES, YES);
+
+  return _workerThread->BlockingCall([module] {
+    webrtc::AudioEngineDevice::EngineState state = {};
+    int32_t result = module->GetEngineState(&state);
+    if (result != 0) return RTC_OBJC_TYPE(RTCAudioEngineIOPermissions)(YES, YES);
+
+    return RTC_OBJC_TYPE(RTCAudioEngineIOPermissions)(state.input_allowed, state.output_allowed);
+  });
+}
+
 - (BOOL)isRecordingAlwaysPreparedMode {
   webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return NO;


### PR DESCRIPTION
Adds a flag to override engine start/stop behavior, useful in scenarios such as CallKit, where the timing for starting AVAudioSession and AVAudioEngine is restricted.