### PR TITLE
Revert default AudioOptions change for webrtc_voice_engine.cc on Android

### DIFF
--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -551,10 +551,17 @@ void WebRtcVoiceEngine::Init() {
   // Set default engine options.
   {
     AudioOptions options;
+#if defined(WEBRTC_ANDROID)
+    options.echo_cancellation = true;
+    options.auto_gain_control = true;
+    options.noise_suppression = true;
+    options.highpass_filter = true;
+#else
     options.echo_cancellation = false;
     options.auto_gain_control = false;
     options.noise_suppression = false;
     options.highpass_filter = false;
+#endif
     options.stereo_swapping = false;
     options.audio_jitter_buffer_max_packets = 200;
     options.audio_jitter_buffer_fast_accelerate = false;


### PR DESCRIPTION
These default values got changed from true to false in #178. On Android, the way the audio options are set is fairly janky, and actually relied on these initially defaulting to true.

I'm not sure if other non iOS platforms rely on these initial default values as well, but that's something to be aware of for those platforms.