### PR TITLE
Fix EGL error code reporting in GLException messages

### DIFF
--- a/sdk/android/src/java/org/webrtc/EglBase10Impl.java
+++ b/sdk/android/src/java/org/webrtc/EglBase10Impl.java
@@ -66,8 +66,7 @@ class EglBase10Impl implements EglBase10 {
           tempEglSurface =
               egl.eglCreatePbufferSurface(currentDisplay, eglContextConfig, surfaceAttribs);
           if (!egl.eglMakeCurrent(currentDisplay, tempEglSurface, tempEglSurface, eglContext)) {
-            throw new GLException(egl.eglGetError(),
-                "Failed to make temporary EGL surface active: " + egl.eglGetError());
+            throwEglException(egl.eglGetError(), "Failed to make temporary EGL surface active");
           }
         }
 
@@ -162,8 +161,7 @@ class EglBase10Impl implements EglBase10 {
 
       synchronized (EglBase.lock) {
         if (!egl.eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)) {
-          throw new GLException(egl.eglGetError(),
-              "eglMakeCurrent failed: 0x" + Integer.toHexString(egl.eglGetError()));
+          throwEglException(egl.eglGetError(), "eglMakeCurrent failed");
         }
       }
       currentSurface = eglSurface;
@@ -173,8 +171,7 @@ class EglBase10Impl implements EglBase10 {
       synchronized (EglBase.lock) {
         if (!egl.eglMakeCurrent(
                 eglDisplay, EGL10.EGL_NO_SURFACE, EGL10.EGL_NO_SURFACE, EGL10.EGL_NO_CONTEXT)) {
-          throw new GLException(egl.eglGetError(),
-              "eglDetachCurrent failed: 0x" + Integer.toHexString(egl.eglGetError()));
+          throwEglException(egl.eglGetError(), "eglDetachCurrent failed");
         }
       }
       currentSurface = EGL10.EGL_NO_SURFACE;
@@ -281,8 +278,7 @@ class EglBase10Impl implements EglBase10 {
     eglSurface = egl.eglCreateWindowSurface(
         eglConnection.getDisplay(), eglConnection.getConfig(), nativeWindow, surfaceAttribs);
     if (eglSurface == EGL10.EGL_NO_SURFACE) {
-      throw new GLException(egl.eglGetError(),
-          "Failed to create window surface: 0x" + Integer.toHexString(egl.eglGetError()));
+      throwEglException(egl.eglGetError(), "Failed to create window surface");
     }
   }
 
@@ -303,9 +299,8 @@ class EglBase10Impl implements EglBase10 {
     eglSurface = egl.eglCreatePbufferSurface(
         eglConnection.getDisplay(), eglConnection.getConfig(), surfaceAttribs);
     if (eglSurface == EGL10.EGL_NO_SURFACE) {
-      throw new GLException(egl.eglGetError(),
-          "Failed to create pixel buffer surface with size " + width + "x" + height + ": 0x"
-              + Integer.toHexString(egl.eglGetError()));
+      throwEglException(egl.eglGetError(),
+          "Failed to create pixel buffer surface with size " + width + "x" + height);
     }
   }
 
@@ -394,13 +389,11 @@ class EglBase10Impl implements EglBase10 {
   private static EGLDisplay getEglDisplay(EGL10 egl) {
     EGLDisplay eglDisplay = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
     if (eglDisplay == EGL10.EGL_NO_DISPLAY) {
-      throw new GLException(egl.eglGetError(),
-          "Unable to get EGL10 display: 0x" + Integer.toHexString(egl.eglGetError()));
+      throwEglException(egl.eglGetError(), "Unable to get EGL10 display");
     }
     int[] version = new int[2];
     if (!egl.eglInitialize(eglDisplay, version)) {
-      throw new GLException(egl.eglGetError(),
-          "Unable to initialize EGL10: 0x" + Integer.toHexString(egl.eglGetError()));
+      throwEglException(egl.eglGetError(), "Unable to initialize EGL10");
     }
     return eglDisplay;
   }
@@ -410,8 +403,7 @@ class EglBase10Impl implements EglBase10 {
     EGLConfig[] configs = new EGLConfig[1];
     int[] numConfigs = new int[1];
     if (!egl.eglChooseConfig(eglDisplay, configAttributes, configs, configs.length, numConfigs)) {
-      throw new GLException(
-          egl.eglGetError(), "eglChooseConfig failed: 0x" + Integer.toHexString(egl.eglGetError()));
+      throwEglException(egl.eglGetError(), "eglChooseConfig failed");
     }
     if (numConfigs[0] <= 0) {
       throw new RuntimeException("Unable to find any matching EGL config");
@@ -436,10 +428,13 @@ class EglBase10Impl implements EglBase10 {
       eglContext = egl.eglCreateContext(eglDisplay, eglConfig, rootContext, contextAttributes);
     }
     if (eglContext == EGL10.EGL_NO_CONTEXT) {
-      throw new GLException(egl.eglGetError(),
-          "Failed to create EGL context: 0x" + Integer.toHexString(egl.eglGetError()));
+        throwEglException(egl.eglGetError(), "Failed to create EGL context");
     }
     return eglContext;
+  }
+
+  private static void throwEglException(int error, String message) {
+      throw new GLException(error, message + ": 0x" + Integer.toHexString(error));
   }
 
   private static native long nativeGetCurrentNativeEGLContext();

--- a/sdk/android/src/java/org/webrtc/EglBase14Impl.java
+++ b/sdk/android/src/java/org/webrtc/EglBase14Impl.java
@@ -118,8 +118,7 @@ class EglBase14Impl implements EglBase14 {
 
       synchronized (EglBase.lock) {
         if (!EGL14.eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)) {
-          throw new GLException(EGL14.eglGetError(),
-              "eglMakeCurrent failed: 0x" + Integer.toHexString(EGL14.eglGetError()));
+          throwEglException(EGL14.eglGetError(), "eglMakeCurrent failed");
         }
       }
       currentSurface = eglSurface;
@@ -129,8 +128,7 @@ class EglBase14Impl implements EglBase14 {
       synchronized (EglBase.lock) {
         if (!EGL14.eglMakeCurrent(
                 eglDisplay, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_CONTEXT)) {
-          throw new GLException(EGL14.eglGetError(),
-              "eglDetachCurrent failed: 0x" + Integer.toHexString(EGL14.eglGetError()));
+          throwEglException(EGL14.eglGetError(), "eglDetachCurrent failed");
         }
       }
       currentSurface = EGL14.EGL_NO_SURFACE;
@@ -173,8 +171,7 @@ class EglBase14Impl implements EglBase14 {
     eglSurface = EGL14.eglCreateWindowSurface(
         eglConnection.getDisplay(), eglConnection.getConfig(), surface, surfaceAttribs, 0);
     if (eglSurface == EGL14.EGL_NO_SURFACE) {
-      throw new GLException(EGL14.eglGetError(),
-          "Failed to create window surface: 0x" + Integer.toHexString(EGL14.eglGetError()));
+      throwEglException(EGL14.eglGetError(), "Failed to create window surface");
     }
   }
 
@@ -193,9 +190,8 @@ class EglBase14Impl implements EglBase14 {
     eglSurface = EGL14.eglCreatePbufferSurface(
         eglConnection.getDisplay(), eglConnection.getConfig(), surfaceAttribs, 0);
     if (eglSurface == EGL14.EGL_NO_SURFACE) {
-      throw new GLException(EGL14.eglGetError(),
-          "Failed to create pixel buffer surface with size " + width + "x" + height + ": 0x"
-              + Integer.toHexString(EGL14.eglGetError()));
+      throwEglException(EGL14.eglGetError(),
+          "Failed to create pixel buffer surface with size " + width + "x" + height);
     }
   }
 
@@ -289,13 +285,11 @@ class EglBase14Impl implements EglBase14 {
   private static EGLDisplay getEglDisplay() {
     EGLDisplay eglDisplay = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY);
     if (eglDisplay == EGL14.EGL_NO_DISPLAY) {
-      throw new GLException(EGL14.eglGetError(),
-          "Unable to get EGL14 display: 0x" + Integer.toHexString(EGL14.eglGetError()));
+      throwEglException(EGL14.eglGetError(), "Unable to get EGL14 display");
     }
     int[] version = new int[2];
     if (!EGL14.eglInitialize(eglDisplay, version, 0, version, 1)) {
-      throw new GLException(EGL14.eglGetError(),
-          "Unable to initialize EGL14: 0x" + Integer.toHexString(EGL14.eglGetError()));
+      throwEglException(EGL14.eglGetError(), "Unable to initialize EGL14");
     }
     return eglDisplay;
   }
@@ -306,8 +300,7 @@ class EglBase14Impl implements EglBase14 {
     int[] numConfigs = new int[1];
     if (!EGL14.eglChooseConfig(
             eglDisplay, configAttributes, 0, configs, 0, configs.length, numConfigs, 0)) {
-      throw new GLException(EGL14.eglGetError(),
-          "eglChooseConfig failed: 0x" + Integer.toHexString(EGL14.eglGetError()));
+      throwEglException(EGL14.eglGetError(), "eglChooseConfig failed");
     }
     if (numConfigs[0] <= 0) {
       throw new RuntimeException("Unable to find any matching EGL config");
@@ -332,9 +325,12 @@ class EglBase14Impl implements EglBase14 {
       eglContext = EGL14.eglCreateContext(eglDisplay, eglConfig, rootContext, contextAttributes, 0);
     }
     if (eglContext == EGL14.EGL_NO_CONTEXT) {
-      throw new GLException(EGL14.eglGetError(),
-          "Failed to create EGL context: 0x" + Integer.toHexString(EGL14.eglGetError()));
+      throwEglException(EGL14.eglGetError(), "Failed to create EGL context");
     }
     return eglContext;
+  }
+
+  private static void throwEglException(int error, String message) {
+      throw new GLException(error, message + ": 0x" + Integer.toHexString(error));
   }
 }


### PR DESCRIPTION
### Problem
In all cases when `GLException` is thrown, `eglGetError()` is being called twice - once for the exception constructor and once for the error message. Since `eglGetError()` clears the error state after being called, the second call always returns `EGL_SUCCESS` instead of the actual error code. While debugging locally, it is still possible to retrieve the initial error code from the exception object, but it gets completely lost when the exception is reported to crash reporting tools like Crashlytics. This unintentional masking of the real error makes debugging such cases more difficult than it should be. There are several issues in [livekit-android](https://github.com/livekit/client-sdk-android) with the same problem as well.

### Solution
Extract a `throwEglException` helper method that accepts the error code as a parameter. Call `eglGetError()` only once at each call site and pass the result to `throwEglException`.