### PR TITLE
Fix EXC_BAD_ACCESS in inputNode VP property reads on Mac Catalyst background

### DIFF
--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1923,8 +1923,14 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --------------------------------------------------------------------------------------------
   // Step: Configure Voice-Processing I/O
   //
+  // Use cached state to avoid accessing inputNode() when voice processing is
+  // disabled – AVAudioInputNode can crash (EXC_BAD_ACCESS) when the audio
+  // hardware is unavailable, e.g. Mac Catalyst in background.
+  // After engine recreate, a fresh AVAudioEngine defaults VP to disabled.
+  bool effective_prev_vp =
+      state.IsEngineRecreateRequired() ? false : state.prev.voice_processing_enabled;
   if (state.next.IsInputEnabled() &&
-      inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
+      effective_prev_vp != state.next.voice_processing_enabled) {
 #if TARGET_OS_SIMULATOR
     LOGI() << "setVoiceProcessingEnabled (input): "
            << (state.next.voice_processing_enabled ? "YES" : "NO") << " (Ignored on Simulator)";
@@ -1941,7 +1947,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     LOGI() << "setVoiceProcessingEnabled (input) result: " << set_vp_result ? "YES" : "NO";
 #endif
 
-    if (inputNode().voiceProcessingEnabled) {
+    if (state.next.voice_processing_enabled) {
       // Always unmute vp if restart mute mode.
       if (state.next.mute_mode == MuteMode::RestartEngine &&
           inputNode().voiceProcessingInputMuted) {
@@ -2293,7 +2299,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     RTC_DCHECK(!engine_device_.running);
 
     // If disabling input, always unmute the voice-processing input mute.
-    if (inputNode().voiceProcessingEnabled && inputNode().voiceProcessingInputMuted) {
+    if (state.prev.voice_processing_enabled && inputNode().voiceProcessingInputMuted) {
       LOGI() << "Update mute (voice processing) unmuting vp for stop-recording";
       inputNode().voiceProcessingInputMuted = false;
     }
@@ -2353,7 +2359,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // Step: Run-time mute toggling if vp mode.
   //
   if (state.next.mute_mode == MuteMode::VoiceProcessing && state.next.IsInputEnabled() &&
-      inputNode().voiceProcessingEnabled &&
+      state.next.voice_processing_enabled &&
       inputNode().voiceProcessingInputMuted != state.next.input_muted) {
     LOGI() << "Update mute (voice processing) runtime update: " << state.next.input_muted;
     inputNode().voiceProcessingInputMuted = state.next.input_muted;
@@ -2376,7 +2382,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // Step: Configure other audio ducking
   //
 #if !TARGET_OS_TV
-  if (state.next.IsInputEnabled() && inputNode().voiceProcessingEnabled &&
+  if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
       (!state.prev.IsInputEnabled() ||
        (state.prev.advanced_ducking != state.next.advanced_ducking ||
         state.prev.ducking_level != state.next.ducking_level))) {
@@ -2396,7 +2402,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --------------------------------------------------------------------------------------------
   // Step: Bypass voice processing
   //
-  if (state.next.IsInputEnabled() && inputNode().voiceProcessingEnabled &&
+  if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
       inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
     LOGI() << "setting voiceProcessingBypassed: " << state.next.voice_processing_bypassed;
     inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
@@ -2405,7 +2411,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --------------------------------------------------------------------------------------------
   // Step: Configure AGC
   //
-  if (state.next.IsInputEnabled() && inputNode().voiceProcessingEnabled &&
+  if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
       inputNode().voiceProcessingAGCEnabled != state.next.voice_processing_agc_enabled) {
     LOGI() << "setting voiceProcessingAGCEnabled: " << state.next.voice_processing_agc_enabled;
     inputNode().voiceProcessingAGCEnabled = state.next.voice_processing_agc_enabled;


### PR DESCRIPTION
## Summary

Accessing `AVAudioInputNode` voice processing properties (`voiceProcessingEnabled`, etc.) can crash with `EXC_BAD_ACCESS` when the audio hardware is unavailable — primarily when a Mac Catalyst app is in the background.

This PR replaces hardware reads of `inputNode().voiceProcessingEnabled` with cached `EngineState` values in guard conditions throughout `ApplyDeviceEngineState`. When voice processing is disabled, `inputNode` VP properties are never accessed. When VP is enabled, the audio hardware must be active, so the remaining sub-property reads (bypass, AGC, mute, ducking) are safe and preserved for self-healing behavior.

**This is a speculative and untested fix**. It looks good to me, but I'm not terribly familiar with this code, nor do I have a good way to test this locally. Feel free to close if this isn't the direction you'd want to take.

## Crash Details

If helpful, a breakdown of crashes in my app that have hit the issue we're drying to address here:

- **91% of crashes occur in background**, 75% specifically on Mac Catalyst
- Affects apps that call `setVoiceProcessingEnabled(false)`
- `AVAudioInputNode` property access triggers hardware query that crashes when hardware is unavailable
- Sentry: ~300+ crash events across multiple app versions

## Changes

- Use `state.prev.voice_processing_enabled` / `state.next.voice_processing_enabled` (cached) instead of `inputNode().voiceProcessingEnabled` (hardware) in 7 guard conditions
- For the "Configure VP" step, compute `effective_prev_vp` accounting for engine recreate (fresh `AVAudioEngine` defaults VP to disabled)
- VP sub-property reads (`voiceProcessingInputMuted`, `voiceProcessingBypassed`, `voiceProcessingAGCEnabled`) are intentionally kept as hardware reads — they're only reached when VP is enabled (hardware active) and provide self-healing if hardware state drifts

## Ref

- https://github.com/livekit/client-sdk-swift/issues/910
