### PR TITLE
Audio engine stability improvements

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -17,7 +17,6 @@
 #ifndef SDK_OBJC_NATIVE_SRC_AUDIO_AUDIO_DEVICE_AUDIOENGINE_H_
 #define SDK_OBJC_NATIVE_SRC_AUDIO_AUDIO_DEVICE_AUDIOENGINE_H_
 
-#include <atomic>
 #include <memory>
 
 #include "api/scoped_refptr.h"
@@ -178,7 +177,8 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     // AUDIO STATE LOGIC
     //
     // Device Mode:
-    // - Output follows input only when voice_processing_enabled=true (for AEC)
+    // - On macOS, output follows input to keep AVAudioEngine IO active for capture.
+    // - On other platforms, output follows input only when voice_processing_enabled=true (for AEC)
     // - Input respects mute mode restrictions (RestartEngine + input_muted)
     // - Independent operation when voice processing is disabled
     //
@@ -195,7 +195,13 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
       switch (render_mode) {
         case RenderMode::Device:
+#if TARGET_OS_OSX
+          // Keep an active output graph while input is enabled; otherwise, capture callbacks can
+          // stall after VP reconfiguration on macOS.
+          return IsInputEnabled() || output_enabled;
+#else
           return voice_processing_enabled ? (IsInputEnabled() || output_enabled) : output_enabled;
+#endif
         case RenderMode::Manual:
           return output_enabled || input_enabled || input_enabled_persistent_mode;
       }
@@ -206,7 +212,11 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
       switch (render_mode) {
         case RenderMode::Device:
+#if TARGET_OS_OSX
+          return IsInputRunning() || output_running;
+#else
           return voice_processing_enabled ? (IsInputRunning() || output_running) : output_running;
+#endif
         case RenderMode::Manual:
           return output_running || input_running;
       }
@@ -429,11 +439,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
     bool DidUpdateMuteMode() const { return prev.mute_mode != next.mute_mode; }
 
-    bool IsEngineRestartRequired() const {
-      return DidUpdateAudioGraph() ||
-             // Voice processing enable state updates
-             DidUpdateVoiceProcessingEnabled();
-    }
+    bool IsEngineRestartRequired() const { return DidUpdateAudioGraph(); }
 
     bool IsEngineRecreateRequired() const {
       // Device id specified
@@ -448,7 +454,11 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
       bool special_case = (prev.IsOutputEnabled() && next.IsOutputEnabled()) &&
                           (prev.IsInputEnabled() && !next.IsInputEnabled());
 
-      return device || default_device || special_case;
+      // Toggling voice processing requires a full engine recreate to ensure
+      // a clean audio hardware state.
+      bool voice_processing = DidUpdateVoiceProcessingEnabled();
+
+      return device || default_device || special_case || voice_processing;
     }
 
     bool DidEnableManualRenderingMode() const {

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -177,10 +177,8 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     // AUDIO STATE LOGIC
     //
     // Device Mode:
-    // - On macOS, output follows input to keep AVAudioEngine IO active for capture.
-    // - On other platforms, output follows input only when voice_processing_enabled=true (for AEC)
+    // - Output follows input to keep AVAudioEngine IO active for capture.
     // - Input respects mute mode restrictions (RestartEngine + input_muted)
-    // - Independent operation when voice processing is disabled
     //
     // Manual Mode:
     // - Bidirectional coupling: if ANY component is enabled/running, BOTH are considered
@@ -195,13 +193,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
       switch (render_mode) {
         case RenderMode::Device:
-#if TARGET_OS_OSX
-          // Keep an active output graph while input is enabled; otherwise, capture callbacks can
-          // stall after VP reconfiguration on macOS.
           return IsInputEnabled() || output_enabled;
-#else
-          return voice_processing_enabled ? (IsInputEnabled() || output_enabled) : output_enabled;
-#endif
         case RenderMode::Manual:
           return output_enabled || input_enabled || input_enabled_persistent_mode;
       }
@@ -212,11 +204,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
       switch (render_mode) {
         case RenderMode::Device:
-#if TARGET_OS_OSX
           return IsInputRunning() || output_running;
-#else
-          return voice_processing_enabled ? (IsInputRunning() || output_running) : output_running;
-#endif
         case RenderMode::Manual:
           return output_running || input_running;
       }

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1791,24 +1791,25 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       (!state.next.IsAnyRunning() || state.IsEngineRestartRequired() ||
        state.DidBeginInterruption() || state.IsEngineRecreateRequired())) {
     LOGI() << "Stopping AVAudioEngine...";
-    RTC_DCHECK(engine_device_ != nil);
 
     if (configuration_observer_ != nullptr) {
       NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
       [center removeObserver:(__bridge_transfer id)configuration_observer_
                         name:AVAudioEngineConfigurationChangeNotification
-                      object:engine_device_];
+                      object:nil];
       configuration_observer_ = nil;
     }
 
-    [engine_device_ stop];
+    if (engine_device_ != nil) {
+      [engine_device_ stop];
 
-    if (observer_ != nullptr) {
-      int32_t result = observer_->OnEngineDidStop(engine_device_, state.next.IsOutputEnabled(),
-                                                  state.next.IsInputEnabled());
-      if (result != 0) {
-        LOGE() << "Call to OnEngineDidStop returned error: " << result;
-        return rollback(result);
+      if (observer_ != nullptr) {
+        int32_t result = observer_->OnEngineDidStop(engine_device_, state.next.IsOutputEnabled(),
+                                                    state.next.IsInputEnabled());
+        if (result != 0) {
+          LOGE() << "Call to OnEngineDidStop returned error: " << result;
+          return rollback(result);
+        }
       }
     }
   }
@@ -1816,7 +1817,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --------------------------------------------------------------------------------------------
   // Step: Stop playout buffer
   //
-  if (!state.next.IsOutputEnabled() && audio_device_buffer_->IsPlaying()) {
+  if ((!state.next.IsOutputEnabled() || state.IsEngineRecreateRequired()) &&
+      audio_device_buffer_->IsPlaying()) {
     LOGI() << "Stopping Playout buffer...";
     if (engine_device_ != nullptr) {
       // Rendering must be stopped first.
@@ -1828,7 +1830,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --------------------------------------------------------------------------------------------
   // Step: Stop recording buffer
   //
-  if (!state.next.IsInputEnabled() && audio_device_buffer_->IsRecording()) {
+  if ((!state.next.IsInputEnabled() || state.IsEngineRecreateRequired()) &&
+      audio_device_buffer_->IsRecording()) {
     LOGI() << "Stopping Record buffer...";
     if (engine_device_ != nullptr) {
       // Rendering must be stopped first.
@@ -1842,13 +1845,28 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   //
   if (state.IsEngineRecreateRequired()) {
     LOGI() << "Recreate required, releasing AVAudioEngine...";
-    if (observer_ != nullptr) {
+    if (observer_ != nullptr && engine_device_ != nil) {
       int32_t result = observer_->OnEngineWillRelease(engine_device_);
       if (result != 0) {
         LOGE() << "Call to OnEngineWillRelease returned error: " << result;
         return rollback(result);
       }
     }
+
+#if TARGET_OS_OSX
+    if (state.DidUpdateVoiceProcessingEnabled() && engine_device_ != nil) {
+      AVAudioInputNode* input_node = engine_device_.inputNode;
+      AVAudioOutputNode* output_node = engine_device_.outputNode;
+
+      if (input_node != nil && input_node.audioUnit != nullptr) {
+        AudioOutputUnitStop(input_node.audioUnit);
+      }
+      if (output_node != nil && output_node.audioUnit != nullptr) {
+        AudioOutputUnitStop(output_node.audioUnit);
+      }
+    }
+#endif
+
     engine_device_ = nil;
   }
 
@@ -2418,19 +2436,26 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   if (state.next.IsAnyEnabled() &&
       (!state.prev.IsAnyEnabled() || state.IsEngineRecreateRequired())) {
     if (state.next.IsInputEnabled()) {
-      uint32_t input_device_id = state.next.input_device_id;
-      if (input_device_id == kAudioObjectUnknown) {
+      uint32_t requested_input_device_id = state.next.input_device_id;
+
+      AudioUnit input_unit = inputNode().audioUnit;
+
+      if (requested_input_device_id == kAudioObjectUnknown) {
+        // For default routing, avoid forcing kAudioOutputUnitProperty_CurrentDevice. On macOS this
+        // can fail during VoiceProcessingIO reconfiguration and the engine already follows the
+        // system default route.
         LOGI() << "Using default input device";
       } else {
-        auto input_device_name = mac_audio_utils::GetDeviceName(input_device_id);
+        auto input_device_name = mac_audio_utils::GetDeviceName(requested_input_device_id);
         LOGI() << "Setting input device: " << input_device_name.value_or("Unknown") << " ("
-               << input_device_id << ")";
-        AudioUnit inputUnit = inputNode().audioUnit;
-        OSStatus err = AudioUnitSetProperty(inputUnit, kAudioOutputUnitProperty_CurrentDevice,
-                                            kAudioUnitScope_Global, 1, &input_device_id,
-                                            sizeof(input_device_id));
-        if (err != noErr) {
-          LOGE() << "Failed to set input device: " << input_device_id << ", error: " << err;
+               << requested_input_device_id << ")";
+
+        OSStatus set_input_err = AudioUnitSetProperty(
+            input_unit, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 1,
+            &requested_input_device_id, sizeof(requested_input_device_id));
+        if (set_input_err != noErr) {
+          LOGE() << "Failed to set input device: requested=" << requested_input_device_id
+                 << ", error: " << set_input_err;
           return rollback(kAudioEngineRecordingDeviceNotAvailableError);
         }
       }

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1817,27 +1817,25 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
          << " defInDevChanged=" << state.DidUpdateDefaultInputDevice()
          << " defOutDevChanged=" << state.DidUpdateDefaultOutputDevice();
 
-  // Log actual hardware state if engine exists
+  // Log actual hardware state if engine exists.
   if (engine_device_ != nil) {
     LOGI() << " [HW] engine: running=" << engine_device_.running
            << " attachedNodes=" << engine_device_.attachedNodes.count;
-    if (state.prev.IsInputEnabled() || state.next.IsInputEnabled()) {
-      @try {
-        AVAudioInputNode* inode = engine_device_.inputNode;
-        LOGI() << " [HW] inputNode: vpEnabled=" << inode.voiceProcessingEnabled
-               << " vpMuted=" << inode.voiceProcessingInputMuted
-               << " vpBypassed=" << inode.voiceProcessingBypassed
-               << " vpAGC=" << inode.voiceProcessingAGCEnabled;
-      } @catch (NSException*) {
-        LOGI() << " [HW] inputNode: <unavailable>";
-      }
-    }
     if (input_mixer_node_ != nil) {
       LOGI() << " [HW] mixerNode: volume=" << input_mixer_node_.outputVolume;
     }
   } else {
     LOGI() << " [HW] engine: nil";
   }
+
+  // Whether VP was previously configured on the current hardware's inputNode.
+  // False after engine recreate (fresh engine, VP defaults to off) or when
+  // input was not previously enabled (VP never applied to hardware).
+  // Used to derive effective previous values for all VP properties without
+  // potentially unsafe hardware reads.
+  const bool vp_was_configured = !state.IsEngineRecreateRequired() &&
+                                  state.prev.IsInputEnabled() &&
+                                  state.prev.voice_processing_enabled;
 
   std::vector<std::function<void()>> rollback_actions;
 
@@ -1925,15 +1923,13 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   //
   if (state.IsEngineRecreateRequired()) {
     LOGI() << "Recreate required, releasing AVAudioEngine...";
-    if (observer_ != nullptr && engine_device_ != nil) {
-      int32_t result = observer_->OnEngineWillRelease(engine_device_);
-      if (result != 0) {
-        LOGE() << "Call to OnEngineWillRelease returned error: " << result;
-        return rollback(result);
-      }
-    }
 
-    if (state.DidUpdateVoiceProcessingEnabled() && engine_device_ != nil) {
+    if ((state.prev.voice_processing_enabled || state.next.voice_processing_enabled) &&
+        engine_device_ != nil) {
+      // Stop AudioUnits explicitly before releasing the engine whenever VP is
+      // or was active. VPIO creates an aggregate device and IO thread that may
+      // not be fully torn down by -[AVAudioEngine stop] alone, leading to
+      // "Timeout waiting for streams" / IO-thread collisions on the new engine.
       AVAudioInputNode* input_node = engine_device_.inputNode;
       AVAudioOutputNode* output_node = engine_device_.outputNode;
 
@@ -1942,6 +1938,14 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       }
       if (output_node != nil && output_node.audioUnit != nullptr) {
         AudioOutputUnitStop(output_node.audioUnit);
+      }
+    }
+
+    if (observer_ != nullptr && engine_device_ != nil) {
+      int32_t result = observer_->OnEngineWillRelease(engine_device_);
+      if (result != 0) {
+        LOGE() << "Call to OnEngineWillRelease returned error: " << result;
+        return rollback(result);
       }
     }
 
@@ -2020,7 +2024,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // Step: Configure Voice-Processing I/O
   //
   if (state.next.IsInputEnabled() &&
-      inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
+      vp_was_configured != state.next.voice_processing_enabled) {
 #if TARGET_OS_SIMULATOR
     LOGI() << "setVoiceProcessingEnabled (input): "
            << (state.next.voice_processing_enabled ? "YES" : "NO") << " (Ignored on Simulator)";
@@ -2037,11 +2041,11 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     LOGI() << "setVoiceProcessingEnabled (input) result: " << set_vp_result ? "YES" : "NO";
 #endif
 
-    if (inputNode().voiceProcessingEnabled) {
-      // Always unmute vp if restart mute mode.
-      if (state.next.mute_mode == MuteMode::RestartEngine &&
-          inputNode().voiceProcessingInputMuted) {
-        LOGI() << "Update mute (voice processing) unmuting vp for restart engine mode";
+    if (state.next.voice_processing_enabled) {
+      // After VP (re)enable, ensure mute starts clean for restart-engine mode.
+      // VP mute defaults to false on fresh enable; set unconditionally to avoid
+      // a potentially unsafe hardware read.
+      if (state.next.mute_mode == MuteMode::RestartEngine) {
         inputNode().voiceProcessingInputMuted = false;
       }
 
@@ -2389,7 +2393,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     RTC_DCHECK(!engine_device_.running);
 
     // If disabling input, always unmute the voice-processing input mute.
-    if (state.prev.voice_processing_enabled && inputNode().voiceProcessingInputMuted) {
+    // Set unconditionally to avoid a potentially unsafe VP property read.
+    if (state.prev.voice_processing_enabled) {
       LOGI() << "Update mute (voice processing) unmuting vp for stop-recording";
       inputNode().voiceProcessingInputMuted = false;
     }
@@ -2452,7 +2457,9 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   if (state.next.IsInputEnabled() && state.next.voice_processing_enabled) {
     bool should_vp_mute =
         (state.next.mute_mode == MuteMode::VoiceProcessing) && state.next.input_muted;
-    if (inputNode().voiceProcessingInputMuted != should_vp_mute) {
+    bool prev_vp_mute = vp_was_configured &&
+        (state.prev.mute_mode == MuteMode::VoiceProcessing) && state.prev.input_muted;
+    if (should_vp_mute != prev_vp_mute) {
       LOGI() << "Update mute (voice processing): " << should_vp_mute;
       inputNode().voiceProcessingInputMuted = should_vp_mute;
     }
@@ -2476,9 +2483,9 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   //
 #if !TARGET_OS_TV
   if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
-      (!state.prev.IsInputEnabled() ||
-       (state.prev.advanced_ducking != state.next.advanced_ducking ||
-        state.prev.ducking_level != state.next.ducking_level))) {
+      (!vp_was_configured ||
+       state.prev.advanced_ducking != state.next.advanced_ducking ||
+       state.prev.ducking_level != state.next.ducking_level)) {
     // Other audio ducking.
     // iOS 17.0+, iPadOS 17.0+, Mac Catalyst 17.0+, macOS 14.0+, visionOS 1.0+
     if (@available(iOS 17.0, macCatalyst 17.0, macOS 14.0, visionOS 1.0, *)) {
@@ -2496,7 +2503,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // Step: Bypass voice processing
   //
   if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
-      inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
+      (!vp_was_configured ||
+       state.prev.voice_processing_bypassed != state.next.voice_processing_bypassed)) {
     LOGI() << "setting voiceProcessingBypassed: " << state.next.voice_processing_bypassed;
     inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
   }
@@ -2505,7 +2513,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // Step: Configure AGC
   //
   if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
-      inputNode().voiceProcessingAGCEnabled != state.next.voice_processing_agc_enabled) {
+      (!vp_was_configured ||
+       state.prev.voice_processing_agc_enabled != state.next.voice_processing_agc_enabled)) {
     LOGI() << "setting voiceProcessingAGCEnabled: " << state.next.voice_processing_agc_enabled;
     inputNode().voiceProcessingAGCEnabled = state.next.voice_processing_agc_enabled;
   }
@@ -2519,8 +2528,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     if (state.next.IsInputEnabled()) {
       uint32_t requested_input_device_id = state.next.input_device_id;
 
-      AudioUnit input_unit = inputNode().audioUnit;
-
       if (requested_input_device_id == kAudioObjectUnknown) {
         // For default routing, avoid forcing kAudioOutputUnitProperty_CurrentDevice. On macOS this
         // can fail during VoiceProcessingIO reconfiguration and the engine already follows the
@@ -2531,6 +2538,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
         LOGI() << "Setting input device: " << input_device_name.value_or("Unknown") << " ("
                << requested_input_device_id << ")";
 
+        AudioUnit input_unit = inputNode().audioUnit;
         OSStatus set_input_err = AudioUnitSetProperty(
             input_unit, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 1,
             &requested_input_device_id, sizeof(requested_input_device_id));
@@ -2715,6 +2723,20 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   if (state.prev.IsAnyEnabled() && !state.next.IsAnyEnabled()) {
     RTC_DCHECK(engine_device_ != nullptr);
 
+    if (state.prev.voice_processing_enabled) {
+      // Stop AudioUnits explicitly when VP was active. Same rationale as the
+      // recreate path: VPIO aggregate device / IO thread cleanup.
+      AVAudioInputNode* input_node = engine_device_.inputNode;
+      AVAudioOutputNode* output_node = engine_device_.outputNode;
+
+      if (input_node != nil && input_node.audioUnit != nullptr) {
+        AudioOutputUnitStop(input_node.audioUnit);
+      }
+      if (output_node != nil && output_node.audioUnit != nullptr) {
+        AudioOutputUnitStop(output_node.audioUnit);
+      }
+    }
+
     if (observer_ != nullptr) {
       int32_t result = observer_->OnEngineWillRelease(engine_device_);
       if (result != 0) {
@@ -2730,17 +2752,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --- Diagnostic: final state after apply ---
   if (engine_device_ != nil) {
     LOGI() << " [Post] engine: running=" << engine_device_.running;
-    if (state.next.IsInputEnabled()) {
-      @try {
-        AVAudioInputNode* inode = engine_device_.inputNode;
-        LOGI() << " [Post] inputNode: vpEnabled=" << inode.voiceProcessingEnabled
-               << " vpMuted=" << inode.voiceProcessingInputMuted
-               << " vpBypassed=" << inode.voiceProcessingBypassed
-               << " vpAGC=" << inode.voiceProcessingAGCEnabled;
-      } @catch (NSException*) {
-        LOGI() << " [Post] inputNode: <unavailable>";
-      }
-    }
     if (input_mixer_node_ != nil) {
       LOGI() << " [Post] mixerNode: volume=" << input_mixer_node_.outputVolume;
     }

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1923,14 +1923,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --------------------------------------------------------------------------------------------
   // Step: Configure Voice-Processing I/O
   //
-  // Use cached state to avoid accessing inputNode() when voice processing is
-  // disabled – AVAudioInputNode can crash (EXC_BAD_ACCESS) when the audio
-  // hardware is unavailable, e.g. Mac Catalyst in background.
-  // After engine recreate, a fresh AVAudioEngine defaults VP to disabled.
-  bool effective_prev_vp =
-      state.IsEngineRecreateRequired() ? false : state.prev.voice_processing_enabled;
   if (state.next.IsInputEnabled() &&
-      effective_prev_vp != state.next.voice_processing_enabled) {
+      inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
 #if TARGET_OS_SIMULATOR
     LOGI() << "setVoiceProcessingEnabled (input): "
            << (state.next.voice_processing_enabled ? "YES" : "NO") << " (Ignored on Simulator)";
@@ -1947,7 +1941,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     LOGI() << "setVoiceProcessingEnabled (input) result: " << set_vp_result ? "YES" : "NO";
 #endif
 
-    if (state.next.voice_processing_enabled) {
+    if (inputNode().voiceProcessingEnabled) {
       // Always unmute vp if restart mute mode.
       if (state.next.mute_mode == MuteMode::RestartEngine &&
           inputNode().voiceProcessingInputMuted) {
@@ -2299,7 +2293,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     RTC_DCHECK(!engine_device_.running);
 
     // If disabling input, always unmute the voice-processing input mute.
-    if (state.prev.voice_processing_enabled && inputNode().voiceProcessingInputMuted) {
+    if (inputNode().voiceProcessingEnabled && inputNode().voiceProcessingInputMuted) {
       LOGI() << "Update mute (voice processing) unmuting vp for stop-recording";
       inputNode().voiceProcessingInputMuted = false;
     }
@@ -2359,7 +2353,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // Step: Run-time mute toggling if vp mode.
   //
   if (state.next.mute_mode == MuteMode::VoiceProcessing && state.next.IsInputEnabled() &&
-      state.next.voice_processing_enabled &&
+      inputNode().voiceProcessingEnabled &&
       inputNode().voiceProcessingInputMuted != state.next.input_muted) {
     LOGI() << "Update mute (voice processing) runtime update: " << state.next.input_muted;
     inputNode().voiceProcessingInputMuted = state.next.input_muted;
@@ -2382,7 +2376,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // Step: Configure other audio ducking
   //
 #if !TARGET_OS_TV
-  if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
+  if (state.next.IsInputEnabled() && inputNode().voiceProcessingEnabled &&
       (!state.prev.IsInputEnabled() ||
        (state.prev.advanced_ducking != state.next.advanced_ducking ||
         state.prev.ducking_level != state.next.ducking_level))) {
@@ -2402,7 +2396,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --------------------------------------------------------------------------------------------
   // Step: Bypass voice processing
   //
-  if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
+  if (state.next.IsInputEnabled() && inputNode().voiceProcessingEnabled &&
       inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
     LOGI() << "setting voiceProcessingBypassed: " << state.next.voice_processing_bypassed;
     inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
@@ -2411,7 +2405,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --------------------------------------------------------------------------------------------
   // Step: Configure AGC
   //
-  if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
+  if (state.next.IsInputEnabled() && inputNode().voiceProcessingEnabled &&
       inputNode().voiceProcessingAGCEnabled != state.next.voice_processing_agc_enabled) {
     LOGI() << "setting voiceProcessingAGCEnabled: " << state.next.voice_processing_agc_enabled;
     inputNode().voiceProcessingAGCEnabled = state.next.voice_processing_agc_enabled;

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -2309,7 +2309,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     RTC_DCHECK(!engine_device_.running);
 
     // If disabling input, always unmute the voice-processing input mute.
-    if (inputNode().voiceProcessingEnabled && inputNode().voiceProcessingInputMuted) {
+    if (state.prev.voice_processing_enabled && inputNode().voiceProcessingInputMuted) {
       LOGI() << "Update mute (voice processing) unmuting vp for stop-recording";
       inputNode().voiceProcessingInputMuted = false;
     }
@@ -2369,7 +2369,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // Step: Run-time mute toggling if vp mode.
   //
   if (state.next.mute_mode == MuteMode::VoiceProcessing && state.next.IsInputEnabled() &&
-      inputNode().voiceProcessingEnabled &&
+      state.next.voice_processing_enabled &&
       inputNode().voiceProcessingInputMuted != state.next.input_muted) {
     LOGI() << "Update mute (voice processing) runtime update: " << state.next.input_muted;
     inputNode().voiceProcessingInputMuted = state.next.input_muted;
@@ -2392,7 +2392,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // Step: Configure other audio ducking
   //
 #if !TARGET_OS_TV
-  if (state.next.IsInputEnabled() && inputNode().voiceProcessingEnabled &&
+  if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
       (!state.prev.IsInputEnabled() ||
        (state.prev.advanced_ducking != state.next.advanced_ducking ||
         state.prev.ducking_level != state.next.ducking_level))) {
@@ -2412,7 +2412,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --------------------------------------------------------------------------------------------
   // Step: Bypass voice processing
   //
-  if (state.next.IsInputEnabled() && inputNode().voiceProcessingEnabled &&
+  if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
       inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
     LOGI() << "setting voiceProcessingBypassed: " << state.next.voice_processing_bypassed;
     inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
@@ -2421,7 +2421,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --------------------------------------------------------------------------------------------
   // Step: Configure AGC
   //
-  if (state.next.IsInputEnabled() && inputNode().voiceProcessingEnabled &&
+  if (state.next.IsInputEnabled() && state.next.voice_processing_enabled &&
       inputNode().voiceProcessingAGCEnabled != state.next.voice_processing_agc_enabled) {
     LOGI() << "setting voiceProcessingAGCEnabled: " << state.next.voice_processing_agc_enabled;
     inputNode().voiceProcessingAGCEnabled = state.next.voice_processing_agc_enabled;

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1853,7 +1853,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       }
     }
 
-#if TARGET_OS_OSX
     if (state.DidUpdateVoiceProcessingEnabled() && engine_device_ != nil) {
       AVAudioInputNode* input_node = engine_device_.inputNode;
       AVAudioOutputNode* output_node = engine_device_.outputNode;
@@ -1865,7 +1864,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
         AudioOutputUnitStop(output_node.audioUnit);
       }
     }
-#endif
 
     engine_device_ = nil;
   }

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -2366,24 +2366,27 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   }
 
   // --------------------------------------------------------------------------------------------
-  // Step: Run-time mute toggling if vp mode.
+  // Step: Run-time mute toggling (voice processing).
+  // VP mute should be on ONLY when VoiceProcessing mode is active AND input is muted.
   //
-  if (state.next.mute_mode == MuteMode::VoiceProcessing && state.next.IsInputEnabled() &&
-      state.next.voice_processing_enabled &&
-      inputNode().voiceProcessingInputMuted != state.next.input_muted) {
-    LOGI() << "Update mute (voice processing) runtime update: " << state.next.input_muted;
-    inputNode().voiceProcessingInputMuted = state.next.input_muted;
+  if (state.next.IsInputEnabled() && state.next.voice_processing_enabled) {
+    bool should_vp_mute =
+        (state.next.mute_mode == MuteMode::VoiceProcessing) && state.next.input_muted;
+    if (inputNode().voiceProcessingInputMuted != should_vp_mute) {
+      LOGI() << "Update mute (voice processing): " << should_vp_mute;
+      inputNode().voiceProcessingInputMuted = should_vp_mute;
+    }
   }
 
   // --------------------------------------------------------------------------------------------
-  // Step: Run-time mute toggling if mixer mute mode.
+  // Step: Run-time mute toggling (input mixer).
+  // Mixer volume should be 0 ONLY when InputMixer mode is active AND input is muted.
   //
-  if (state.next.mute_mode == MuteMode::InputMixer && state.next.IsInputEnabled() &&
-      input_mixer_node_ != nil) {
-    // Only update if the volume has changed.
-    float mixer_volume = state.next.input_muted ? 0.0f : 1.0f;
+  if (state.next.IsInputEnabled() && input_mixer_node_ != nil) {
+    float mixer_volume =
+        (state.next.mute_mode == MuteMode::InputMixer && state.next.input_muted) ? 0.0f : 1.0f;
     if (input_mixer_node_.outputVolume != mixer_volume) {
-      LOGI() << "Update mute (input mixer) runtime update: " << state.next.input_muted;
+      LOGI() << "Update mute (input mixer): " << (mixer_volume == 0.0f);
       input_mixer_node_.outputVolume = mixer_volume;
     }
   }

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1759,6 +1759,86 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   RTC_DCHECK_RUN_ON(thread_);
   RTC_DCHECK(engine_manual_input_ == nullptr);
 
+  // --- Diagnostic: state transition summary ---
+  auto mute_mode_str = [](MuteMode m) -> const char* {
+    switch (m) {
+      case MuteMode::VoiceProcessing: return "VP";
+      case MuteMode::RestartEngine: return "Restart";
+      case MuteMode::InputMixer: return "Mixer";
+    }
+    return "?";
+  };
+
+  auto render_mode_str = [](RenderMode m) -> const char* {
+    switch (m) {
+      case RenderMode::Device: return "Device";
+      case RenderMode::Manual: return "Manual";
+    }
+    return "?";
+  };
+
+  auto log_engine_state = [&](const char* label, const EngineState& s) {
+    LOGI() << label << ": "
+           << "in=" << s.input_enabled << "/" << s.input_running
+           << " out=" << s.output_enabled << "/" << s.output_running
+           << " persistent=" << s.input_enabled_persistent_mode
+           << " muted=" << s.input_muted
+           << " vp=" << s.voice_processing_enabled
+           << " vpBypass=" << s.voice_processing_bypassed
+           << " agc=" << s.voice_processing_agc_enabled
+           << " mute_mode=" << mute_mode_str(s.mute_mode)
+           << " render=" << render_mode_str(s.render_mode)
+           << " interrupted=" << s.is_interrupted
+           << " in_avail=" << s.input_available
+           << " out_avail=" << s.output_available
+           << " inDev=" << s.input_device_id
+           << " outDev=" << s.output_device_id
+           << " defInUpd=" << s.default_input_device_update_count
+           << " defOutUpd=" << s.default_output_device_update_count
+           << " | IsInEnabled=" << s.IsInputEnabled()
+           << " IsOutEnabled=" << s.IsOutputEnabled()
+           << " IsInRunning=" << s.IsInputRunning()
+           << " IsOutRunning=" << s.IsOutputRunning();
+  };
+
+  log_engine_state(" [State] prev", state.prev);
+  log_engine_state(" [State] next", state.next);
+
+  LOGI() << " [State] decisions: "
+         << "restart=" << state.IsEngineRestartRequired()
+         << " recreate=" << state.IsEngineRecreateRequired()
+         << " graphChanged=" << state.DidUpdateAudioGraph()
+         << " vpChanged=" << state.DidUpdateVoiceProcessingEnabled()
+         << " muteChanged=" << state.DidUpdateMuteMode()
+         << " interrupted=" << state.DidBeginInterruption()
+         << " uninterrupted=" << state.DidEndInterruption()
+         << " inDevChanged=" << state.DidUpdateInputDevice()
+         << " outDevChanged=" << state.DidUpdateOutputDevice()
+         << " defInDevChanged=" << state.DidUpdateDefaultInputDevice()
+         << " defOutDevChanged=" << state.DidUpdateDefaultOutputDevice();
+
+  // Log actual hardware state if engine exists
+  if (engine_device_ != nil) {
+    LOGI() << " [HW] engine: running=" << engine_device_.running
+           << " attachedNodes=" << engine_device_.attachedNodes.count;
+    if (state.prev.IsInputEnabled() || state.next.IsInputEnabled()) {
+      @try {
+        AVAudioInputNode* inode = engine_device_.inputNode;
+        LOGI() << " [HW] inputNode: vpEnabled=" << inode.voiceProcessingEnabled
+               << " vpMuted=" << inode.voiceProcessingInputMuted
+               << " vpBypassed=" << inode.voiceProcessingBypassed
+               << " vpAGC=" << inode.voiceProcessingAGCEnabled;
+      } @catch (NSException*) {
+        LOGI() << " [HW] inputNode: <unavailable>";
+      }
+    }
+    if (input_mixer_node_ != nil) {
+      LOGI() << " [HW] mixerNode: volume=" << input_mixer_node_.outputVolume;
+    }
+  } else {
+    LOGI() << " [HW] engine: nil";
+  }
+
   std::vector<std::function<void()>> rollback_actions;
 
   auto rollback = [&](int32_t result) {
@@ -2645,6 +2725,31 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
 
     LOGI() << "Releasing AVAudioEngine...";
     engine_device_ = nil;
+  }
+
+  // --- Diagnostic: final state after apply ---
+  if (engine_device_ != nil) {
+    LOGI() << " [Post] engine: running=" << engine_device_.running;
+    if (state.next.IsInputEnabled()) {
+      @try {
+        AVAudioInputNode* inode = engine_device_.inputNode;
+        LOGI() << " [Post] inputNode: vpEnabled=" << inode.voiceProcessingEnabled
+               << " vpMuted=" << inode.voiceProcessingInputMuted
+               << " vpBypassed=" << inode.voiceProcessingBypassed
+               << " vpAGC=" << inode.voiceProcessingAGCEnabled;
+      } @catch (NSException*) {
+        LOGI() << " [Post] inputNode: <unavailable>";
+      }
+    }
+    if (input_mixer_node_ != nil) {
+      LOGI() << " [Post] mixerNode: volume=" << input_mixer_node_.outputVolume;
+    }
+    if (audio_device_buffer_ != nullptr) {
+      LOGI() << " [Post] buffer: playing=" << audio_device_buffer_->IsPlaying()
+             << " recording=" << audio_device_buffer_->IsRecording();
+    }
+  } else {
+    LOGI() << " [Post] engine: nil";
   }
 
   return 0;


### PR DESCRIPTION
- VP toggle → full engine recreate: Toggling voiceProcessingEnabled now triggers a full engine recreate instead of a restart, ensuring clean audio hardware state and preventing stalled
  capture callbacks after VP reconfiguration.
- Output follows input on all platforms: The output graph now always stays active while input is enabled, not just on macOS or when VP is on. Simplifies logic and prevents capture stalls.
- AudioOutputUnitStop before engine release: Explicitly stops input/output AudioUnits before releasing the engine during VP toggle. Ungated to all platforms.
- Hybrid VP property reads: Guard conditions use cached EngineState values (safe from EXC_BAD_ACCESS when hardware is unavailable, e.g. Mac Catalyst background). The "Configure VP" step
  retains the hardware read for self-healing. Supersedes #219 with a more targeted approach.
- Fix no audio on mute mode switch: Mute mechanisms (VP mute, mixer volume) now declaratively converge to the correct state — each mechanism is always driven to its target regardless of
  mode transitions. Fixes audio loss when switching from InputMixer to VoiceProcessing mode while muted.
- Diagnostic logging: Added detailed [State] / [HW] / [Post] logging to ApplyDeviceEngineState for debugging state transitions.