### PR TITLE
Allow using custom KDF in `frame_crypto_transformer`

### DIFF
--- a/api/crypto/frame_crypto_transformer.cc
+++ b/api/crypto/frame_crypto_transformer.cc
@@ -234,16 +234,16 @@ uint8_t get_unencrypted_bytes(webrtc::TransformableFrameInterface* frame,
   return unencrypted_bytes;
 }
 
-int DerivePBKDF2KeyFromRawKey(const std::vector<uint8_t> raw_key,
+int DerivePBKDF2KeyFromRawKey(const std::vector<uint8_t>& raw_key,
                               const std::vector<uint8_t>& salt,
                               unsigned int optional_length_bits,
-                              std::vector<uint8_t>* derived_key) {
+                              std::vector<uint8_t>& derived_key) {
   size_t key_size_bytes = optional_length_bits / 8;
-  derived_key->resize(key_size_bytes);
+  derived_key.resize(key_size_bytes);
 
   if (PKCS5_PBKDF2_HMAC((const char*)raw_key.data(), raw_key.size(),
                         salt.data(), salt.size(), 100000, EVP_sha256(),
-                        key_size_bytes, derived_key->data()) != 1) {
+                        key_size_bytes, derived_key.data()) != 1) {
     RTC_LOG(LS_ERROR) << "Failed to derive AES key from password.";
     return ErrorUnexpected;
   }
@@ -253,8 +253,8 @@ int DerivePBKDF2KeyFromRawKey(const std::vector<uint8_t> raw_key,
                    << raw_key.size() << " slat << "
                    << to_uint8_list(salt.data(), salt.size()) << " len "
                    << salt.size() << "\n derived_key "
-                   << to_uint8_list(derived_key->data(), derived_key->size())
-                   << " len " << derived_key->size();
+                   << to_uint8_list(derived_key.data(), derived_key.size())
+                   << " len " << derived_key.size();
 
   return Success;
 }
@@ -827,7 +827,7 @@ RTCErrorOr<std::vector<uint8_t>> DataPacketCryptor::Decrypt(
                         std::to_string(key_index) +
                         "] out of range for participant " + participant_id);
   }
-  
+
   std::vector<uint8_t> buffer;
   rtc::Buffer encrypted_payload(encryptedPacket->data.data(),
                                 encryptedPacket->data.size());

--- a/api/crypto/frame_crypto_transformer.h
+++ b/api/crypto/frame_crypto_transformer.h
@@ -17,6 +17,7 @@
 #ifndef WEBRTC_FRAME_CRYPTOR_TRANSFORMER_H_
 #define WEBRTC_FRAME_CRYPTOR_TRANSFORMER_H_
 
+#include <functional>
 #include <unordered_map>
 
 #include "api/frame_transformer_interface.h"
@@ -29,10 +30,10 @@
 #include "rtc_base/system/rtc_export.h"
 #include "rtc_base/thread.h"
 
-int DerivePBKDF2KeyFromRawKey(const std::vector<uint8_t> raw_key,
+int DerivePBKDF2KeyFromRawKey(const std::vector<uint8_t>& raw_key,
                               const std::vector<uint8_t>& salt,
                               unsigned int optional_length_bits,
-                              std::vector<uint8_t>* derived_key);
+                              std::vector<uint8_t>& derived_key);
 
 namespace webrtc {
 
@@ -40,6 +41,12 @@ const size_t DEFAULT_KEYRING_SIZE = 16;
 const size_t MAX_KEYRING_SIZE = 255;
 
 class ParticipantKeyHandler;
+
+typedef std::function<int(const std::vector<uint8_t>& raw_key,
+                          const std::vector<uint8_t>& salt,
+                          unsigned int optional_length_bits,
+                          std::vector<uint8_t>& derived_key)>
+    KeyDericationFunction;
 
 struct KeyProviderOptions {
   bool shared_key;
@@ -50,19 +57,22 @@ struct KeyProviderOptions {
   // key ring size should be between 1 and 255
   int key_ring_size;
   bool discard_frame_when_cryptor_not_ready;
+  KeyDericationFunction key_derivation_function;
   KeyProviderOptions()
       : shared_key(false),
         ratchet_window_size(0),
         failure_tolerance(-1),
         key_ring_size(DEFAULT_KEYRING_SIZE),
-        discard_frame_when_cryptor_not_ready(false) {}
+        discard_frame_when_cryptor_not_ready(false),
+        key_derivation_function(DerivePBKDF2KeyFromRawKey) {}
   KeyProviderOptions(KeyProviderOptions& copy)
       : shared_key(copy.shared_key),
         ratchet_salt(copy.ratchet_salt),
         uncrypted_magic_bytes(copy.uncrypted_magic_bytes),
         ratchet_window_size(copy.ratchet_window_size),
         failure_tolerance(copy.failure_tolerance),
-        key_ring_size(copy.key_ring_size) {}
+        key_ring_size(copy.key_ring_size),
+        key_derivation_function(copy.key_derivation_function) {}
 };
 
 class KeyProvider : public webrtc::RefCountInterface {
@@ -137,9 +147,9 @@ class ParticipantKeyHandler : public webrtc::RefCountInterface {
     }
     auto current_material = key_set->material;
     std::vector<uint8_t> new_material;
-    if (DerivePBKDF2KeyFromRawKey(current_material,
-                                  key_provider_->options().ratchet_salt, 256,
-                                  &new_material) != 0) {
+    if (key_provider_->options().key_derivation_function(
+            current_material, key_provider_->options().ratchet_salt, 256,
+            new_material) != 0) {
       return std::vector<uint8_t>();
     }
     SetKeyFromMaterial(new_material,
@@ -161,9 +171,9 @@ class ParticipantKeyHandler : public webrtc::RefCountInterface {
   std::vector<uint8_t> RatchetKeyMaterial(
       std::vector<uint8_t> current_material) {
     std::vector<uint8_t> new_material;
-    if (DerivePBKDF2KeyFromRawKey(current_material,
-                                  key_provider_->options().ratchet_salt, 256,
-                                  &new_material) != 0) {
+    if (key_provider_->options().key_derivation_function(
+            current_material, key_provider_->options().ratchet_salt, 256,
+            new_material) != 0) {
       return std::vector<uint8_t>();
     }
     return new_material;
@@ -173,8 +183,8 @@ class ParticipantKeyHandler : public webrtc::RefCountInterface {
                                            std::vector<uint8_t> ratchet_salt,
                                            unsigned int optional_length_bits) {
     std::vector<uint8_t> derived_key;
-    if (DerivePBKDF2KeyFromRawKey(password, ratchet_salt, optional_length_bits,
-                                  &derived_key) == 0) {
+    if (key_provider_->options().key_derivation_function(
+            password, ratchet_salt, optional_length_bits, derived_key) == 0) {
       return webrtc::make_ref_counted<KeySet>(password, derived_key);
     }
     return nullptr;


### PR DESCRIPTION
This adds a `key_derivation_function` field to `KeyProviderOptions` to allow the user to define their own KDF.

~I've managed to build webrtc-sdk, but I've not managed to build LiveKit my custom build, so I couldn't test it.~

Fixes: #220