### PR TITLE
Fix recording always prepared mode

### DIFF
--- a/modules/audio_device/audio_device_buffer.cc
+++ b/modules/audio_device/audio_device_buffer.cc
@@ -104,8 +104,7 @@ int32_t AudioDeviceBuffer::RegisterAudioCallback(
   RTC_DCHECK_RUN_ON(&main_thread_checker_);
   RTC_DLOG(LS_INFO) << __FUNCTION__;
   if (playing_ || recording_) {
-    RTC_LOG(LS_ERROR) << "Failed to set audio transport since media was active";
-    return -1;
+    RTC_LOG(LS_WARNING) << "Setting audio transport while media is active";
   }
   audio_transport_cb_ = audio_callback;
   return 0;


### PR DESCRIPTION
`AudioDeviceBuffer` constructor changed between m137/m144:

```
  - audio_device_buffer_.reset(new webrtc::AudioDeviceBuffer(task_queue_factory_.get()));
  + audio_device_buffer_.reset(new webrtc::AudioDeviceBuffer(env));
```

so that (the race window is wider) recording starts before `RegisterAudioCallback` when calling `RTC.audioDeviceModule.setRecordingAlwaysPreparedMode` (without changes on the Swift side) leading to non-recoverable failure:

```
  AudioEngineDevice::SetInitRecordingPersistentMode: 1
  ...
  AudioEngineDevice:: [Post] buffer: playing=1 recording=1  ← engine already active
  thread.cc:551: Message to worker_thread took 267ms to dispatch  ← 267ms delay!
  Room.connect...
  ...
  RegisterAudioCallback  ← too late, rejected
  Failed to set audio transport since media was active
```

### Safety
- readers do null-check of the cb
- null should produce silence `It is currently supported to start playout without a valid audio transport object.`
- no other state/ordering is protected by this check
- the transition is only ever nullptr → valid (never swapped while active)

### Alternatives

Temporarily disable recording around transport creation in Swift (both ugly and risky).