### PR TITLE
Fix AudioConverterRef "conv == NULL" causing silent mic capture

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -517,7 +517,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   // Set to true after successful call to Init(), false otherwise.
   bool initialized_ RTC_GUARDED_BY(thread_);
 
-  AudioDeviceObserver* observer_ RTC_GUARDED_BY(thread_);
+  AudioDeviceObserver* observer_ RTC_GUARDED_BY(thread_) = nullptr;
 
 #if defined(WEBRTC_IOS)
   // Audio interruption observer instance.
@@ -547,10 +547,10 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   AVAudioMixerNode* input_mixer_node_ RTC_GUARDED_BY(thread_);
 
   // Float32 -> Int16 converter.
-  AudioConverterRef converter_ref_;
+  AudioConverterRef converter_ref_ = nullptr;
   AVAudioPCMBuffer* converter_buffer_;
 
-  void* configuration_observer_ RTC_GUARDED_BY(thread_);
+  void* configuration_observer_ RTC_GUARDED_BY(thread_) = nullptr;
 };
 }  // namespace webrtc
 


### PR DESCRIPTION
## Problem

Microphone capture silently fails with `ca_debug_string: conv == NULL` logged every render cycle (~21ms). Once triggered, all calls in the APP session are affected until restart.

Reproduced on iPhone 7 / iOS 15 but can occur on any device/version since it is undefined behavior.

> **Note:** Older devices (e.g. iPhone 7, 2GB RAM) reproduce more frequently, likely because higher memory pressure leads to more heap reuse, making recycled memory blocks more likely to contain non-zero residual data.

## Root Cause

`converter_ref_` (`AudioConverterRef`, a bare C pointer) in `AudioEngineDevice` is not initialized ([`audio_engine_device.h:550`](https://github.com/webrtc-sdk/webrtc/blob/770e546/modules/audio_device/audio_engine_device.h#L550)). In C++, uninitialized scalar members hold indeterminate values.

The guard at [`audio_engine_device.mm:2304`](https://github.com/webrtc-sdk/webrtc/blob/770e546/modules/audio_device/audio_engine_device.mm#L2304) skips converter creation when `converter_ref_` is non-zero garbage:

```cpp
// converter_ref_ is uninitialized — may hold a non-zero garbage value
if (converter_ref_ == nullptr) {       // ← false when garbage is non-zero
    AudioConverterNew(...);            // ← SKIPPED, converter never created
}
```

All subsequent calls to `AudioConverterConvertComplexBuffer(converter_ref_, ...)` in the sink block use this invalid pointer, causing Core Audio to log `conv == NULL` and discard all captured mic audio.

`AudioEngineDevice` is created once per APP lifecycle, so a bad initial value persists across all calls until the APP is restarted.

## Fix

Add default member initializers to all uninitialized bare pointer members:

- `converter_ref_ = nullptr` (critical — fixes silent capture)
- `observer_ = nullptr`
- `configuration_observer_ = nullptr`
