### PR TITLE
Fix software APM on iOS/macOS

### DIFF
--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -536,17 +536,15 @@ void WebRtcVoiceEngine::Init() {
   // Set default engine options.
   {
     AudioOptions options;
-#if defined(WEBRTC_ANDROID)
     options.echo_cancellation = true;
     options.auto_gain_control = true;
-    options.noise_suppression = true;
-    options.highpass_filter = true;
-#else
-    options.echo_cancellation = false;
-    options.auto_gain_control = false;
+#if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
+    // On iOS/macOS, VPIO provides built-in NS.
     options.noise_suppression = false;
-    options.highpass_filter = false;
+#else
+    options.noise_suppression = true;
 #endif
+    options.highpass_filter = true;
     options.stereo_swapping = false;
     options.audio_jitter_buffer_max_packets = 200;
     options.audio_jitter_buffer_fast_accelerate = false;
@@ -614,10 +612,24 @@ void WebRtcVoiceEngine::ApplyOptions(const AudioOptions& options_in) {
                    << options_in.ToString();
   AudioOptions options = options_in;  // The options are modified below.
 
-  // Skip AEC AGC NS option manipulation for iOS adn macOS.
-#if !(defined(WEBRTC_IOS) || defined(WEBRTC_MAC))
+#if (defined(WEBRTC_IOS) && !TARGET_OS_SIMULATOR) || defined(WEBRTC_MAC)
+  // On iOS device / macOS, AVAudioEngine VPIO provides built-in AEC/AGC/NS.
+  // Force software APM off to prevent double processing with VPIO.
+  options.echo_cancellation = false;
+  options.auto_gain_control = false;
+  options.noise_suppression = false;
+  options.highpass_filter = false;
+  RTC_LOG(LS_INFO) << "Disabling software APM on Apple. Using VPIO instead.";
+#else
+
+#if defined(WEBRTC_IOS) && TARGET_OS_SIMULATOR
+  // On iOS Simulator, VPIO is not reliably available.
+  // Allow software AEC/AGC/NS to be controlled by SDK options.
+  RTC_LOG(LS_INFO) << "iOS Simulator: allowing software APM options.";
+#endif
 
 #if defined(WEBRTC_ANDROID)
+  use_mobile_software_aec = true;
   // Turn off the gain control if specified by the field trial.
   // The purpose of the field trial is to reduce the amount of resampling
   // performed inside the audio processing module on mobile platforms by

--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -612,7 +612,8 @@ void WebRtcVoiceEngine::ApplyOptions(const AudioOptions& options_in) {
                    << options_in.ToString();
   AudioOptions options = options_in;  // The options are modified below.
 
-#if (defined(WEBRTC_IOS) && !TARGET_OS_SIMULATOR) || defined(WEBRTC_MAC)
+#if (defined(WEBRTC_IOS) && !TARGET_OS_SIMULATOR) || \
+    (defined(WEBRTC_MAC) && !defined(WEBRTC_IOS))
   // On iOS device / macOS, AVAudioEngine VPIO provides built-in AEC/AGC/NS.
   // Force software APM off to prevent double processing with VPIO.
   options.echo_cancellation = false;
@@ -629,7 +630,6 @@ void WebRtcVoiceEngine::ApplyOptions(const AudioOptions& options_in) {
 #endif
 
 #if defined(WEBRTC_ANDROID)
-  use_mobile_software_aec = true;
   // Turn off the gain control if specified by the field trial.
   // The purpose of the field trial is to reduce the amount of resampling
   // performed inside the audio processing module on mobile platforms by

--- a/media/engine/webrtc_voice_engine.cc
+++ b/media/engine/webrtc_voice_engine.cc
@@ -538,12 +538,7 @@ void WebRtcVoiceEngine::Init() {
     AudioOptions options;
     options.echo_cancellation = true;
     options.auto_gain_control = true;
-#if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
-    // On iOS/macOS, VPIO provides built-in NS.
-    options.noise_suppression = false;
-#else
     options.noise_suppression = true;
-#endif
     options.highpass_filter = true;
     options.stereo_swapping = false;
     options.audio_jitter_buffer_max_packets = 200;
@@ -612,23 +607,6 @@ void WebRtcVoiceEngine::ApplyOptions(const AudioOptions& options_in) {
                    << options_in.ToString();
   AudioOptions options = options_in;  // The options are modified below.
 
-#if (defined(WEBRTC_IOS) && !TARGET_OS_SIMULATOR) || \
-    (defined(WEBRTC_MAC) && !defined(WEBRTC_IOS))
-  // On iOS device / macOS, AVAudioEngine VPIO provides built-in AEC/AGC/NS.
-  // Force software APM off to prevent double processing with VPIO.
-  options.echo_cancellation = false;
-  options.auto_gain_control = false;
-  options.noise_suppression = false;
-  options.highpass_filter = false;
-  RTC_LOG(LS_INFO) << "Disabling software APM on Apple. Using VPIO instead.";
-#else
-
-#if defined(WEBRTC_IOS) && TARGET_OS_SIMULATOR
-  // On iOS Simulator, VPIO is not reliably available.
-  // Allow software AEC/AGC/NS to be controlled by SDK options.
-  RTC_LOG(LS_INFO) << "iOS Simulator: allowing software APM options.";
-#endif
-
 #if defined(WEBRTC_ANDROID)
   // Turn off the gain control if specified by the field trial.
   // The purpose of the field trial is to reduce the amount of resampling
@@ -648,15 +626,13 @@ void WebRtcVoiceEngine::ApplyOptions(const AudioOptions& options_in) {
   }
 #endif
 
+  // Delegate to built-in AEC/AGC/NS if the ADM provides them (e.g.
+  // AVAudioEngine VPIO on iOS device / macOS). On platforms where the ADM
+  // reports no built-in processing (Android, iOS Simulator, etc.) the
+  // software APM stays enabled as requested by the SDK.
   if (options.echo_cancellation) {
-    // Check if platform supports built-in EC. Currently only supported on
-    // Android and in combination with Java based audio layer.
-    // TODO(henrika): investigate possibility to support built-in EC also
-    // in combination with Open SL ES audio.
     const bool built_in_aec = adm()->BuiltInAECIsAvailable();
     if (built_in_aec) {
-      // Built-in EC exists on this device. Enable/Disable it according to the
-      // echo_cancellation audio option.
       const bool enable_built_in_aec = *options.echo_cancellation;
       if (adm()->EnableBuiltInAEC(enable_built_in_aec) == 0 &&
           enable_built_in_aec) {
@@ -695,7 +671,6 @@ void WebRtcVoiceEngine::ApplyOptions(const AudioOptions& options_in) {
       }
     }
   }
-#endif
 
   if (options.stereo_swapping) {
     audio_state()->SetStereoChannelSwapping(*options.stereo_swapping);

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -326,12 +326,10 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   int32_t RegisterAudioCallback(AudioTransport* audioCallback) override;
 
-  // Only supported on Android.
+  // Built-in AEC/AGC/NS via VPIO. Available on device, not on simulator.
   bool BuiltInAECIsAvailable() const override;
   bool BuiltInAGCIsAvailable() const override;
   bool BuiltInNSIsAvailable() const override;
-
-  // Enables the built-in audio effects. Only supported on Android.
   int32_t EnableBuiltInAEC(bool enable) override;
   int32_t EnableBuiltInAGC(bool enable) override;
   int32_t EnableBuiltInNS(bool enable) override;

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -991,9 +991,22 @@ int32_t AudioEngineDevice::RegisterAudioCallback(AudioTransport* audioCallback) 
 // ----------------------------------------------------------------------------------------------------
 // Misc
 
-bool AudioEngineDevice::BuiltInAECIsAvailable() const { return true; }
+bool AudioEngineDevice::BuiltInAECIsAvailable() const {
+#if TARGET_OS_SIMULATOR
+  // VPIO is not reliably available on iOS Simulator.
+  return false;
+#else
+  return true;
+#endif
+}
 
-bool AudioEngineDevice::BuiltInAGCIsAvailable() const { return true; }
+bool AudioEngineDevice::BuiltInAGCIsAvailable() const {
+#if TARGET_OS_SIMULATOR
+  return false;
+#else
+  return true;
+#endif
+}
 
 bool AudioEngineDevice::BuiltInNSIsAvailable() const { return false; }
 

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -993,7 +993,6 @@ int32_t AudioEngineDevice::RegisterAudioCallback(AudioTransport* audioCallback) 
 
 bool AudioEngineDevice::BuiltInAECIsAvailable() const {
 #if TARGET_OS_SIMULATOR
-  // VPIO is not reliably available on iOS Simulator.
   return false;
 #else
   return true;
@@ -1008,13 +1007,19 @@ bool AudioEngineDevice::BuiltInAGCIsAvailable() const {
 #endif
 }
 
-bool AudioEngineDevice::BuiltInNSIsAvailable() const { return false; }
+bool AudioEngineDevice::BuiltInNSIsAvailable() const {
+#if TARGET_OS_SIMULATOR
+  return false;
+#else
+  return true;
+#endif
+}
 
 int32_t AudioEngineDevice::EnableBuiltInAEC(bool enable) { return 0; }
 
 int32_t AudioEngineDevice::EnableBuiltInAGC(bool enable) { return 0; }
 
-int32_t AudioEngineDevice::EnableBuiltInNS(bool enable) { return -1; }
+int32_t AudioEngineDevice::EnableBuiltInNS(bool enable) { return 0; }
 
 // ----------------------------------------------------------------------------------------------------
 // Misc

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1019,7 +1019,7 @@ int32_t AudioEngineDevice::EnableBuiltInAEC(bool enable) {
 #if TARGET_OS_SIMULATOR
   return -1;
 #else
-  // VPIO AEC is always-on when VP is active; can't individually disable.
+  // Succeed on enable, fail on disable so software APM stays on as fallback.
   return enable ? 0 : -1;
 #endif
 }

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1019,7 +1019,8 @@ int32_t AudioEngineDevice::EnableBuiltInAEC(bool enable) {
 #if TARGET_OS_SIMULATOR
   return -1;
 #else
-  return 0;
+  // VPIO AEC is always-on when VP is active; can't individually disable.
+  return enable ? 0 : -1;
 #endif
 }
 
@@ -1027,7 +1028,7 @@ int32_t AudioEngineDevice::EnableBuiltInAGC(bool enable) {
 #if TARGET_OS_SIMULATOR
   return -1;
 #else
-  return 0;
+  return enable ? 0 : -1;
 #endif
 }
 
@@ -1035,7 +1036,7 @@ int32_t AudioEngineDevice::EnableBuiltInNS(bool enable) {
 #if TARGET_OS_SIMULATOR
   return -1;
 #else
-  return 0;
+  return enable ? 0 : -1;
 #endif
 }
 

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1015,11 +1015,29 @@ bool AudioEngineDevice::BuiltInNSIsAvailable() const {
 #endif
 }
 
-int32_t AudioEngineDevice::EnableBuiltInAEC(bool enable) { return 0; }
+int32_t AudioEngineDevice::EnableBuiltInAEC(bool enable) {
+#if TARGET_OS_SIMULATOR
+  return -1;
+#else
+  return 0;
+#endif
+}
 
-int32_t AudioEngineDevice::EnableBuiltInAGC(bool enable) { return 0; }
+int32_t AudioEngineDevice::EnableBuiltInAGC(bool enable) {
+#if TARGET_OS_SIMULATOR
+  return -1;
+#else
+  return 0;
+#endif
+}
 
-int32_t AudioEngineDevice::EnableBuiltInNS(bool enable) { return 0; }
+int32_t AudioEngineDevice::EnableBuiltInNS(bool enable) {
+#if TARGET_OS_SIMULATOR
+  return -1;
+#else
+  return 0;
+#endif
+}
 
 // ----------------------------------------------------------------------------------------------------
 // Misc

--- a/modules/audio_device/win/audio_device_module_win.cc
+++ b/modules/audio_device/win/audio_device_module_win.cc
@@ -448,9 +448,9 @@ class WindowsAudioDeviceModule : public AudioDeviceModuleForTest {
   bool BuiltInAGCIsAvailable() const override { return false; }
   bool BuiltInNSIsAvailable() const override { return false; }
 
-  int32_t EnableBuiltInAEC(bool enable) override { return 0; }
-  int32_t EnableBuiltInAGC(bool enable) override { return 0; }
-  int32_t EnableBuiltInNS(bool enable) override { return 0; }
+  int32_t EnableBuiltInAEC(bool enable) override { return -1; }
+  int32_t EnableBuiltInAGC(bool enable) override { return -1; }
+  int32_t EnableBuiltInNS(bool enable) override { return -1; }
 
   int32_t AttachAudioBuffer() {
     RTC_DLOG(LS_INFO) << __FUNCTION__;

--- a/sdk/objc/native/src/objc_audio_device.mm
+++ b/sdk/objc/native/src/objc_audio_device.mm
@@ -731,7 +731,7 @@ bool ObjCAudioDeviceModule::BuiltInAECIsAvailable() const {
 }
 
 int32_t ObjCAudioDeviceModule::EnableBuiltInAEC(bool enable) {
-  return 0;
+  return -1;
 }
 
 bool ObjCAudioDeviceModule::BuiltInAGCIsAvailable() const {
@@ -739,7 +739,7 @@ bool ObjCAudioDeviceModule::BuiltInAGCIsAvailable() const {
 }
 
 int32_t ObjCAudioDeviceModule::EnableBuiltInAGC(bool enable) {
-  return 0;
+  return -1;
 }
 
 bool ObjCAudioDeviceModule::BuiltInNSIsAvailable() const {
@@ -747,7 +747,7 @@ bool ObjCAudioDeviceModule::BuiltInNSIsAvailable() const {
 }
 
 int32_t ObjCAudioDeviceModule::EnableBuiltInNS(bool enable) {
-  return 0;
+  return -1;
 }
 
 int32_t ObjCAudioDeviceModule::GetPlayoutUnderrunCount() const {


### PR DESCRIPTION
## Summary
- Removes Apple-specific `#if` guards in `webrtc_voice_engine.cc` that hard-disabled software APM on iOS/macOS. The voice engine now uses the standard `BuiltInAEC*` ADM delegation path on all platforms.
- `AudioEngineDevice` reports `BuiltInAEC/AGC/NS` availability based on whether VPIO can actually run (false on Simulator, true on device), and returns `0` from `EnableBuiltIn*` only when it can honor the request — so webrtc disables software APM iff VPIO will run.
- Aligns `WindowsAudioDeviceModule` and `ObjCAudioDeviceModule` with the same invariant: `Enable*` returns `-1` when `BuiltIn*IsAvailable` is `false`. Dead code today, but truthful and safe against future refactors.

## Behavior
| Platform | Before | After |
|---|---|---|
| Android | software APM via ADM delegation | **unchanged** |
| iOS/macOS device, VPIO on | hardware VPIO only (via #if skip) | hardware VPIO only (via ADM delegation) |
| iOS Simulator | no AEC | software APM |
| iOS/macOS, `setVoiceProcessingEnabled(false)` | no AEC | no AEC (intentional) |

No code path can run software APM and VPIO simultaneously.