### PR TITLE
Fix iOS OOM in DcSctpTransport from receive_buffer COW capacity bloat

### DIFF
--- a/media/sctp/dcsctp_transport.cc
+++ b/media/sctp/dcsctp_transport.cc
@@ -522,14 +522,16 @@ void DcSctpTransport::OnMessageReceived(dcsctp::DcSctpMessage message) {
                         << " on an SCTP packet. Dropping.";
     return;
   }
-  receive_buffer_.Clear();
-  if (!IsEmptyPPID(message.ppid()))
-    receive_buffer_.AppendData(message.payload().data(),
-                               message.payload().size());
+
+  CopyOnWriteBuffer payload =
+      IsEmptyPPID(message.ppid())
+          ? CopyOnWriteBuffer()
+          : CopyOnWriteBuffer(message.payload().data(),
+                              message.payload().size());
 
   if (data_channel_sink_) {
     data_channel_sink_->OnDataReceived(message.stream_id().value(), *type,
-                                       receive_buffer_);
+                                       payload);
   }
 }
 

--- a/media/sctp/dcsctp_transport.h
+++ b/media/sctp/dcsctp_transport.h
@@ -123,7 +123,6 @@ class DcSctpTransport : public SctpTransportInternal,
   dcsctp::TaskQueueTimeoutFactory task_queue_timeout_factory_;
   std::unique_ptr<dcsctp::DcSctpSocketInterface> socket_;
   std::string debug_name_ = "DcSctpTransport";
-  CopyOnWriteBuffer receive_buffer_;
 
   // Used to keep track of the state of data channels.
   // Reset needs to happen both ways before signaling the transport

--- a/media/sctp/dcsctp_transport_unittest.cc
+++ b/media/sctp/dcsctp_transport_unittest.cc
@@ -10,9 +10,11 @@
 
 #include "media/sctp/dcsctp_transport.h"
 
+#include <cstddef>
 #include <memory>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "api/environment/environment.h"
 #include "api/environment/environment_factory.h"
@@ -317,5 +319,52 @@ TEST(DcSctpTransportTest, DropMessageWithUnknownPpid) {
   static_cast<dcsctp::DcSctpSocketCallbacks*>(peer_a.sctp_transport_.get())
       ->OnMessageReceived(
           dcsctp::DcSctpMessage(dcsctp::StreamID(1), dcsctp::PPID(1337), {0}));
+}
+
+// Regression: a per-message receive buffer must not retain the high-water
+// capacity of a previous, larger message. If it did, every subsequent small
+// message would force a fresh full-capacity allocation whenever a downstream
+// consumer still held a reference, which on iOS (no NSRunLoop on the network
+// thread, autoreleased RTCDataBuffers retain the backing buffer) OOMs the
+// app on sustained small-message receives after a single large one.
+TEST(DcSctpTransportTest, ReceiveBufferCapacityTracksCurrentMessageSize) {
+  AutoThread main_thread;
+  Peer peer_a;
+
+  std::vector<size_t> reported_capacities;
+  EXPECT_CALL(peer_a.sink_, OnDataReceived(_, _, _))
+      .WillRepeatedly([&](int /*channel_id*/, DataMessageType /*type*/,
+                          const CopyOnWriteBuffer& buffer) {
+        reported_capacities.push_back(buffer.capacity());
+      });
+
+  peer_a.sctp_transport_->OpenStream(1, kDefaultPriority);
+  peer_a.sctp_transport_->Start({.local_port = 5000,
+                                 .remote_port = 5000,
+                                 .max_message_size = 8 * 1024 * 1024});
+
+  auto* callbacks = static_cast<dcsctp::DcSctpSocketCallbacks*>(
+      peer_a.sctp_transport_.get());
+
+  constexpr size_t kLargeMessageSize = 4 * 1024 * 1024;
+  constexpr size_t kSmallMessageSize = 32;
+  callbacks->OnMessageReceived(dcsctp::DcSctpMessage(
+      dcsctp::StreamID(1), dcsctp::PPID(53),
+      std::vector<uint8_t>(kLargeMessageSize, 0xAA)));
+  for (int i = 0; i < 5; ++i) {
+    callbacks->OnMessageReceived(dcsctp::DcSctpMessage(
+        dcsctp::StreamID(1), dcsctp::PPID(53),
+        std::vector<uint8_t>(kSmallMessageSize, 0xBB)));
+  }
+
+  ASSERT_EQ(reported_capacities.size(), 6u);
+  EXPECT_GE(reported_capacities[0], kLargeMessageSize);
+  for (size_t i = 1; i < reported_capacities.size(); ++i) {
+    EXPECT_LT(reported_capacities[i], kLargeMessageSize / 2)
+        << "small message " << i << " reported capacity "
+        << reported_capacities[i]
+        << "; expected capacity to follow current message size, not the "
+           "prior high-water mark";
+  }
 }
 }  // namespace webrtc


### PR DESCRIPTION
Found this while developing the https://github.com/music-assistant/mobile-app iOS app. It was a bit of a humdinger to track down, I don't mind saying. Once I compiled the SDK myself and had dSYMs, though, it was easy enough to spot the allocation issue. Now, it's perfect (or at least, I'm pretty sure the remaining problems are all on my end. 😅)

Anyway, here's the robot's description of the exact change: 

DcSctpTransport::OnMessageReceived reused a CopyOnWriteBuffer member via Clear() + AppendData() on each incoming SCTP message. CopyOnWriteBuffer::Clear() preserves capacity (it only resets size), so the member retained the high-water-mark capacity of the largest message ever delivered. When a downstream consumer still held a CopyOnWriteBuffer reference at the moment Clear() ran, the COW detach branch allocated a fresh buffer at that prior capacity.

On iOS the network thread is a webrtc::Thread (pthread, no NSRunLoop), so its autorelease pool only drains opportunistically. Each incoming message produces an autoreleased RTCDataBuffer (via DataChannelDelegateAdapter:: OnMessage in sdk/objc/api/peerconnection/RTCDataChannel.mm) which retains the CopyOnWriteBuffer until the pool drains. With sustained high-rate receives shortly after a single large message -- e.g. an early album-art payload followed by streaming audio over the same data channel -- multiple multi-megabyte allocations stack up and the app aborts via std::bad_alloc within sub-second of playback starting.

Replace the receive_buffer_ member with a function-local CopyOnWriteBuffer sized to the actual message. Capacity becomes a property of the current message rather than session history, no shared underlying buffer is left to detach, and the transport no longer pins the most recent payload between receives.

Add a regression test asserting that the buffer reported to the sink for a small message after a large message tracks the small message's size, not the prior high-water mark.