### PR TITLE
Fix deprecated UIScreen/NSScreen mainScreen in Metal renderer

### DIFF
--- a/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
+++ b/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
@@ -140,19 +140,20 @@
 - (CGFloat)currentScaleFactor {
   // Avoid deprecated [UIScreen mainScreen] / [NSScreen mainScreen],
   // see https://github.com/livekit/client-sdk-swift/issues/998.
-  // The traitCollection.displayScale fallback handles the case where the view
-  // is queried before being attached to a window scene; Flutter hit crashes
-  // without this guard, see https://github.com/flutter/flutter/pull/166080.
+  // Prefer the trait/window-local scale; fall back to the scene's screen.
+  // MAX(scale, 1.0) covers the not-yet-attached case where both yield 0.
+  // TODO: switch to nativeScale per Apple's Metal best practices,
+  // https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/NativeScreenScale.html
   CGFloat scale = 0.0;
 #if TARGET_OS_IPHONE
-  scale = self.window.windowScene.screen.scale;
+  scale = self.traitCollection.displayScale;
   if (scale <= 0.0) {
-    scale = self.traitCollection.displayScale;
+    scale = self.window.windowScene.screen.scale;
   }
 #elif TARGET_OS_OSX
-  scale = self.window.screen.backingScaleFactor;
+  scale = self.window.backingScaleFactor;
   if (scale <= 0.0) {
-    scale = self.window.backingScaleFactor;
+    scale = self.window.screen.backingScaleFactor;
   }
 #endif
   return MAX(scale, 1.0);

--- a/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
+++ b/sdk/objc/components/renderer/metal/RTCMTLVideoView.m
@@ -138,11 +138,22 @@
 #endif
 
 - (CGFloat)currentScaleFactor {
-  CGFloat scale = 1.0;
+  // Avoid deprecated [UIScreen mainScreen] / [NSScreen mainScreen],
+  // see https://github.com/livekit/client-sdk-swift/issues/998.
+  // The traitCollection.displayScale fallback handles the case where the view
+  // is queried before being attached to a window scene; Flutter hit crashes
+  // without this guard, see https://github.com/flutter/flutter/pull/166080.
+  CGFloat scale = 0.0;
 #if TARGET_OS_IPHONE
-  scale = [UIScreen mainScreen].scale;
+  scale = self.window.windowScene.screen.scale;
+  if (scale <= 0.0) {
+    scale = self.traitCollection.displayScale;
+  }
 #elif TARGET_OS_OSX
-  scale = [NSScreen mainScreen].backingScaleFactor;
+  scale = self.window.screen.backingScaleFactor;
+  if (scale <= 0.0) {
+    scale = self.window.backingScaleFactor;
+  }
 #endif
   return MAX(scale, 1.0);
 }


### PR DESCRIPTION
Drop `[UIScreen mainScreen] / [NSScreen mainScreen]` from `currentScaleFactor`.

Still requires some testing, especially in multiscreen scenarios.

### References

- [livekit/client-sdk-swift#998](https://github.com/livekit/client-sdk-swift/issues/998) — App Store rejection on iOS 26 citing deprecated UIKit APIs in `LiveKitWebRTC.framework`.
- [Apple Developer Forums — `UITraitCollection.displayScale` is the preferred replacement](https://developer.apple.com/forums/thread/733516) (Apple Frameworks Engineer).
- [Apple — `UITraitCollection.displayScale`](https://developer.apple.com/documentation/uikit/uitraitcollection/1623519-displayscale)
- [Apple Metal Best Practices: Native Screen Scale](https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/NativeScreenScale.html) — future TODO to switch to `nativeScale` for drawable sizing.

Prior art in other SDKs:

- [airbnb/MagazineLayout#112](https://github.com/airbnb/MagazineLayout/pull/112) — replaced `UIScreen.main` with `traitCollection.displayScale` directly.
- [jellyfin/Swiftfin#1809](https://github.com/jellyfin/Swiftfin/issues/1809) — same migration.
- [flutter/flutter#162785](https://github.com/flutter/flutter/pull/162785) — chose `view.window.windowScene.screen.scale`, [reverted in #166080](https://github.com/flutter/flutter/pull/166080) after a downstream `scale == 0` crash (informed the `MAX(scale, 1.0)` safety net here).
- [react-native-community#493](https://github.com/react-native-community/discussions-and-proposals/issues/493) — community discussion of the same migration.
