### PR TITLE
Fix H.264 h/w acceleration

### DIFF
--- a/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -359,6 +359,19 @@ NSUInteger GetMaxSampleRate(
       return 0;
   }
 }
+
+const char *H264ProfileName(const std::optional<webrtc::H264ProfileLevelId> &id) {
+  if (!id) return "<unparsed>";
+  switch (id->profile) {
+    case webrtc::H264Profile::kProfileConstrainedBaseline: return "ConstrainedBaseline";
+    case webrtc::H264Profile::kProfileBaseline: return "Baseline";
+    case webrtc::H264Profile::kProfileMain: return "Main";
+    case webrtc::H264Profile::kProfileConstrainedHigh: return "ConstrainedHigh";
+    case webrtc::H264Profile::kProfileHigh: return "High";
+    case webrtc::H264Profile::kProfilePredictiveHigh444: return "PredictiveHigh444";
+  }
+  return "<unknown>";
+}
 }  // namespace
 
 @implementation RTC_OBJC_TYPE (RTCVideoEncoderH264) {
@@ -730,11 +743,25 @@ NSUInteger GetMaxSampleRate(
     }];
   }
 
-  // Enable low-latency video encoding
+  // kVTVideoEncoderSpecification_EnableLowLatencyRateControl only supports High
+  // profiles per VTCompressionProperties.h; setting it alongside a Baseline/Main
+  // ProfileLevel disables hardware acceleration.
   if (@available(iOS 14.5, macCatalyst 14.5, macOS 11.3, tvOS 14.5, visionOS 1.0, *)) {
-    [encoder_specs addEntriesFromDictionary:@{
-      (NSString *)kVTVideoEncoderSpecification_EnableLowLatencyRateControl : @(YES),
-    }];
+    const bool isHighFamily = _profile_level_id &&
+        (_profile_level_id->profile == webrtc::H264Profile::kProfileConstrainedHigh ||
+         _profile_level_id->profile == webrtc::H264Profile::kProfileHigh ||
+         _profile_level_id->profile == webrtc::H264Profile::kProfilePredictiveHigh444);
+    const char *profileName = H264ProfileName(_profile_level_id);
+    if (isHighFamily) {
+      RTC_LOG(LS_INFO) << "H264: enabling EnableLowLatencyRateControl (profile=" << profileName
+                       << ", in High family).";
+      [encoder_specs addEntriesFromDictionary:@{
+        (NSString *)kVTVideoEncoderSpecification_EnableLowLatencyRateControl : @(YES),
+      }];
+    } else {
+      RTC_LOG(LS_INFO) << "H264: skipping EnableLowLatencyRateControl (profile=" << profileName
+                       << ", not in High family).";
+    }
   }
 
   OSStatus status = VTCompressionSessionCreate(

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -360,6 +360,14 @@ NSUInteger GetMaxSampleRate(
   }
 }
 
+// EnableLowLatencyRateControl only supports High profiles (VTCompressionProperties.h).
+bool IsH264HighProfileFamily(const std::optional<webrtc::H264ProfileLevelId> &id) {
+  return id &&
+      (id->profile == webrtc::H264Profile::kProfileConstrainedHigh ||
+       id->profile == webrtc::H264Profile::kProfileHigh ||
+       id->profile == webrtc::H264Profile::kProfilePredictiveHigh444);
+}
+
 const char *H264ProfileName(const std::optional<webrtc::H264ProfileLevelId> &id) {
   if (!id) return "<unparsed>";
   switch (id->profile) {
@@ -747,10 +755,7 @@ const char *H264ProfileName(const std::optional<webrtc::H264ProfileLevelId> &id)
   // profiles per VTCompressionProperties.h; setting it alongside a Baseline/Main
   // ProfileLevel disables hardware acceleration.
   if (@available(iOS 14.5, macCatalyst 14.5, macOS 11.3, tvOS 14.5, visionOS 1.0, *)) {
-    const bool isHighFamily = _profile_level_id &&
-        (_profile_level_id->profile == webrtc::H264Profile::kProfileConstrainedHigh ||
-         _profile_level_id->profile == webrtc::H264Profile::kProfileHigh ||
-         _profile_level_id->profile == webrtc::H264Profile::kProfilePredictiveHigh444);
+    const bool isHighFamily = IsH264HighProfileFamily(_profile_level_id);
     const char *profileName = H264ProfileName(_profile_level_id);
     if (isHighFamily) {
       RTC_LOG(LS_INFO) << "H264: enabling EnableLowLatencyRateControl (profile=" << profileName


### PR DESCRIPTION
Should allow h/w acceleration even if the base profile is negotiated:

```
(RTCVideoEncoderH264.mm:407): Using profile H264_Baseline_5_0
(RTCVideoEncoderH264.mm:747): H264: skipping EnableLowLatencyRateControl (non-High profile family).
(RTCVideoEncoderH264.mm:774): Compression session created with hw accl enabled
```

Follow-up of https://github.com/livekit/client-sdk-swift/issues/1002 and maybe https://github.com/livekit/client-sdk-swift/issues/1021

Edit: Unfortunately this problem also occurs for H.265, but I haven't found any reasonable solution/workaround, so keeping it small...