### PR TITLE
Pulse ADM lifecycle improvements

### DIFF
--- a/modules/audio_device/linux/audio_device_pulse_linux.cc
+++ b/modules/audio_device/linux/audio_device_pulse_linux.cc
@@ -10,6 +10,8 @@
 
 #include "modules/audio_device/linux/audio_device_pulse_linux.h"
 
+#include <sys/time.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -1728,24 +1730,64 @@ void AudioDeviceLinuxPulse::PaUnLock() {
 
 bool AudioDeviceLinuxPulse::WaitForPulseStreamReady(pa_stream* stream,
                                                     const char* stream_name) {
+  // Bound the wait: a PulseAudio server stuck in CREATING/UNCONNECTED would
+  // otherwise wedge the audio thread inside pa_threaded_mainloop_wait() while
+  // holding mutex_, deadlocking any concurrent StopRecording/StopPlayout.
+  constexpr int kStreamReadyTimeoutSec = 10;
+
+  struct TimerCtx {
+    pa_threaded_mainloop* mainloop;
+    bool fired;
+  };
+  TimerCtx ctx{_paMainloop, false};
+
+  struct timeval when;
+  gettimeofday(&when, nullptr);
+  when.tv_sec += kStreamReadyTimeoutSec;
+
+  pa_time_event* timer = _paMainloopApi->time_new(
+      _paMainloopApi, &when,
+      [](pa_mainloop_api* /*api*/, pa_time_event* /*e*/,
+         const struct timeval* /*tv*/, void* userdata) {
+        auto* c = static_cast<TimerCtx*>(userdata);
+        c->fired = true;
+        LATE(pa_threaded_mainloop_signal)(c->mainloop, 0);
+      },
+      &ctx);
+  if (!timer) {
+    RTC_LOG(LS_WARNING)
+        << stream_name
+        << " stream wait: failed to arm timeout timer, proceeding unbounded";
+  }
+
+  bool result = false;
   while (true) {
     const pa_stream_state_t state = LATE(pa_stream_get_state)(stream);
-    switch (state) {
-      case PA_STREAM_READY:
-        return true;
-      case PA_STREAM_FAILED:
-        RTC_LOG(LS_ERROR) << stream_name << " stream failed, err="
-                          << LATE(pa_context_errno)(_paContext);
-        return false;
-      case PA_STREAM_TERMINATED:
-        RTC_LOG(LS_ERROR) << stream_name << " stream terminated";
-        return false;
-      case PA_STREAM_UNCONNECTED:
-      case PA_STREAM_CREATING:
-        LATE(pa_threaded_mainloop_wait)(_paMainloop);
-        break;
+    if (state == PA_STREAM_READY) {
+      result = true;
+      break;
     }
+    if (state == PA_STREAM_FAILED) {
+      RTC_LOG(LS_ERROR) << stream_name << " stream failed, err="
+                        << LATE(pa_context_errno)(_paContext);
+      break;
+    }
+    if (state == PA_STREAM_TERMINATED) {
+      RTC_LOG(LS_ERROR) << stream_name << " stream terminated";
+      break;
+    }
+    if (ctx.fired) {
+      RTC_LOG(LS_ERROR) << stream_name << " stream wait timed out after "
+                        << kStreamReadyTimeoutSec << "s, state=" << state;
+      break;
+    }
+    LATE(pa_threaded_mainloop_wait)(_paMainloop);
   }
+
+  if (timer) {
+    _paMainloopApi->time_free(timer);
+  }
+  return result;
 }
 
 void AudioDeviceLinuxPulse::WaitForOperationCompletion(

--- a/modules/audio_device/linux/audio_device_pulse_linux.cc
+++ b/modules/audio_device/linux/audio_device_pulse_linux.cc
@@ -1737,9 +1737,10 @@ void AudioDeviceLinuxPulse::PaUnLock() {
 
 bool AudioDeviceLinuxPulse::WaitForPulseStreamReady(pa_stream* stream,
                                                     const char* stream_name) {
-  // Bound the wait: a PulseAudio server stuck in CREATING/UNCONNECTED would
-  // otherwise wedge the audio thread inside pa_threaded_mainloop_wait() while
-  // holding mutex_, deadlocking any concurrent StopRecording/StopPlayout.
+  // Bound the wait: callers enter this helper from the audio worker thread
+  // while holding mutex_. A PulseAudio server stuck in CREATING/UNCONNECTED
+  // would otherwise wedge the worker in pa_threaded_mainloop_wait(), blocking
+  // concurrent StopRecording/StopPlayout from acquiring mutex_.
   constexpr int kStreamReadyTimeoutSec = 9;
 
   struct TimerCtx {

--- a/modules/audio_device/linux/audio_device_pulse_linux.cc
+++ b/modules/audio_device/linux/audio_device_pulse_linux.cc
@@ -47,6 +47,13 @@ WebRTCPulseSymbolTable* GetPulseSymbolTable() {
 
 namespace webrtc {
 
+namespace {
+
+constexpr int kPulseStreamReadyTimeoutSec = 9;
+constexpr int kPulseStartTimeoutSec = kPulseStreamReadyTimeoutSec + 1;
+
+}  // namespace
+
 AudioDeviceLinuxPulse::AudioDeviceLinuxPulse()
     : _ptrAudioBuffer(nullptr),
       _inputDeviceIndex(0),
@@ -1085,7 +1092,7 @@ int32_t AudioDeviceLinuxPulse::StartRecording() {
 
   // The audio thread will signal when recording has started.
   _timeEventRec.Set();
-  if (!_recStartEvent.Wait(TimeDelta::Seconds(10))) {
+  if (!_recStartEvent.Wait(TimeDelta::Seconds(kPulseStartTimeoutSec))) {
     {
       MutexLock lock(&mutex_);
       _startRec = false;
@@ -1206,7 +1213,7 @@ int32_t AudioDeviceLinuxPulse::StartPlayout() {
 
   // The audio thread will signal when playout has started.
   _timeEventPlay.Set();
-  if (!_playStartEvent.Wait(TimeDelta::Seconds(10))) {
+  if (!_playStartEvent.Wait(TimeDelta::Seconds(kPulseStartTimeoutSec))) {
     {
       MutexLock lock(&mutex_);
       _startPlay = false;
@@ -1741,8 +1748,6 @@ bool AudioDeviceLinuxPulse::WaitForPulseStreamReady(pa_stream* stream,
   // while holding mutex_. A PulseAudio server stuck in CREATING/UNCONNECTED
   // would otherwise wedge the worker in pa_threaded_mainloop_wait(), blocking
   // concurrent StopRecording/StopPlayout from acquiring mutex_.
-  constexpr int kStreamReadyTimeoutSec = 9;
-
   struct TimerCtx {
     pa_threaded_mainloop* mainloop;
     bool fired;
@@ -1751,7 +1756,7 @@ bool AudioDeviceLinuxPulse::WaitForPulseStreamReady(pa_stream* stream,
 
   struct timeval when;
   gettimeofday(&when, nullptr);
-  when.tv_sec += kStreamReadyTimeoutSec;
+  when.tv_sec += kPulseStreamReadyTimeoutSec;
 
   pa_time_event* timer = _paMainloopApi->time_new(
       _paMainloopApi, &when,
@@ -1786,7 +1791,8 @@ bool AudioDeviceLinuxPulse::WaitForPulseStreamReady(pa_stream* stream,
     }
     if (ctx.fired) {
       RTC_LOG(LS_ERROR) << stream_name << " stream wait timed out after "
-                        << kStreamReadyTimeoutSec << "s, state=" << state;
+                        << kPulseStreamReadyTimeoutSec
+                        << "s, state=" << state;
       break;
     }
     LATE(pa_threaded_mainloop_wait)(_paMainloop);

--- a/modules/audio_device/linux/audio_device_pulse_linux.cc
+++ b/modules/audio_device/linux/audio_device_pulse_linux.cc
@@ -155,6 +155,13 @@ AudioDeviceGeneric::InitStatus AudioDeviceLinuxPulse::Init() {
     return InitStatus::OK;
   }
 
+  {
+    MutexLock lock(&mutex_);
+    quit_ = false;
+    _startRec = false;
+    _startPlay = false;
+  }
+
   // Initialize PulseAudio
   if (InitPulseAudio() < 0) {
     RTC_LOG(LS_ERROR) << "failed to initialize PulseAudio";
@@ -2076,6 +2083,11 @@ bool AudioDeviceLinuxPulse::PlayThreadProcess() {
   MutexLock lock(&mutex_);
 
   if (quit_) {
+    if (_startPlay) {
+      _startPlay = false;
+      _playing = false;
+      _playStartEvent.Set();
+    }
     return false;
   }
 
@@ -2265,6 +2277,11 @@ bool AudioDeviceLinuxPulse::RecThreadProcess() {
 
   MutexLock lock(&mutex_);
   if (quit_) {
+    if (_startRec) {
+      _startRec = false;
+      _recording = false;
+      _recStartEvent.Set();
+    }
     return false;
   }
   if (_startRec) {

--- a/modules/audio_device/linux/audio_device_pulse_linux.cc
+++ b/modules/audio_device/linux/audio_device_pulse_linux.cc
@@ -1063,12 +1063,16 @@ int32_t AudioDeviceLinuxPulse::StartRecording() {
     return -1;
   }
 
-  if (_recording) {
-    return 0;
-  }
+  _recStartEvent.Reset();
+  {
+    MutexLock lock(&mutex_);
+    if (_recording) {
+      return 0;
+    }
 
-  // Set state to ensure that the recording starts from the audio thread.
-  _startRec = true;
+    // Set state to ensure that the recording starts from the audio thread.
+    _startRec = true;
+  }
 
   // The audio thread will signal when recording has started.
   _timeEventRec.Set();
@@ -1082,15 +1086,17 @@ int32_t AudioDeviceLinuxPulse::StartRecording() {
     return -1;
   }
 
+  bool recording = false;
   {
     MutexLock lock(&mutex_);
-    if (_recording) {
-      // The recording state is set by the audio thread after recording
-      // has started.
-    } else {
-      RTC_LOG(LS_ERROR) << "failed to activate recording";
-      return -1;
+    recording = _recording;
+    if (!recording) {
+      RTC_LOG(LS_ERROR) << "recording thread failed to activate recording";
     }
+  }
+  if (!recording) {
+    StopRecording();
+    return -1;
   }
 
   return 0;
@@ -1114,6 +1120,7 @@ int32_t AudioDeviceLinuxPulse::StopRecording() {
   RTC_LOG(LS_VERBOSE) << "stopping recording";
 
   // Stop Recording
+  int32_t ret_val = 0;
   PaLock();
 
   DisableReadCallback();
@@ -1122,16 +1129,18 @@ int32_t AudioDeviceLinuxPulse::StopRecording() {
   // Unset this here so that we don't get a TERMINATED callback
   LATE(pa_stream_set_state_callback)(_recStream, nullptr, nullptr);
 
-  if (LATE(pa_stream_get_state)(_recStream) != PA_STREAM_UNCONNECTED) {
+  const pa_stream_state_t stream_state = LATE(pa_stream_get_state)(_recStream);
+  if (stream_state != PA_STREAM_UNCONNECTED &&
+      stream_state != PA_STREAM_FAILED &&
+      stream_state != PA_STREAM_TERMINATED) {
     // Disconnect the stream
     if (LATE(pa_stream_disconnect)(_recStream) != PA_OK) {
       RTC_LOG(LS_ERROR) << "failed to disconnect rec stream, err="
                         << LATE(pa_context_errno)(_paContext);
-      PaUnLock();
-      return -1;
+      ret_val = -1;
+    } else {
+      RTC_LOG(LS_VERBOSE) << "disconnected recording";
     }
-
-    RTC_LOG(LS_VERBOSE) << "disconnected recording";
   }
 
   LATE(pa_stream_unref)(_recStream);
@@ -1147,7 +1156,7 @@ int32_t AudioDeviceLinuxPulse::StopRecording() {
     _recBuffer = nullptr;
   }
 
-  return 0;
+  return ret_val;
 }
 
 bool AudioDeviceLinuxPulse::RecordingIsInitialized() const {
@@ -1172,13 +1181,14 @@ int32_t AudioDeviceLinuxPulse::StartPlayout() {
     return -1;
   }
 
-  if (_playing) {
-    return 0;
-  }
-
-  // Set state to ensure that playout starts from the audio thread.
+  _playStartEvent.Reset();
   {
     MutexLock lock(&mutex_);
+    if (_playing) {
+      return 0;
+    }
+
+    // Set state to ensure that playout starts from the audio thread.
     _startPlay = true;
   }
 
@@ -1197,15 +1207,17 @@ int32_t AudioDeviceLinuxPulse::StartPlayout() {
     return -1;
   }
 
+  bool playing = false;
   {
     MutexLock lock(&mutex_);
-    if (_playing) {
-      // The playing state is set by the audio thread after playout
-      // has started.
-    } else {
-      RTC_LOG(LS_ERROR) << "failed to activate playing";
-      return -1;
+    playing = _playing;
+    if (!playing) {
+      RTC_LOG(LS_ERROR) << "playout thread failed to activate playing";
     }
+  }
+  if (!playing) {
+    StopPlayout();
+    return -1;
   }
 
   return 0;
@@ -1230,6 +1242,7 @@ int32_t AudioDeviceLinuxPulse::StopPlayout() {
   RTC_LOG(LS_VERBOSE) << "stopping playback";
 
   // Stop Playout
+  int32_t ret_val = 0;
   PaLock();
 
   DisableWriteCallback();
@@ -1238,16 +1251,18 @@ int32_t AudioDeviceLinuxPulse::StopPlayout() {
   // Unset this here so that we don't get a TERMINATED callback
   LATE(pa_stream_set_state_callback)(_playStream, nullptr, nullptr);
 
-  if (LATE(pa_stream_get_state)(_playStream) != PA_STREAM_UNCONNECTED) {
+  const pa_stream_state_t stream_state = LATE(pa_stream_get_state)(_playStream);
+  if (stream_state != PA_STREAM_UNCONNECTED &&
+      stream_state != PA_STREAM_FAILED &&
+      stream_state != PA_STREAM_TERMINATED) {
     // Disconnect the stream
     if (LATE(pa_stream_disconnect)(_playStream) != PA_OK) {
       RTC_LOG(LS_ERROR) << "failed to disconnect play stream, err="
                         << LATE(pa_context_errno)(_paContext);
-      PaUnLock();
-      return -1;
+      ret_val = -1;
+    } else {
+      RTC_LOG(LS_VERBOSE) << "disconnected playback";
     }
-
-    RTC_LOG(LS_VERBOSE) << "disconnected playback";
   }
 
   LATE(pa_stream_unref)(_playStream);
@@ -1263,7 +1278,7 @@ int32_t AudioDeviceLinuxPulse::StopPlayout() {
     _playBuffer = nullptr;
   }
 
-  return 0;
+  return ret_val;
 }
 
 int32_t AudioDeviceLinuxPulse::PlayoutDelay(uint16_t& delayMS) const {
@@ -1711,6 +1726,28 @@ void AudioDeviceLinuxPulse::PaUnLock() {
   LATE(pa_threaded_mainloop_unlock)(_paMainloop);
 }
 
+bool AudioDeviceLinuxPulse::WaitForPulseStreamReady(pa_stream* stream,
+                                                    const char* stream_name) {
+  while (true) {
+    const pa_stream_state_t state = LATE(pa_stream_get_state)(stream);
+    switch (state) {
+      case PA_STREAM_READY:
+        return true;
+      case PA_STREAM_FAILED:
+        RTC_LOG(LS_ERROR) << stream_name << " stream failed, err="
+                          << LATE(pa_context_errno)(_paContext);
+        return false;
+      case PA_STREAM_TERMINATED:
+        RTC_LOG(LS_ERROR) << stream_name << " stream terminated";
+        return false;
+      case PA_STREAM_UNCONNECTED:
+      case PA_STREAM_CREATING:
+        LATE(pa_threaded_mainloop_wait)(_paMainloop);
+        break;
+    }
+  }
+}
+
 void AudioDeviceLinuxPulse::WaitForOperationCompletion(
     pa_operation* paOperation) const {
   if (!paOperation) {
@@ -2052,13 +2089,29 @@ bool AudioDeviceLinuxPulse::PlayThreadProcess() {
                                          ptr_cvolume, nullptr) != PA_OK) {
       RTC_LOG(LS_ERROR) << "failed to connect play stream, err="
                         << LATE(pa_context_errno)(_paContext);
+      PaUnLock();
+      if (_playDeviceName) {
+        delete[] _playDeviceName;
+        _playDeviceName = nullptr;
+      }
+      _startPlay = false;
+      _playing = false;
+      _playStartEvent.Set();
+      return true;
     }
 
     RTC_LOG(LS_VERBOSE) << "play stream connected";
 
-    // Wait for state change
-    while (LATE(pa_stream_get_state)(_playStream) != PA_STREAM_READY) {
-      LATE(pa_threaded_mainloop_wait)(_paMainloop);
+    if (!WaitForPulseStreamReady(_playStream, "playout")) {
+      PaUnLock();
+      if (_playDeviceName) {
+        delete[] _playDeviceName;
+        _playDeviceName = nullptr;
+      }
+      _startPlay = false;
+      _playing = false;
+      _playStartEvent.Set();
+      return true;
     }
 
     RTC_LOG(LS_VERBOSE) << "play stream ready";
@@ -2195,13 +2248,29 @@ bool AudioDeviceLinuxPulse::RecThreadProcess() {
             (pa_stream_flags_t)_recStreamFlags) != PA_OK) {
       RTC_LOG(LS_ERROR) << "failed to connect rec stream, err="
                         << LATE(pa_context_errno)(_paContext);
+      PaUnLock();
+      if (_recDeviceName) {
+        delete[] _recDeviceName;
+        _recDeviceName = nullptr;
+      }
+      _startRec = false;
+      _recording = false;
+      _recStartEvent.Set();
+      return true;
     }
 
     RTC_LOG(LS_VERBOSE) << "connected";
 
-    // Wait for state change
-    while (LATE(pa_stream_get_state)(_recStream) != PA_STREAM_READY) {
-      LATE(pa_threaded_mainloop_wait)(_paMainloop);
+    if (!WaitForPulseStreamReady(_recStream, "recording")) {
+      PaUnLock();
+      if (_recDeviceName) {
+        delete[] _recDeviceName;
+        _recDeviceName = nullptr;
+      }
+      _startRec = false;
+      _recording = false;
+      _recStartEvent.Set();
+      return true;
     }
 
     RTC_LOG(LS_VERBOSE) << "done";

--- a/modules/audio_device/linux/audio_device_pulse_linux.cc
+++ b/modules/audio_device/linux/audio_device_pulse_linux.cc
@@ -50,7 +50,7 @@ namespace webrtc {
 namespace {
 
 constexpr int kPulseStreamReadyTimeoutSec = 9;
-constexpr int kPulseStartTimeoutSec = kPulseStreamReadyTimeoutSec + 1;
+constexpr int kPulseStartTimeoutSec = kPulseStreamReadyTimeoutSec + 3;
 
 }  // namespace
 

--- a/modules/audio_device/linux/audio_device_pulse_linux.cc
+++ b/modules/audio_device/linux/audio_device_pulse_linux.cc
@@ -1733,7 +1733,7 @@ bool AudioDeviceLinuxPulse::WaitForPulseStreamReady(pa_stream* stream,
   // Bound the wait: a PulseAudio server stuck in CREATING/UNCONNECTED would
   // otherwise wedge the audio thread inside pa_threaded_mainloop_wait() while
   // holding mutex_, deadlocking any concurrent StopRecording/StopPlayout.
-  constexpr int kStreamReadyTimeoutSec = 10;
+  constexpr int kStreamReadyTimeoutSec = 9;
 
   struct TimerCtx {
     pa_threaded_mainloop* mainloop;
@@ -1755,9 +1755,9 @@ bool AudioDeviceLinuxPulse::WaitForPulseStreamReady(pa_stream* stream,
       },
       &ctx);
   if (!timer) {
-    RTC_LOG(LS_WARNING)
-        << stream_name
-        << " stream wait: failed to arm timeout timer, proceeding unbounded";
+    RTC_LOG(LS_ERROR)
+        << stream_name << " stream wait: failed to arm timeout timer";
+    return false;
   }
 
   bool result = false;

--- a/modules/audio_device/linux/audio_device_pulse_linux.h
+++ b/modules/audio_device/linux/audio_device_pulse_linux.h
@@ -250,6 +250,7 @@ class AudioDeviceLinuxPulse : public AudioDeviceGeneric {
   int32_t GetDefaultDeviceInfo(bool recDevice, char* name, uint16_t& index);
   int32_t InitPulseAudio();
   int32_t TerminatePulseAudio();
+  bool WaitForPulseStreamReady(pa_stream* stream, const char* stream_name);
 
   void PaLock();
   void PaUnLock();


### PR DESCRIPTION
Improves PulseAudio ADM start/stop handling for repeated recording/playout lifecycle changes.

Changes:
- Synchronize recording/playout start requests with the Pulse worker threads.
- Reset and validate start events so StartRecording() / StartPlayout() only succeed after the worker thread actually activates.
- Handle Pulse stream connect failures, FAILED, and TERMINATED states cleanly.
- Add a bounded wait while Pulse streams transition to READY, avoiding indefinite hangs.
- Make stop paths tolerate already failed/terminated streams while still cleaning up callbacks, streams, and buffers.

This is intended to make repeated StartRecording() / StopRecording() cycles more robust, including call teardown/restart and mute-driven recording lifecycle changes.