### PR TITLE
Fix macOS audio build warnings

### DIFF
--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -266,7 +266,7 @@ int32_t AudioEngineDevice::Init() {
   // main thread to issue notifications.
   AudioObjectPropertyAddress propertyAddress = {kAudioHardwarePropertyRunLoop,
                                                 kAudioObjectPropertyScopeGlobal,
-                                                kAudioObjectPropertyElementMaster};
+                                                kAudioObjectPropertyElementMain};
 
   CFRunLoopRef runLoop = NULL;
   UInt32 size = sizeof(CFRunLoopRef);
@@ -323,9 +323,9 @@ int32_t AudioEngineDevice::Terminate() {
 #if TARGET_OS_OSX
   // Remove listeners for global scope.
   AudioObjectPropertyAddress propertyAddress = {
-      kAudioHardwarePropertyDevices,     // selector
-      kAudioObjectPropertyScopeGlobal,   // scope
-      kAudioObjectPropertyElementMaster  // element
+      kAudioHardwarePropertyDevices,    // selector
+      kAudioObjectPropertyScopeGlobal,  // scope
+      kAudioObjectPropertyElementMain   // element
   };
 
   OSStatus err = noErr;

--- a/modules/audio_device/mac/audio_device_mac.cc
+++ b/modules/audio_device/mac/audio_device_mac.cc
@@ -276,7 +276,7 @@ AudioDeviceGeneric::InitStatus AudioDeviceMac::Init() {
   AudioObjectPropertyAddress propertyAddress = {
     kAudioHardwarePropertyRunLoop,
     kAudioObjectPropertyScopeGlobal,
-    kAudioObjectPropertyElementMaster
+    kAudioObjectPropertyElementMain
   };
 
   CFRunLoopRef runLoop = NULL;
@@ -334,7 +334,7 @@ int32_t AudioDeviceMac::Terminate() {
   AudioObjectPropertyAddress propertyAddress = {
     kAudioHardwarePropertyDevices, // selector
     kAudioObjectPropertyScopeGlobal, // scope
-    kAudioObjectPropertyElementMaster // element
+    kAudioObjectPropertyElementMain // element
   };
 
   WEBRTC_CA_LOG_WARN(AudioObjectRemovePropertyListener(
@@ -1539,7 +1539,7 @@ int32_t AudioDeviceMac::GetNumberDevices(const AudioObjectPropertyScope scope,
   AudioObjectPropertyAddress propertyAddress = {
     kAudioHardwarePropertyDevices,
     kAudioObjectPropertyScopeGlobal,
-    kAudioObjectPropertyElementMaster,
+    kAudioObjectPropertyElementMain,
   };
 
   UInt32 size = 0;

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule+Private.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule+Private.h
@@ -21,11 +21,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// clang-format off
 @interface RTC_OBJC_TYPE(RTCAudioDeviceModule) ()
 
 - (instancetype)initWithNativeModule:(webrtc::scoped_refptr<webrtc::AudioDeviceModule>)module
-                        workerThread:(webrtc::Thread *)workerThread;
+                        workerThread:(webrtc::Thread *)workerThread
+               audioDeviceModuleType:(RTC_OBJC_TYPE(RTCAudioDeviceModuleType))audioDeviceModuleType;
 
 @end
+// clang-format on
 
 NS_ASSUME_NONNULL_END

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -67,6 +67,15 @@ inline RTC_OBJC_TYPE(RTCAudioDuckingLevel)
   }
 }
 
+inline webrtc::AudioEngineDevice *AudioEngineDeviceOrNull(webrtc::AudioDeviceModule *module,
+                                                          RTC_OBJC_TYPE(RTCAudioDeviceModuleType)
+                                                              module_type) {
+  if (module_type != RTC_OBJC_TYPE(RTCAudioDeviceModuleTypeAudioEngine)) {
+    return nullptr;
+  }
+  return static_cast<webrtc::AudioEngineDevice *>(module);
+}
+
 class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
  public:
   AudioDeviceObserver(RTC_OBJC_TYPE(RTCAudioDeviceModule) * adm) { adm_ = adm; }
@@ -167,6 +176,7 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 @implementation RTC_OBJC_TYPE (RTCAudioDeviceModule) {
   webrtc::Thread *_workerThread;
   webrtc::scoped_refptr<webrtc::AudioDeviceModule> _native;
+  RTC_OBJC_TYPE(RTCAudioDeviceModuleType) _audioDeviceModuleType;
   AudioDeviceObserver *_observer;
 }
 
@@ -182,12 +192,15 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (instancetype)initWithNativeModule:(webrtc::scoped_refptr<webrtc::AudioDeviceModule>)module
-                        workerThread:(webrtc::Thread *)workerThread {
+                        workerThread:(webrtc::Thread *)workerThread
+               audioDeviceModuleType:
+                   (RTC_OBJC_TYPE(RTCAudioDeviceModuleType))audioDeviceModuleType {
   RTCLogInfo(@"RTCAudioDeviceModule initWithNativeModule:workerThread:");
 
   self = [super init];
   _native = module;
   _workerThread = workerThread;
+  _audioDeviceModuleType = audioDeviceModuleType;
 
   _observer = new AudioDeviceObserver(self);
 
@@ -329,7 +342,7 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 - (NSInteger)initAndStartRecording {
   return _workerThread->BlockingCall([self] {
     webrtc::AudioEngineDevice *engine_device =
-        dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+        AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
     if (engine_device != nullptr) {
       return engine_device->InitAndStartRecording();
     } else {
@@ -356,7 +369,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isEngineRunning {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return false;
 
   return _workerThread->BlockingCall([module] { return module->IsEngineRunning(); });
@@ -374,7 +388,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (RTC_OBJC_TYPE(RTCAudioEngineState))engineState {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineState)();
 
   return _workerThread->BlockingCall([module] {
@@ -393,7 +408,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)setEngineState:(RTC_OBJC_TYPE(RTCAudioEngineState))state {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return;
 
   _workerThread->BlockingCall([module, state] {
@@ -412,7 +428,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 #pragma mark - Unique to AudioEngineDevice
 
 - (NSInteger)setEngineAvailability:(RTC_OBJC_TYPE(RTCAudioEngineAvailability))availability {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return -1;
 
   return _workerThread->BlockingCall([module, availability] {
@@ -422,7 +439,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (RTC_OBJC_TYPE(RTCAudioEngineAvailability))engineAvailability {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineAvailability)(NO, NO);
 
   return _workerThread->BlockingCall([module] {
@@ -436,7 +454,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isRecordingAlwaysPreparedMode {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return NO;
 
   return _workerThread->BlockingCall([module] {
@@ -446,7 +465,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)setRecordingAlwaysPreparedMode:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return -1;
 
   return _workerThread->BlockingCall(
@@ -454,7 +474,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isManualRenderingMode {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return NO;
 
   return _workerThread->BlockingCall([module] {
@@ -464,7 +485,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)setManualRenderingMode:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return -1;
 
   return _workerThread->BlockingCall(
@@ -472,7 +494,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isAdvancedDuckingEnabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return NO;
 
   return _workerThread->BlockingCall([module] {
@@ -482,7 +505,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)setAdvancedDuckingEnabled:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return;
 
   _workerThread->BlockingCall(
@@ -490,7 +514,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (RTC_OBJC_TYPE(RTCAudioDuckingLevel))duckingLevel {
-  webrtc::AudioEngineDevice* module = dynamic_cast<webrtc::AudioEngineDevice*>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioDuckingLevelDefault);
 
   return _workerThread->BlockingCall([module] {
@@ -501,7 +526,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)setDuckingLevel:(RTC_OBJC_TYPE(RTCAudioDuckingLevel))value {
-  webrtc::AudioEngineDevice* module = dynamic_cast<webrtc::AudioEngineDevice*>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return;
 
   _workerThread->BlockingCall(
@@ -509,7 +535,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (RTC_OBJC_TYPE(RTCAudioEngineMuteMode))muteMode {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineMuteModeUnknown);
 
   return _workerThread->BlockingCall([module] {
@@ -520,7 +547,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)setMuteMode:(RTC_OBJC_TYPE(RTCAudioEngineMuteMode))mode {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return -1;
 
   return _workerThread->BlockingCall(
@@ -528,7 +556,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isVoiceProcessingEnabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return NO;
 
   return _workerThread->BlockingCall([module] {
@@ -538,7 +567,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)setVoiceProcessingEnabled:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return -1;
 
   return _workerThread->BlockingCall(
@@ -546,7 +576,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isVoiceProcessingBypassed {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return NO;
 
   return _workerThread->BlockingCall([module] {
@@ -556,7 +587,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)setVoiceProcessingBypassed:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return;
 
   _workerThread->BlockingCall(
@@ -564,7 +596,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isVoiceProcessingAGCEnabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return NO;
 
   return _workerThread->BlockingCall([module] {
@@ -574,7 +607,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)setVoiceProcessingAGCEnabled:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = dynamic_cast<webrtc::AudioEngineDevice *>(_native.get());
+  webrtc::AudioEngineDevice *module =
+      AudioEngineDeviceOrNull(_native.get(), _audioDeviceModuleType);
   if (module == nullptr) return;
 
   _workerThread->BlockingCall(

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -379,8 +379,10 @@ static webrtc::Environment CreateDefaultEnvironment() {
           });
     }
 
-    _audioDeviceModule = [[RTC_OBJC_TYPE(RTCAudioDeviceModule) alloc] initWithNativeModule: _nativeAudioDeviceModule
-                                                       workerThread: _workerThread.get()];
+    _audioDeviceModule =
+        [[RTC_OBJC_TYPE(RTCAudioDeviceModule) alloc] initWithNativeModule:_nativeAudioDeviceModule
+                                                             workerThread:_workerThread.get()
+                                                    audioDeviceModuleType:audioDeviceModuleType];
     dependencies.adm = _nativeAudioDeviceModule;
     dependencies.audio_encoder_factory = std::move(audioEncoderFactory);
     dependencies.audio_decoder_factory = std::move(audioDecoderFactory);


### PR DESCRIPTION
## Summary
- Replace deprecated CoreAudio `kAudioObjectPropertyElementMaster` uses with `kAudioObjectPropertyElementMain`.
- Avoid repeated ObjC++ `dynamic_cast` checks in `RTCAudioDeviceModule` by carrying the selected ADM type into the wrapper.
- Keep AudioEngine-only wrapper APIs gated behind `RTCAudioDeviceModuleTypeAudioEngine`.

## Details
The public factory path already creates `AudioEngineDevice` when `audioDeviceModuleType` is `AudioEngine`. This PR preserves that behavior and uses the module type as the wrapper discriminator for AudioEngine-only calls.

For native/custom ADM injection, callers should keep the provided `audioDeviceModuleType` consistent with the actual ADM instance. A custom non-AudioEngine ADM should not be tagged as `AudioEngine`.

## Validation
- `git diff --check m144_release...HEAD`
- `autoninja -C out/codex-mac sdk:peerconnectionfactory_base_objc`