### PR TITLE
Reduce frame cryptor log noise

### DIFF
--- a/api/crypto/frame_crypto_transformer.cc
+++ b/api/crypto/frame_crypto_transformer.cc
@@ -469,12 +469,16 @@ void FrameCryptorTransformer::encryptFrame(
   }
 
   webrtc::ArrayView<const uint8_t> data_in = frame->GetData();
-  if (data_in.size() == 0 || !enabled_cryption) {
-    RTC_LOG(LS_WARNING) << "FrameCryptorTransformer::encryptFrame() "
-                           "data_in.size() == 0 || enabled_cryption == false";
+  if (data_in.size() == 0) {
+    RTC_LOG(LS_VERBOSE)
+        << "FrameCryptorTransformer::encryptFrame() empty frame";
     if (key_provider_->options().discard_frame_when_cryptor_not_ready) {
       return;
     }
+    sink_callback->OnTransformedFrame(std::move(frame));
+    return;
+  }
+  if (!enabled_cryption) {
     sink_callback->OnTransformedFrame(std::move(frame));
     return;
   }
@@ -586,13 +590,17 @@ void FrameCryptorTransformer::decryptFrame(
 
   webrtc::ArrayView<const uint8_t> data_in = frame->GetData();
 
-  if (data_in.size() == 0 || !enabled_cryption) {
-    RTC_LOG(LS_WARNING) << "FrameCryptorTransformer::decryptFrame() "
-                           "data_in.size() == 0 || enabled_cryption == false";
+  if (data_in.size() == 0) {
+    RTC_LOG(LS_VERBOSE)
+        << "FrameCryptorTransformer::decryptFrame() empty frame";
     if (key_provider_->options().discard_frame_when_cryptor_not_ready) {
       return;
     }
 
+    sink_callback->OnTransformedFrame(std::move(frame));
+    return;
+  }
+  if (!enabled_cryption) {
     sink_callback->OnTransformedFrame(std::move(frame));
     return;
   }


### PR DESCRIPTION
## Summary
- Stop logging disabled frame cryptor pass-through as a warning on every frame.
- Keep empty-frame logs at verbose level.
- Treat `enabled=false` as explicit pass-through for both encrypt and decrypt paths.

## Behavior
Previously `data_in.size() == 0` and `enabled_cryption == false` shared the same warning and discard handling. This split keeps discard behavior for empty frames, while disabled cryptors now pass frames through without warning spam.

## Validation
- `git diff --check m144_release...HEAD`
- `autoninja -C out/codex-api-test api/crypto:frame_crypto_transformer`

## Notes
- Full `rtc_unittests` is currently blocked on `m144_release` by unrelated macOS `kAudioObjectPropertyElementMaster` deprecation warnings.
- Focused `api/crypto:crypto_unittests` is blocked by an existing `system_wrappers/include/sleep.h` include-path issue in that target.