### PR TITLE
Allow null audio callback deregistration in AudioEngineDevice

### DIFF
--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -983,7 +983,9 @@ int32_t AudioEngineDevice::RegisterAudioCallback(AudioTransport* audioCallback) 
   LOGI() << "RegisterAudioCallback";
   RTC_DCHECK_RUN_ON(thread_);
   RTC_DCHECK(audio_device_buffer_ != nullptr);
-  RTC_DCHECK(audioCallback != nullptr);
+  // audioCallback is nullptr when deregistering (e.g. WebRtcVoiceEngine::Terminate).
+  // AudioDeviceBuffer::RegisterAudioCallback accepts nullptr, so don't DCHECK it
+  // (doing so crashes debug builds on teardown).
 
   return audio_device_buffer_->RegisterAudioCallback(audioCallback);
 }


### PR DESCRIPTION
## Summary
- Allows `AudioEngineDevice::RegisterAudioCallback(nullptr)` when WebRTC deregisters its audio callback during teardown.
- Keeps non-null callback registration behavior unchanged.
- Matches `AudioDeviceBuffer::RegisterAudioCallback`, which already accepts `nullptr` for deregistration.

## Why
`WebRtcVoiceEngine::Terminate()` calls `RegisterAudioCallback(nullptr)` to clear the callback. The AudioEngine ADM still had a debug-only `RTC_DCHECK(audioCallback != nullptr)`, which could crash debug builds during disconnect or teardown.

## Validation
- `git diff --check origin/m144_release...HEAD`