### PR TITLE
Fix Apple H.264 profile-level capability advertisement

### DIFF
--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -808,6 +808,7 @@ if (is_ios || is_mac) {
         "../modules/video_coding:video_codec_interface",
         "../rtc_base:checks",
       ]
+      frameworks = [ "VideoToolbox.framework" ]
     }
 
     rtc_library("default_codec_factory_objc") {

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
@@ -52,6 +52,16 @@ struct VideoToolboxH264ProfileLevels {
   std::optional<webrtc::H264Level> constrainedHigh;
 };
 
+bool HasAnyVideoToolboxH264ProfileLevel(
+    const VideoToolboxH264ProfileLevels &levels) {
+  return levels.constrainedBaseline || levels.main || levels.constrainedHigh;
+}
+
+struct VideoToolboxH264LevelSupport {
+  std::optional<webrtc::H264Level> level;
+  bool queried;
+};
+
 enum class VideoToolboxH264ProfileFamily {
   kBaseline,
   kMain,
@@ -301,22 +311,23 @@ const VideoToolboxH264ProfileLevels &MaxSupportedVideoToolboxH264ProfileLevels()
   return levels;
 }
 
-std::optional<webrtc::H264Level> SupportedVideoToolboxLevelForProfile(
+VideoToolboxH264LevelSupport SupportedVideoToolboxLevelForProfile(
     webrtc::H264Profile profile) {
   const VideoToolboxH264ProfileLevels &profileLevels =
       MaxSupportedVideoToolboxH264ProfileLevels();
+  const bool queried = HasAnyVideoToolboxH264ProfileLevel(profileLevels);
   switch (profile) {
     case webrtc::H264Profile::kProfileConstrainedBaseline:
     case webrtc::H264Profile::kProfileBaseline:
-      return profileLevels.constrainedBaseline;
+      return {profileLevels.constrainedBaseline, queried};
     case webrtc::H264Profile::kProfileMain:
-      return profileLevels.main;
+      return {profileLevels.main, queried};
     case webrtc::H264Profile::kProfileConstrainedHigh:
     case webrtc::H264Profile::kProfileHigh:
     case webrtc::H264Profile::kProfilePredictiveHigh444:
-      return profileLevels.constrainedHigh;
+      return {profileLevels.constrainedHigh, queried};
   }
-  return std::nullopt;
+  return {std::nullopt, queried};
 }
 
 #if defined(WEBRTC_IOS)
@@ -363,16 +374,20 @@ NSString *MaxSupportedLevelForProfile(webrtc::H264Profile profile) {
   // 1. Prefer VideoToolbox, because it reflects the current machine/OS encoder.
   // 2. On iOS, keep the UIDevice table as a conservative fallback for older OSes
   //    where VideoToolbox cannot be constrained to the hardware encoder.
-  // 3. For non-iOS-device Apple platforms, fall back to Level 5 rather than the
-  //    historical WebRTC Level 3.1 constants that break 1080p30 sends.
-  std::optional<webrtc::H264Level> supportedLevel =
+  // 3. For non-iOS-device Apple platforms, fall back to Level 5 only when
+  //    VideoToolbox returned no useful H264 profile list. If VideoToolbox
+  //    reports a list but omits this profile family, avoid inventing support for
+  //    it and let the caller use the historical WebRTC constants instead.
+  const VideoToolboxH264LevelSupport videoToolboxSupport =
       SupportedVideoToolboxLevelForProfile(profile);
+  std::optional<webrtc::H264Level> supportedLevel =
+      videoToolboxSupport.level;
 #if defined(WEBRTC_IOS)
   if (!supportedLevel) {
     supportedLevel = SupportedUIDeviceLevelForProfile(profile);
   }
 #endif
-  if (!supportedLevel) {
+  if (!supportedLevel && !videoToolboxSupport.queried) {
     supportedLevel = FallbackLevelForCurrentPlatform();
   }
 

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
@@ -52,8 +52,7 @@ struct VideoToolboxH264ProfileLevels {
   std::optional<webrtc::H264Level> constrainedHigh;
 };
 
-bool HasAnyVideoToolboxH264ProfileLevel(
-    const VideoToolboxH264ProfileLevels &levels) {
+bool HasAnyVideoToolboxH264ProfileLevel(const VideoToolboxH264ProfileLevels &levels) {
   return levels.constrainedBaseline || levels.main || levels.constrainedHigh;
 }
 
@@ -74,30 +73,25 @@ struct VideoToolboxH264ProfileLevel {
   webrtc::H264Level level;
 };
 
-bool H264LevelIsHigherThan(std::optional<webrtc::H264Level> current,
-                           webrtc::H264Level candidate) {
-  return !current ||
-      static_cast<int>(candidate) > static_cast<int>(*current);
+bool H264LevelIsHigherThan(std::optional<webrtc::H264Level> current, webrtc::H264Level candidate) {
+  return !current || static_cast<int>(candidate) > static_cast<int>(*current);
 }
 
-void UpdateMaxH264Level(std::optional<webrtc::H264Level> *current,
-                        webrtc::H264Level candidate) {
+void UpdateMaxH264Level(std::optional<webrtc::H264Level> *current, webrtc::H264Level candidate) {
   if (H264LevelIsHigherThan(*current, candidate)) {
     *current = candidate;
   }
 }
 
-VideoToolboxH264ProfileLevels ParseSupportedH264ProfileLevels(
-    NSDictionary *supportedProperties) {
+VideoToolboxH264ProfileLevels ParseSupportedH264ProfileLevels(NSDictionary *supportedProperties) {
   VideoToolboxH264ProfileLevels levels;
-  NSDictionary *profileLevelProperty = [supportedProperties
-      objectForKey:(__bridge NSString *)kVTCompressionPropertyKey_ProfileLevel];
+  NSDictionary *profileLevelProperty =
+      [supportedProperties objectForKey:(__bridge NSString *)kVTCompressionPropertyKey_ProfileLevel];
   if (![profileLevelProperty isKindOfClass:[NSDictionary class]]) {
     return levels;
   }
 
-  NSArray *supportedValues =
-      [profileLevelProperty objectForKey:(__bridge NSString *)kVTPropertySupportedValueListKey];
+  NSArray *supportedValues = [profileLevelProperty objectForKey:(__bridge NSString *)kVTPropertySupportedValueListKey];
   if (![supportedValues isKindOfClass:[NSArray class]]) {
     return levels;
   }
@@ -108,60 +102,33 @@ VideoToolboxH264ProfileLevels ParseSupportedH264ProfileLevels(
   // representations; the actual capability decision comes from VideoToolbox's
   // supported value list.
   const VideoToolboxH264ProfileLevel kKnownProfileLevels[] = {
-      {kVTProfileLevel_H264_Baseline_3_0, VideoToolboxH264ProfileFamily::kBaseline,
-       webrtc::H264Level::kLevel3},
-      {kVTProfileLevel_H264_Baseline_3_1, VideoToolboxH264ProfileFamily::kBaseline,
-       webrtc::H264Level::kLevel3_1},
-      {kVTProfileLevel_H264_Baseline_3_2, VideoToolboxH264ProfileFamily::kBaseline,
-       webrtc::H264Level::kLevel3_2},
-      {kVTProfileLevel_H264_Baseline_4_0, VideoToolboxH264ProfileFamily::kBaseline,
-       webrtc::H264Level::kLevel4},
-      {kVTProfileLevel_H264_Baseline_4_1, VideoToolboxH264ProfileFamily::kBaseline,
-       webrtc::H264Level::kLevel4_1},
-      {kVTProfileLevel_H264_Baseline_4_2, VideoToolboxH264ProfileFamily::kBaseline,
-       webrtc::H264Level::kLevel4_2},
-      {kVTProfileLevel_H264_Baseline_5_0, VideoToolboxH264ProfileFamily::kBaseline,
-       webrtc::H264Level::kLevel5},
-      {kVTProfileLevel_H264_Baseline_5_1, VideoToolboxH264ProfileFamily::kBaseline,
-       webrtc::H264Level::kLevel5_1},
-      {kVTProfileLevel_H264_Baseline_5_2, VideoToolboxH264ProfileFamily::kBaseline,
-       webrtc::H264Level::kLevel5_2},
-      {kVTProfileLevel_H264_Main_3_0, VideoToolboxH264ProfileFamily::kMain,
-       webrtc::H264Level::kLevel3},
-      {kVTProfileLevel_H264_Main_3_1, VideoToolboxH264ProfileFamily::kMain,
-       webrtc::H264Level::kLevel3_1},
-      {kVTProfileLevel_H264_Main_3_2, VideoToolboxH264ProfileFamily::kMain,
-       webrtc::H264Level::kLevel3_2},
-      {kVTProfileLevel_H264_Main_4_0, VideoToolboxH264ProfileFamily::kMain,
-       webrtc::H264Level::kLevel4},
-      {kVTProfileLevel_H264_Main_4_1, VideoToolboxH264ProfileFamily::kMain,
-       webrtc::H264Level::kLevel4_1},
-      {kVTProfileLevel_H264_Main_4_2, VideoToolboxH264ProfileFamily::kMain,
-       webrtc::H264Level::kLevel4_2},
-      {kVTProfileLevel_H264_Main_5_0, VideoToolboxH264ProfileFamily::kMain,
-       webrtc::H264Level::kLevel5},
-      {kVTProfileLevel_H264_Main_5_1, VideoToolboxH264ProfileFamily::kMain,
-       webrtc::H264Level::kLevel5_1},
-      {kVTProfileLevel_H264_Main_5_2, VideoToolboxH264ProfileFamily::kMain,
-       webrtc::H264Level::kLevel5_2},
-      {kVTProfileLevel_H264_High_3_0, VideoToolboxH264ProfileFamily::kHigh,
-       webrtc::H264Level::kLevel3},
-      {kVTProfileLevel_H264_High_3_1, VideoToolboxH264ProfileFamily::kHigh,
-       webrtc::H264Level::kLevel3_1},
-      {kVTProfileLevel_H264_High_3_2, VideoToolboxH264ProfileFamily::kHigh,
-       webrtc::H264Level::kLevel3_2},
-      {kVTProfileLevel_H264_High_4_0, VideoToolboxH264ProfileFamily::kHigh,
-       webrtc::H264Level::kLevel4},
-      {kVTProfileLevel_H264_High_4_1, VideoToolboxH264ProfileFamily::kHigh,
-       webrtc::H264Level::kLevel4_1},
-      {kVTProfileLevel_H264_High_4_2, VideoToolboxH264ProfileFamily::kHigh,
-       webrtc::H264Level::kLevel4_2},
-      {kVTProfileLevel_H264_High_5_0, VideoToolboxH264ProfileFamily::kHigh,
-       webrtc::H264Level::kLevel5},
-      {kVTProfileLevel_H264_High_5_1, VideoToolboxH264ProfileFamily::kHigh,
-       webrtc::H264Level::kLevel5_1},
-      {kVTProfileLevel_H264_High_5_2, VideoToolboxH264ProfileFamily::kHigh,
-       webrtc::H264Level::kLevel5_2},
+      {kVTProfileLevel_H264_Baseline_3_0, VideoToolboxH264ProfileFamily::kBaseline, webrtc::H264Level::kLevel3},
+      {kVTProfileLevel_H264_Baseline_3_1, VideoToolboxH264ProfileFamily::kBaseline, webrtc::H264Level::kLevel3_1},
+      {kVTProfileLevel_H264_Baseline_3_2, VideoToolboxH264ProfileFamily::kBaseline, webrtc::H264Level::kLevel3_2},
+      {kVTProfileLevel_H264_Baseline_4_0, VideoToolboxH264ProfileFamily::kBaseline, webrtc::H264Level::kLevel4},
+      {kVTProfileLevel_H264_Baseline_4_1, VideoToolboxH264ProfileFamily::kBaseline, webrtc::H264Level::kLevel4_1},
+      {kVTProfileLevel_H264_Baseline_4_2, VideoToolboxH264ProfileFamily::kBaseline, webrtc::H264Level::kLevel4_2},
+      {kVTProfileLevel_H264_Baseline_5_0, VideoToolboxH264ProfileFamily::kBaseline, webrtc::H264Level::kLevel5},
+      {kVTProfileLevel_H264_Baseline_5_1, VideoToolboxH264ProfileFamily::kBaseline, webrtc::H264Level::kLevel5_1},
+      {kVTProfileLevel_H264_Baseline_5_2, VideoToolboxH264ProfileFamily::kBaseline, webrtc::H264Level::kLevel5_2},
+      {kVTProfileLevel_H264_Main_3_0, VideoToolboxH264ProfileFamily::kMain, webrtc::H264Level::kLevel3},
+      {kVTProfileLevel_H264_Main_3_1, VideoToolboxH264ProfileFamily::kMain, webrtc::H264Level::kLevel3_1},
+      {kVTProfileLevel_H264_Main_3_2, VideoToolboxH264ProfileFamily::kMain, webrtc::H264Level::kLevel3_2},
+      {kVTProfileLevel_H264_Main_4_0, VideoToolboxH264ProfileFamily::kMain, webrtc::H264Level::kLevel4},
+      {kVTProfileLevel_H264_Main_4_1, VideoToolboxH264ProfileFamily::kMain, webrtc::H264Level::kLevel4_1},
+      {kVTProfileLevel_H264_Main_4_2, VideoToolboxH264ProfileFamily::kMain, webrtc::H264Level::kLevel4_2},
+      {kVTProfileLevel_H264_Main_5_0, VideoToolboxH264ProfileFamily::kMain, webrtc::H264Level::kLevel5},
+      {kVTProfileLevel_H264_Main_5_1, VideoToolboxH264ProfileFamily::kMain, webrtc::H264Level::kLevel5_1},
+      {kVTProfileLevel_H264_Main_5_2, VideoToolboxH264ProfileFamily::kMain, webrtc::H264Level::kLevel5_2},
+      {kVTProfileLevel_H264_High_3_0, VideoToolboxH264ProfileFamily::kHigh, webrtc::H264Level::kLevel3},
+      {kVTProfileLevel_H264_High_3_1, VideoToolboxH264ProfileFamily::kHigh, webrtc::H264Level::kLevel3_1},
+      {kVTProfileLevel_H264_High_3_2, VideoToolboxH264ProfileFamily::kHigh, webrtc::H264Level::kLevel3_2},
+      {kVTProfileLevel_H264_High_4_0, VideoToolboxH264ProfileFamily::kHigh, webrtc::H264Level::kLevel4},
+      {kVTProfileLevel_H264_High_4_1, VideoToolboxH264ProfileFamily::kHigh, webrtc::H264Level::kLevel4_1},
+      {kVTProfileLevel_H264_High_4_2, VideoToolboxH264ProfileFamily::kHigh, webrtc::H264Level::kLevel4_2},
+      {kVTProfileLevel_H264_High_5_0, VideoToolboxH264ProfileFamily::kHigh, webrtc::H264Level::kLevel5},
+      {kVTProfileLevel_H264_High_5_1, VideoToolboxH264ProfileFamily::kHigh, webrtc::H264Level::kLevel5_1},
+      {kVTProfileLevel_H264_High_5_2, VideoToolboxH264ProfileFamily::kHigh, webrtc::H264Level::kLevel5_2},
   };
 
   for (id value in supportedValues) {
@@ -171,8 +138,7 @@ VideoToolboxH264ProfileLevels ParseSupportedH264ProfileLevels(
 
     CFStringRef profileLevel = (__bridge CFStringRef)value;
     for (const VideoToolboxH264ProfileLevel &knownProfileLevel : kKnownProfileLevels) {
-      if (CFStringCompare(profileLevel, knownProfileLevel.profileLevel, 0) !=
-          kCFCompareEqualTo) {
+      if (CFStringCompare(profileLevel, knownProfileLevel.profileLevel, 0) != kCFCompareEqualTo) {
         continue;
       }
 
@@ -214,8 +180,7 @@ NSDictionary *HardwareRequiredVideoToolboxEncoderSpecification() {
   // would create SDP that may not be encodable by the session we later create.
   if (@available(iOS 17.4, macCatalyst 17.4, macOS 10.9, tvOS 17.4, visionOS 1.1, *)) {
     return @{
-      (__bridge NSString *)kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder :
-          @(YES),
+      (__bridge NSString *)kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder : @(YES),
     };
   }
   return nil;
@@ -237,9 +202,7 @@ bool ShouldQueryVideoToolboxWithoutHardwareRequirement() {
 #endif
 }
 
-VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevelsForSize(
-    int32_t width,
-    int32_t height) {
+VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevelsForSize(int32_t width, int32_t height) {
   VideoToolboxH264ProfileLevels levels;
 
   if (!CanQueryVideoToolboxEncoderProperties()) {
@@ -251,17 +214,12 @@ VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevelsForSize(
     return levels;
   }
 
-  NSDictionary *encoderSpecification =
-      requireHardware ? HardwareRequiredVideoToolboxEncoderSpecification() : nil;
+  NSDictionary *encoderSpecification = requireHardware ? HardwareRequiredVideoToolboxEncoderSpecification() : nil;
 
   CFDictionaryRef supportedPropertiesRef = nullptr;
-  OSStatus status = VTCopySupportedPropertyDictionaryForEncoder(
-      width,
-      height,
-      kCMVideoCodecType_H264,
-      (__bridge CFDictionaryRef)encoderSpecification,
-      nullptr,
-      &supportedPropertiesRef);
+  OSStatus status = VTCopySupportedPropertyDictionaryForEncoder(width, height, kCMVideoCodecType_H264,
+                                                                (__bridge CFDictionaryRef)encoderSpecification, nullptr,
+                                                                &supportedPropertiesRef);
   if (status != noErr || supportedPropertiesRef == nullptr) {
     return levels;
   }
@@ -306,15 +264,12 @@ const VideoToolboxH264ProfileLevels &MaxSupportedVideoToolboxH264ProfileLevels()
   // The advertised codec list is built repeatedly, but Apple encoder
   // capabilities are effectively static for the process. Cache the query result
   // to avoid creating VideoToolbox property dictionaries on every factory call.
-  static const VideoToolboxH264ProfileLevels levels =
-      QueryVideoToolboxH264ProfileLevels();
+  static const VideoToolboxH264ProfileLevels levels = QueryVideoToolboxH264ProfileLevels();
   return levels;
 }
 
-VideoToolboxH264LevelSupport SupportedVideoToolboxLevelForProfile(
-    webrtc::H264Profile profile) {
-  const VideoToolboxH264ProfileLevels &profileLevels =
-      MaxSupportedVideoToolboxH264ProfileLevels();
+VideoToolboxH264LevelSupport SupportedVideoToolboxLevelForProfile(webrtc::H264Profile profile) {
+  const VideoToolboxH264ProfileLevels &profileLevels = MaxSupportedVideoToolboxH264ProfileLevels();
   const bool queried = HasAnyVideoToolboxH264ProfileLevel(profileLevels);
   switch (profile) {
     case webrtc::H264Profile::kProfileConstrainedBaseline:
@@ -331,10 +286,8 @@ VideoToolboxH264LevelSupport SupportedVideoToolboxLevelForProfile(
 }
 
 #if defined(WEBRTC_IOS)
-std::optional<webrtc::H264Level> SupportedUIDeviceLevelForProfile(
-    webrtc::H264Profile profile) {
-  const std::optional<webrtc::H264ProfileLevelId> profileLevelId =
-      [UIDevice maxSupportedH264Profile];
+std::optional<webrtc::H264Level> SupportedUIDeviceLevelForProfile(webrtc::H264Profile profile) {
+  const std::optional<webrtc::H264ProfileLevelId> profileLevelId = [UIDevice maxSupportedH264Profile];
   if (profileLevelId && profileLevelId->profile >= profile) {
     return profileLevelId->level;
   }
@@ -359,8 +312,7 @@ std::optional<webrtc::H264Level> FallbackLevelForCurrentPlatform() {
 #endif
 }
 
-NSString *ProfileStringForProfileAndLevel(webrtc::H264Profile profile,
-                                          webrtc::H264Level level) {
+NSString *ProfileStringForProfileAndLevel(webrtc::H264Profile profile, webrtc::H264Level level) {
   const std::optional<std::string> profileString =
       H264ProfileLevelIdToString(webrtc::H264ProfileLevelId(profile, level));
   if (profileString) {
@@ -378,10 +330,8 @@ NSString *MaxSupportedLevelForProfile(webrtc::H264Profile profile) {
   //    VideoToolbox returned no useful H264 profile list. If VideoToolbox
   //    reports a list but omits this profile family, avoid inventing support for
   //    it and let the caller use the historical WebRTC constants instead.
-  const VideoToolboxH264LevelSupport videoToolboxSupport =
-      SupportedVideoToolboxLevelForProfile(profile);
-  std::optional<webrtc::H264Level> supportedLevel =
-      videoToolboxSupport.level;
+  const VideoToolboxH264LevelSupport videoToolboxSupport = SupportedVideoToolboxLevelForProfile(profile);
+  std::optional<webrtc::H264Level> supportedLevel = videoToolboxSupport.level;
 #if defined(WEBRTC_IOS)
   if (!supportedLevel) {
     supportedLevel = SupportedUIDeviceLevelForProfile(profile);
@@ -400,8 +350,7 @@ NSString *MaxSupportedLevelForProfile(webrtc::H264Profile profile) {
 
 NSString *MaxSupportedProfileLevelConstrainedBaseline() {
 #if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
-  NSString *profile = MaxSupportedLevelForProfile(
-      webrtc::H264Profile::kProfileConstrainedBaseline);
+  NSString *profile = MaxSupportedLevelForProfile(webrtc::H264Profile::kProfileConstrainedBaseline);
   if (profile != nil) {
     return profile;
   }

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
@@ -15,6 +15,9 @@
 #if defined(WEBRTC_IOS)
 #import "UIDevice+H264Profile.h"
 #endif
+#if defined(WEBRTC_MAC)
+#import <VideoToolbox/VideoToolbox.h>
+#endif
 
 #include "api/video_codecs/h264_profile_level_id.h"
 #include "media/base/media_constants.h"
@@ -38,6 +41,180 @@ namespace {
 
 #if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
 
+#if defined(WEBRTC_MAC)
+
+struct VideoToolboxH264ProfileLevels {
+  std::optional<webrtc::H264Level> constrainedBaseline;
+  std::optional<webrtc::H264Level> constrainedHigh;
+};
+
+enum class VideoToolboxH264ProfileFamily {
+  kBaseline,
+  kHigh,
+};
+
+struct VideoToolboxH264ProfileLevel {
+  CFStringRef profileLevel;
+  VideoToolboxH264ProfileFamily family;
+  webrtc::H264Level level;
+};
+
+bool H264LevelIsHigherThan(std::optional<webrtc::H264Level> current,
+                           webrtc::H264Level candidate) {
+  return !current ||
+      static_cast<int>(candidate) > static_cast<int>(*current);
+}
+
+void UpdateMaxH264Level(std::optional<webrtc::H264Level> *current,
+                        webrtc::H264Level candidate) {
+  if (H264LevelIsHigherThan(*current, candidate)) {
+    *current = candidate;
+  }
+}
+
+VideoToolboxH264ProfileLevels ParseSupportedH264ProfileLevels(
+    NSDictionary *supportedProperties) {
+  VideoToolboxH264ProfileLevels levels;
+  NSDictionary *profileLevelProperty = [supportedProperties
+      objectForKey:(__bridge NSString *)kVTCompressionPropertyKey_ProfileLevel];
+  if (![profileLevelProperty isKindOfClass:[NSDictionary class]]) {
+    return levels;
+  }
+
+  NSArray *supportedValues =
+      [profileLevelProperty objectForKey:(__bridge NSString *)kVTPropertySupportedValueListKey];
+  if (![supportedValues isKindOfClass:[NSArray class]]) {
+    return levels;
+  }
+
+  const VideoToolboxH264ProfileLevel kKnownProfileLevels[] = {
+      {kVTProfileLevel_H264_Baseline_3_0, VideoToolboxH264ProfileFamily::kBaseline,
+       webrtc::H264Level::kLevel3},
+      {kVTProfileLevel_H264_Baseline_3_1, VideoToolboxH264ProfileFamily::kBaseline,
+       webrtc::H264Level::kLevel3_1},
+      {kVTProfileLevel_H264_Baseline_3_2, VideoToolboxH264ProfileFamily::kBaseline,
+       webrtc::H264Level::kLevel3_2},
+      {kVTProfileLevel_H264_Baseline_4_0, VideoToolboxH264ProfileFamily::kBaseline,
+       webrtc::H264Level::kLevel4},
+      {kVTProfileLevel_H264_Baseline_4_1, VideoToolboxH264ProfileFamily::kBaseline,
+       webrtc::H264Level::kLevel4_1},
+      {kVTProfileLevel_H264_Baseline_4_2, VideoToolboxH264ProfileFamily::kBaseline,
+       webrtc::H264Level::kLevel4_2},
+      {kVTProfileLevel_H264_Baseline_5_0, VideoToolboxH264ProfileFamily::kBaseline,
+       webrtc::H264Level::kLevel5},
+      {kVTProfileLevel_H264_Baseline_5_1, VideoToolboxH264ProfileFamily::kBaseline,
+       webrtc::H264Level::kLevel5_1},
+      {kVTProfileLevel_H264_Baseline_5_2, VideoToolboxH264ProfileFamily::kBaseline,
+       webrtc::H264Level::kLevel5_2},
+      {kVTProfileLevel_H264_High_3_0, VideoToolboxH264ProfileFamily::kHigh,
+       webrtc::H264Level::kLevel3},
+      {kVTProfileLevel_H264_High_3_1, VideoToolboxH264ProfileFamily::kHigh,
+       webrtc::H264Level::kLevel3_1},
+      {kVTProfileLevel_H264_High_3_2, VideoToolboxH264ProfileFamily::kHigh,
+       webrtc::H264Level::kLevel3_2},
+      {kVTProfileLevel_H264_High_4_0, VideoToolboxH264ProfileFamily::kHigh,
+       webrtc::H264Level::kLevel4},
+      {kVTProfileLevel_H264_High_4_1, VideoToolboxH264ProfileFamily::kHigh,
+       webrtc::H264Level::kLevel4_1},
+      {kVTProfileLevel_H264_High_4_2, VideoToolboxH264ProfileFamily::kHigh,
+       webrtc::H264Level::kLevel4_2},
+      {kVTProfileLevel_H264_High_5_0, VideoToolboxH264ProfileFamily::kHigh,
+       webrtc::H264Level::kLevel5},
+      {kVTProfileLevel_H264_High_5_1, VideoToolboxH264ProfileFamily::kHigh,
+       webrtc::H264Level::kLevel5_1},
+      {kVTProfileLevel_H264_High_5_2, VideoToolboxH264ProfileFamily::kHigh,
+       webrtc::H264Level::kLevel5_2},
+  };
+
+  for (id value in supportedValues) {
+    if (![value isKindOfClass:[NSString class]]) {
+      continue;
+    }
+
+    CFStringRef profileLevel = (__bridge CFStringRef)value;
+    for (const VideoToolboxH264ProfileLevel &knownProfileLevel : kKnownProfileLevels) {
+      if (CFStringCompare(profileLevel, knownProfileLevel.profileLevel, 0) !=
+          kCFCompareEqualTo) {
+        continue;
+      }
+
+      switch (knownProfileLevel.family) {
+        case VideoToolboxH264ProfileFamily::kBaseline:
+          UpdateMaxH264Level(&levels.constrainedBaseline, knownProfileLevel.level);
+          break;
+        case VideoToolboxH264ProfileFamily::kHigh:
+          UpdateMaxH264Level(&levels.constrainedHigh, knownProfileLevel.level);
+          break;
+      }
+    }
+  }
+
+  return levels;
+}
+
+VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevelsForSize(
+    int32_t width,
+    int32_t height) {
+  VideoToolboxH264ProfileLevels levels;
+
+  if (@available(macOS 10.13, *)) {
+    NSDictionary *encoderSpecification = @{
+      (__bridge NSString *)kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder :
+          @(YES),
+    };
+
+    CFDictionaryRef supportedPropertiesRef = nullptr;
+    OSStatus status = VTCopySupportedPropertyDictionaryForEncoder(
+        width,
+        height,
+        kCMVideoCodecType_H264,
+        (__bridge CFDictionaryRef)encoderSpecification,
+        nullptr,
+        &supportedPropertiesRef);
+    if (status != noErr || supportedPropertiesRef == nullptr) {
+      return levels;
+    }
+
+    NSDictionary *supportedProperties = CFBridgingRelease(supportedPropertiesRef);
+    return ParseSupportedH264ProfileLevels(supportedProperties);
+  }
+
+  return levels;
+}
+
+VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevels() {
+  VideoToolboxH264ProfileLevels levels;
+  const struct {
+    int32_t width;
+    int32_t height;
+  } kQuerySizes[] = {
+      {3840, 2160},
+      {1920, 1080},
+      {1280, 720},
+  };
+
+  for (const auto &querySize : kQuerySizes) {
+    VideoToolboxH264ProfileLevels queryLevels =
+        QueryVideoToolboxH264ProfileLevelsForSize(querySize.width, querySize.height);
+    if (queryLevels.constrainedBaseline) {
+      UpdateMaxH264Level(&levels.constrainedBaseline, *queryLevels.constrainedBaseline);
+    }
+    if (queryLevels.constrainedHigh) {
+      UpdateMaxH264Level(&levels.constrainedHigh, *queryLevels.constrainedHigh);
+    }
+  }
+
+  return levels;
+}
+
+const VideoToolboxH264ProfileLevels &MaxSupportedH264ProfileLevelsFromVideoToolbox() {
+  static const VideoToolboxH264ProfileLevels levels =
+      QueryVideoToolboxH264ProfileLevels();
+  return levels;
+}
+
+#endif
+
 NSString *MaxSupportedLevelForProfile(webrtc::H264Profile profile) {
 #if defined(WEBRTC_IOS)
   const std::optional<webrtc::H264ProfileLevelId> profileLevelId =
@@ -50,7 +227,33 @@ NSString *MaxSupportedLevelForProfile(webrtc::H264Profile profile) {
     }
   }
 #elif defined(WEBRTC_MAC)
-  // macOS has no per-device H264 table here; Level 3.1 rejects 1080p30 in VideoToolbox.
+  const VideoToolboxH264ProfileLevels &profileLevels =
+      MaxSupportedH264ProfileLevelsFromVideoToolbox();
+  std::optional<webrtc::H264Level> supportedLevel;
+  switch (profile) {
+    case webrtc::H264Profile::kProfileConstrainedBaseline:
+    case webrtc::H264Profile::kProfileBaseline:
+      supportedLevel = profileLevels.constrainedBaseline;
+      break;
+    case webrtc::H264Profile::kProfileConstrainedHigh:
+    case webrtc::H264Profile::kProfileHigh:
+    case webrtc::H264Profile::kProfilePredictiveHigh444:
+      supportedLevel = profileLevels.constrainedHigh;
+      break;
+    case webrtc::H264Profile::kProfileMain:
+      break;
+  }
+
+  if (supportedLevel) {
+    const std::optional<std::string> profileString = H264ProfileLevelIdToString(
+        webrtc::H264ProfileLevelId(profile, *supportedLevel));
+    if (profileString) {
+      return [NSString stringForStdString:*profileString];
+    }
+  }
+
+  // Keep macOS above Level 3.1 if VideoToolbox cannot return a useful profile
+  // list. Level 3.1 rejects 1080p30 before encoding starts.
   const std::optional<std::string> profileString = H264ProfileLevelIdToString(
       webrtc::H264ProfileLevelId(profile, webrtc::H264Level::kLevel5));
   if (profileString) {

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
@@ -36,9 +36,10 @@ NSString *const RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBase
 
 namespace {
 
-#if defined(WEBRTC_IOS)
+#if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
 
 NSString *MaxSupportedLevelForProfile(webrtc::H264Profile profile) {
+#if defined(WEBRTC_IOS)
   const std::optional<webrtc::H264ProfileLevelId> profileLevelId =
       [UIDevice maxSupportedH264Profile];
   if (profileLevelId && profileLevelId->profile >= profile) {
@@ -48,12 +49,20 @@ NSString *MaxSupportedLevelForProfile(webrtc::H264Profile profile) {
       return [NSString stringForStdString:*profileString];
     }
   }
+#elif defined(WEBRTC_MAC)
+  // macOS has no per-device H264 table here; Level 3.1 rejects 1080p30 in VideoToolbox.
+  const std::optional<std::string> profileString = H264ProfileLevelIdToString(
+      webrtc::H264ProfileLevelId(profile, webrtc::H264Level::kLevel5));
+  if (profileString) {
+    return [NSString stringForStdString:*profileString];
+  }
+#endif
   return nil;
 }
 #endif
 
 NSString *MaxSupportedProfileLevelConstrainedBaseline() {
-#if defined(WEBRTC_IOS)
+#if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
   NSString *profile = MaxSupportedLevelForProfile(
       webrtc::H264Profile::kProfileConstrainedBaseline);
   if (profile != nil) {
@@ -64,7 +73,7 @@ NSString *MaxSupportedProfileLevelConstrainedBaseline() {
 }
 
 NSString *MaxSupportedProfileLevelConstrainedHigh() {
-#if defined(WEBRTC_IOS)
+#if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
   NSString *profile =
       MaxSupportedLevelForProfile(webrtc::H264Profile::kProfileConstrainedHigh);
   if (profile != nil) {

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
@@ -42,6 +42,10 @@ namespace {
 
 #if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
 
+// H264 sender capabilities are advertised through SDP profile-level-id strings,
+// but the Apple encoder is configured with VideoToolbox profile-level constants.
+// Keep this helper as the single place where Apple runtime capabilities are
+// converted back into WebRTC's H264Profile/H264Level model.
 struct VideoToolboxH264ProfileLevels {
   std::optional<webrtc::H264Level> constrainedBaseline;
   std::optional<webrtc::H264Level> main;
@@ -88,6 +92,11 @@ VideoToolboxH264ProfileLevels ParseSupportedH264ProfileLevels(
     return levels;
   }
 
+  // This is not a device capability table. VideoToolbox returns its supported
+  // profile levels as CFString constants, while WebRTC stores them as enums.
+  // The fixed list below is only the ABI translation layer between those two
+  // representations; the actual capability decision comes from VideoToolbox's
+  // supported value list.
   const VideoToolboxH264ProfileLevel kKnownProfileLevels[] = {
       {kVTProfileLevel_H264_Baseline_3_0, VideoToolboxH264ProfileFamily::kBaseline,
        webrtc::H264Level::kLevel3},
@@ -189,6 +198,10 @@ bool CanRequireHardwareAcceleratedVideoToolboxEncoder() {
 }
 
 NSDictionary *HardwareRequiredVideoToolboxEncoderSpecification() {
+  // On platforms where this key is available, ask VideoToolbox specifically for
+  // the hardware encoder's property dictionary. The encoder path itself also
+  // prefers hardware acceleration, so advertising software-only H264 levels here
+  // would create SDP that may not be encodable by the session we later create.
   if (@available(iOS 17.4, macCatalyst 17.4, macOS 10.9, tvOS 17.4, visionOS 1.1, *)) {
     return @{
       (__bridge NSString *)kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder :
@@ -200,8 +213,16 @@ NSDictionary *HardwareRequiredVideoToolboxEncoderSpecification() {
 
 bool ShouldQueryVideoToolboxWithoutHardwareRequirement() {
 #if defined(WEBRTC_IOS) && TARGET_OS_IOS && !TARGET_OS_SIMULATOR && !TARGET_OS_MACCATALYST
+  // Before iOS 17.4, VideoToolbox exposes the property query API but not the
+  // "require hardware encoder" selector. For physical iPhone/iPad builds, keep
+  // using the known device table in that case instead of accepting a possibly
+  // software-backed capability list.
   return false;
 #else
+  // Other Apple targets either do not have an iOS device table fallback
+  // (macOS/Catalyst/tvOS/visionOS) or are simulator builds where software
+  // encoding is already expected. Querying VideoToolbox is still the best
+  // available signal for those targets when the hardware selector is unavailable.
   return true;
 #endif
 }
@@ -241,6 +262,10 @@ VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevelsForSize(
 
 VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevels() {
   VideoToolboxH264ProfileLevels levels;
+  // VideoToolbox capability dictionaries can vary by requested dimensions.
+  // Probe representative high-to-common sender sizes and keep the highest level
+  // returned for each profile family so we do not under-advertise devices that
+  // expose their larger H264 levels only for larger encode configurations.
   const struct {
     int32_t width;
     int32_t height;
@@ -268,6 +293,9 @@ VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevels() {
 }
 
 const VideoToolboxH264ProfileLevels &MaxSupportedVideoToolboxH264ProfileLevels() {
+  // The advertised codec list is built repeatedly, but Apple encoder
+  // capabilities are effectively static for the process. Cache the query result
+  // to avoid creating VideoToolbox property dictionaries on every factory call.
   static const VideoToolboxH264ProfileLevels levels =
       QueryVideoToolboxH264ProfileLevels();
   return levels;
@@ -305,10 +333,17 @@ std::optional<webrtc::H264Level> SupportedUIDeviceLevelForProfile(
 
 std::optional<webrtc::H264Level> FallbackLevelForCurrentPlatform() {
 #if defined(WEBRTC_IOS) && TARGET_OS_IOS && !TARGET_OS_SIMULATOR && !TARGET_OS_MACCATALYST
+  // Physical iOS has the UIDevice table fallback above. If both VideoToolbox and
+  // the table fail, fall through to the historical WebRTC Level 3.1 constants
+  // rather than inventing a level for an unknown iOS device.
   return std::nullopt;
 #else
-  // Keep non-iOS-device Apple platforms above Level 3.1 if VideoToolbox cannot
-  // return a useful profile list. Level 3.1 rejects 1080p30 before encoding starts.
+  // Native macOS used to fall back to Level 3.1 because it did not have the iOS
+  // UIDevice table. That is too low for common captures: Level 3.1 caps
+  // 1920x1080 to roughly 13 fps, which causes VideoToolbox to reject 1080p30
+  // and the sender to time out. Level 5 matches the previous LiveKit workaround
+  // and keeps non-iOS-device Apple targets above that failure mode when the
+  // runtime query cannot return a useful profile list.
   return webrtc::H264Level::kLevel5;
 #endif
 }
@@ -324,6 +359,12 @@ NSString *ProfileStringForProfileAndLevel(webrtc::H264Profile profile,
 }
 
 NSString *MaxSupportedLevelForProfile(webrtc::H264Profile profile) {
+  // Selection order:
+  // 1. Prefer VideoToolbox, because it reflects the current machine/OS encoder.
+  // 2. On iOS, keep the UIDevice table as a conservative fallback for older OSes
+  //    where VideoToolbox cannot be constrained to the hardware encoder.
+  // 3. For non-iOS-device Apple platforms, fall back to Level 5 rather than the
+  //    historical WebRTC Level 3.1 constants that break 1080p30 sends.
   std::optional<webrtc::H264Level> supportedLevel =
       SupportedVideoToolboxLevelForProfile(profile);
 #if defined(WEBRTC_IOS)

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
@@ -221,6 +221,9 @@ VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevelsForSize(int32_t 
                                                                 (__bridge CFDictionaryRef)encoderSpecification, nullptr,
                                                                 &supportedPropertiesRef);
   if (status != noErr || supportedPropertiesRef == nullptr) {
+    if (supportedPropertiesRef != nullptr) {
+      CFRelease(supportedPropertiesRef);
+    }
     return levels;
   }
 

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
@@ -15,7 +15,8 @@
 #if defined(WEBRTC_IOS)
 #import "UIDevice+H264Profile.h"
 #endif
-#if defined(WEBRTC_MAC)
+#if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
+#import <TargetConditionals.h>
 #import <VideoToolbox/VideoToolbox.h>
 #endif
 
@@ -41,15 +42,15 @@ namespace {
 
 #if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
 
-#if defined(WEBRTC_MAC)
-
 struct VideoToolboxH264ProfileLevels {
   std::optional<webrtc::H264Level> constrainedBaseline;
+  std::optional<webrtc::H264Level> main;
   std::optional<webrtc::H264Level> constrainedHigh;
 };
 
 enum class VideoToolboxH264ProfileFamily {
   kBaseline,
+  kMain,
   kHigh,
 };
 
@@ -106,6 +107,24 @@ VideoToolboxH264ProfileLevels ParseSupportedH264ProfileLevels(
        webrtc::H264Level::kLevel5_1},
       {kVTProfileLevel_H264_Baseline_5_2, VideoToolboxH264ProfileFamily::kBaseline,
        webrtc::H264Level::kLevel5_2},
+      {kVTProfileLevel_H264_Main_3_0, VideoToolboxH264ProfileFamily::kMain,
+       webrtc::H264Level::kLevel3},
+      {kVTProfileLevel_H264_Main_3_1, VideoToolboxH264ProfileFamily::kMain,
+       webrtc::H264Level::kLevel3_1},
+      {kVTProfileLevel_H264_Main_3_2, VideoToolboxH264ProfileFamily::kMain,
+       webrtc::H264Level::kLevel3_2},
+      {kVTProfileLevel_H264_Main_4_0, VideoToolboxH264ProfileFamily::kMain,
+       webrtc::H264Level::kLevel4},
+      {kVTProfileLevel_H264_Main_4_1, VideoToolboxH264ProfileFamily::kMain,
+       webrtc::H264Level::kLevel4_1},
+      {kVTProfileLevel_H264_Main_4_2, VideoToolboxH264ProfileFamily::kMain,
+       webrtc::H264Level::kLevel4_2},
+      {kVTProfileLevel_H264_Main_5_0, VideoToolboxH264ProfileFamily::kMain,
+       webrtc::H264Level::kLevel5},
+      {kVTProfileLevel_H264_Main_5_1, VideoToolboxH264ProfileFamily::kMain,
+       webrtc::H264Level::kLevel5_1},
+      {kVTProfileLevel_H264_Main_5_2, VideoToolboxH264ProfileFamily::kMain,
+       webrtc::H264Level::kLevel5_2},
       {kVTProfileLevel_H264_High_3_0, VideoToolboxH264ProfileFamily::kHigh,
        webrtc::H264Level::kLevel3},
       {kVTProfileLevel_H264_High_3_1, VideoToolboxH264ProfileFamily::kHigh,
@@ -142,6 +161,9 @@ VideoToolboxH264ProfileLevels ParseSupportedH264ProfileLevels(
         case VideoToolboxH264ProfileFamily::kBaseline:
           UpdateMaxH264Level(&levels.constrainedBaseline, knownProfileLevel.level);
           break;
+        case VideoToolboxH264ProfileFamily::kMain:
+          UpdateMaxH264Level(&levels.main, knownProfileLevel.level);
+          break;
         case VideoToolboxH264ProfileFamily::kHigh:
           UpdateMaxH264Level(&levels.constrainedHigh, knownProfileLevel.level);
           break;
@@ -152,34 +174,69 @@ VideoToolboxH264ProfileLevels ParseSupportedH264ProfileLevels(
   return levels;
 }
 
+bool CanQueryVideoToolboxEncoderProperties() {
+  if (@available(iOS 11.0, macCatalyst 13.0, macOS 10.13, tvOS 11.0, visionOS 1.0, *)) {
+    return true;
+  }
+  return false;
+}
+
+bool CanRequireHardwareAcceleratedVideoToolboxEncoder() {
+  if (@available(iOS 17.4, macCatalyst 17.4, macOS 10.9, tvOS 17.4, visionOS 1.1, *)) {
+    return true;
+  }
+  return false;
+}
+
+NSDictionary *HardwareRequiredVideoToolboxEncoderSpecification() {
+  if (@available(iOS 17.4, macCatalyst 17.4, macOS 10.9, tvOS 17.4, visionOS 1.1, *)) {
+    return @{
+      (__bridge NSString *)kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder :
+          @(YES),
+    };
+  }
+  return nil;
+}
+
+bool ShouldQueryVideoToolboxWithoutHardwareRequirement() {
+#if defined(WEBRTC_IOS) && TARGET_OS_IOS && !TARGET_OS_SIMULATOR && !TARGET_OS_MACCATALYST
+  return false;
+#else
+  return true;
+#endif
+}
+
 VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevelsForSize(
     int32_t width,
     int32_t height) {
   VideoToolboxH264ProfileLevels levels;
 
-  if (@available(macOS 10.13, *)) {
-    NSDictionary *encoderSpecification = @{
-      (__bridge NSString *)kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder :
-          @(YES),
-    };
-
-    CFDictionaryRef supportedPropertiesRef = nullptr;
-    OSStatus status = VTCopySupportedPropertyDictionaryForEncoder(
-        width,
-        height,
-        kCMVideoCodecType_H264,
-        (__bridge CFDictionaryRef)encoderSpecification,
-        nullptr,
-        &supportedPropertiesRef);
-    if (status != noErr || supportedPropertiesRef == nullptr) {
-      return levels;
-    }
-
-    NSDictionary *supportedProperties = CFBridgingRelease(supportedPropertiesRef);
-    return ParseSupportedH264ProfileLevels(supportedProperties);
+  if (!CanQueryVideoToolboxEncoderProperties()) {
+    return levels;
   }
 
-  return levels;
+  const bool requireHardware = CanRequireHardwareAcceleratedVideoToolboxEncoder();
+  if (!requireHardware && !ShouldQueryVideoToolboxWithoutHardwareRequirement()) {
+    return levels;
+  }
+
+  NSDictionary *encoderSpecification =
+      requireHardware ? HardwareRequiredVideoToolboxEncoderSpecification() : nil;
+
+  CFDictionaryRef supportedPropertiesRef = nullptr;
+  OSStatus status = VTCopySupportedPropertyDictionaryForEncoder(
+      width,
+      height,
+      kCMVideoCodecType_H264,
+      (__bridge CFDictionaryRef)encoderSpecification,
+      nullptr,
+      &supportedPropertiesRef);
+  if (status != noErr || supportedPropertiesRef == nullptr) {
+    return levels;
+  }
+
+  NSDictionary *supportedProperties = CFBridgingRelease(supportedPropertiesRef);
+  return ParseSupportedH264ProfileLevels(supportedProperties);
 }
 
 VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevels() {
@@ -199,6 +256,9 @@ VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevels() {
     if (queryLevels.constrainedBaseline) {
       UpdateMaxH264Level(&levels.constrainedBaseline, *queryLevels.constrainedBaseline);
     }
+    if (queryLevels.main) {
+      UpdateMaxH264Level(&levels.main, *queryLevels.main);
+    }
     if (queryLevels.constrainedHigh) {
       UpdateMaxH264Level(&levels.constrainedHigh, *queryLevels.constrainedHigh);
     }
@@ -207,59 +267,77 @@ VideoToolboxH264ProfileLevels QueryVideoToolboxH264ProfileLevels() {
   return levels;
 }
 
-const VideoToolboxH264ProfileLevels &MaxSupportedH264ProfileLevelsFromVideoToolbox() {
+const VideoToolboxH264ProfileLevels &MaxSupportedVideoToolboxH264ProfileLevels() {
   static const VideoToolboxH264ProfileLevels levels =
       QueryVideoToolboxH264ProfileLevels();
   return levels;
 }
 
-#endif
-
-NSString *MaxSupportedLevelForProfile(webrtc::H264Profile profile) {
-#if defined(WEBRTC_IOS)
-  const std::optional<webrtc::H264ProfileLevelId> profileLevelId =
-      [UIDevice maxSupportedH264Profile];
-  if (profileLevelId && profileLevelId->profile >= profile) {
-    const std::optional<std::string> profileString = H264ProfileLevelIdToString(
-        webrtc::H264ProfileLevelId(profile, profileLevelId->level));
-    if (profileString) {
-      return [NSString stringForStdString:*profileString];
-    }
-  }
-#elif defined(WEBRTC_MAC)
+std::optional<webrtc::H264Level> SupportedVideoToolboxLevelForProfile(
+    webrtc::H264Profile profile) {
   const VideoToolboxH264ProfileLevels &profileLevels =
-      MaxSupportedH264ProfileLevelsFromVideoToolbox();
-  std::optional<webrtc::H264Level> supportedLevel;
+      MaxSupportedVideoToolboxH264ProfileLevels();
   switch (profile) {
     case webrtc::H264Profile::kProfileConstrainedBaseline:
     case webrtc::H264Profile::kProfileBaseline:
-      supportedLevel = profileLevels.constrainedBaseline;
-      break;
+      return profileLevels.constrainedBaseline;
+    case webrtc::H264Profile::kProfileMain:
+      return profileLevels.main;
     case webrtc::H264Profile::kProfileConstrainedHigh:
     case webrtc::H264Profile::kProfileHigh:
     case webrtc::H264Profile::kProfilePredictiveHigh444:
-      supportedLevel = profileLevels.constrainedHigh;
-      break;
-    case webrtc::H264Profile::kProfileMain:
-      break;
+      return profileLevels.constrainedHigh;
   }
+  return std::nullopt;
+}
 
-  if (supportedLevel) {
-    const std::optional<std::string> profileString = H264ProfileLevelIdToString(
-        webrtc::H264ProfileLevelId(profile, *supportedLevel));
-    if (profileString) {
-      return [NSString stringForStdString:*profileString];
-    }
+#if defined(WEBRTC_IOS)
+std::optional<webrtc::H264Level> SupportedUIDeviceLevelForProfile(
+    webrtc::H264Profile profile) {
+  const std::optional<webrtc::H264ProfileLevelId> profileLevelId =
+      [UIDevice maxSupportedH264Profile];
+  if (profileLevelId && profileLevelId->profile >= profile) {
+    return profileLevelId->level;
   }
+  return std::nullopt;
+}
+#endif
 
-  // Keep macOS above Level 3.1 if VideoToolbox cannot return a useful profile
-  // list. Level 3.1 rejects 1080p30 before encoding starts.
-  const std::optional<std::string> profileString = H264ProfileLevelIdToString(
-      webrtc::H264ProfileLevelId(profile, webrtc::H264Level::kLevel5));
+std::optional<webrtc::H264Level> FallbackLevelForCurrentPlatform() {
+#if defined(WEBRTC_IOS) && TARGET_OS_IOS && !TARGET_OS_SIMULATOR && !TARGET_OS_MACCATALYST
+  return std::nullopt;
+#else
+  // Keep non-iOS-device Apple platforms above Level 3.1 if VideoToolbox cannot
+  // return a useful profile list. Level 3.1 rejects 1080p30 before encoding starts.
+  return webrtc::H264Level::kLevel5;
+#endif
+}
+
+NSString *ProfileStringForProfileAndLevel(webrtc::H264Profile profile,
+                                          webrtc::H264Level level) {
+  const std::optional<std::string> profileString =
+      H264ProfileLevelIdToString(webrtc::H264ProfileLevelId(profile, level));
   if (profileString) {
     return [NSString stringForStdString:*profileString];
   }
+  return nil;
+}
+
+NSString *MaxSupportedLevelForProfile(webrtc::H264Profile profile) {
+  std::optional<webrtc::H264Level> supportedLevel =
+      SupportedVideoToolboxLevelForProfile(profile);
+#if defined(WEBRTC_IOS)
+  if (!supportedLevel) {
+    supportedLevel = SupportedUIDeviceLevelForProfile(profile);
+  }
 #endif
+  if (!supportedLevel) {
+    supportedLevel = FallbackLevelForCurrentPlatform();
+  }
+
+  if (supportedLevel) {
+    return ProfileStringForProfileAndLevel(profile, *supportedLevel);
+  }
   return nil;
 }
 #endif

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -795,6 +795,9 @@ const char *H264ProfileName(const std::optional<webrtc::H264ProfileLevelId> &id)
     } else {
       RTC_LOG(LS_INFO) << "Compression session created with hw accl disabled";
     }
+    if (hwaccl_enabled) {
+      CFRelease(hwaccl_enabled);
+    }
   }
   [self configureCompressionSession];
 
@@ -995,4 +998,3 @@ const char *H264ProfileName(const std::optional<webrtc::H264ProfileLevelId> &id)
 }
 
 @end
-

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm
@@ -434,6 +434,9 @@ void compressionOutputCallback(void* encoder, void* params, OSStatus status,
     } else {
       RTC_LOG(LS_INFO) << "Compression session created with hw accl disabled";
     }
+    if (hwaccl_enabled) {
+      CFRelease(hwaccl_enabled);
+    }
   }
   [self configureCompressionSession];
   return WEBRTC_VIDEO_CODEC_OK;


### PR DESCRIPTION
## Summary

- Query VideoToolbox on Apple platforms to derive the max advertised H.264 level per profile family.
- Translate VideoToolbox profile-level constants into WebRTC's `H264Profile` / `H264Level` model. The fixed list is a constant mapping, not a device capability table; the capability decision still comes from VideoToolbox's supported value list.
- Keep the existing iOS `UIDevice` capability table as the conservative fallback for older physical iOS builds where VideoToolbox cannot be constrained to the hardware encoder.
- Avoid the historical Level 3.1 fallback on macOS/Catalyst/simulator-style Apple targets when VideoToolbox returns no useful H.264 profile list, since Level 3.1 can make 1080p30 non-simulcast publishing fail.
- If VideoToolbox returns a useful H.264 list but omits a profile family, do not invent support for that profile family. Let the caller fall back to WebRTC's historical constants instead.
- Preserve the existing H.264 profile ordering: ConstrainedHigh remains first for VideoToolbox's low-latency hardware path, and ConstrainedBaseline remains available for interop fallback.
- Declare the direct `VideoToolbox.framework` dependency from `sdk:videocodec_objc`, because `RTCH264ProfileLevelId.mm` now owns VideoToolbox symbol references.

## Context

LiveKitWebRTC should advertise Apple H.264 encoder capabilities accurately from the WebRTC SDK itself, without relying on downstream SDP profile-level rewrites.

Physical iOS already had a device capability table, but macOS/Catalyst did not. Those targets could still fall back to WebRTC's Level 3.1 constants, which cap 1920x1080 to roughly 13 fps and can lead to VideoToolbox encode failures for 1080p30 publishing.

This patch moves that decision into the WebRTC SDK's Apple H.264 profile-level code by asking VideoToolbox what the current platform supports, while keeping the older iOS table as a fallback where it is still the safer signal.

The H.264 VideoToolbox encoder only enables `kVTVideoEncoderSpecification_EnableLowLatencyRateControl` for High-family profiles, because applying it with Baseline/Main disables hardware acceleration. Keeping ConstrainedHigh first preserves that low-latency path when negotiation supports it.

## Validation

- `git diff --check origin/m144_release...HEAD`
- Earlier local compile check before the latest review-only follow-ups: `autoninja -C out/codex-mac sdk:videocodec_objc`
