### PR TITLE
Allow keyring size 256 and bounds-guard GetKeySet

### DIFF
--- a/api/crypto/frame_crypto_transformer.h
+++ b/api/crypto/frame_crypto_transformer.h
@@ -32,7 +32,7 @@
 namespace webrtc {
 
 const size_t DEFAULT_KEYRING_SIZE = 16;
-const size_t MAX_KEYRING_SIZE = 255;
+const size_t MAX_KEYRING_SIZE = 256;
 
 class ParticipantKeyHandler;
 
@@ -153,7 +153,11 @@ class ParticipantKeyHandler : public webrtc::RefCountInterface {
 
   virtual webrtc::scoped_refptr<KeySet> GetKeySet(int key_index) {
     webrtc::MutexLock lock(&mutex_);
-    return crypto_key_ring_[key_index != -1 ? key_index : current_key_index_];
+    int idx = key_index != -1 ? key_index : current_key_index_;
+    if (idx < 0 || static_cast<size_t>(idx) >= crypto_key_ring_.size()) {
+      return nullptr;
+    }
+    return crypto_key_ring_[idx];
   }
 
   virtual void SetKey(std::vector<uint8_t> password, int key_index) {

--- a/api/crypto/frame_crypto_transformer_unittest.cc
+++ b/api/crypto/frame_crypto_transformer_unittest.cc
@@ -241,4 +241,36 @@ TEST(KeyProvider, KeyDerivationAlgorithm) {
   EXPECT_NE(encrypted_data.value()->iv, encrypted_data2.value()->iv);
 }
 
+TEST(KeyProvider, KeyRingSizeMaxAcceptsIndex255) {
+  auto key_options = KeyProviderOptions();
+  key_options.shared_key = true;
+  key_options.key_ring_size = static_cast<int>(MAX_KEYRING_SIZE);
+  auto key_provider =
+      webrtc::make_ref_counted<DefaultKeyProviderImpl>(key_options);
+
+  const std::vector<uint8_t> key{0xAA, 0xBB, 0xCC, 0xDD};
+  EXPECT_TRUE(key_provider->SetSharedKey(255, key));
+  EXPECT_EQ(key_provider->ExportSharedKey(255), key);
+}
+
+TEST(KeyProvider, GetKeySetReturnsNullptrForOutOfRange) {
+  auto key_options = KeyProviderOptions();
+  key_options.shared_key = true;
+  auto key_provider =
+      webrtc::make_ref_counted<DefaultKeyProviderImpl>(key_options);
+  ASSERT_TRUE(key_provider->SetSharedKey(0, std::vector<uint8_t>{0x00}));
+
+  auto key_handler = key_provider->GetSharedKey("participant_1");
+  ASSERT_NE(key_handler, nullptr);
+
+  // -1 is the "use current_key_index_" sentinel — still resolves.
+  EXPECT_NE(key_handler->GetKeySet(-1), nullptr);
+  // DEFAULT_KEYRING_SIZE (16) → indices >= 16 are out of range.
+  EXPECT_EQ(key_handler->GetKeySet(static_cast<int>(DEFAULT_KEYRING_SIZE)),
+            nullptr);
+  EXPECT_EQ(key_handler->GetKeySet(1000), nullptr);
+  // Negative indices other than the -1 sentinel are out of range.
+  EXPECT_EQ(key_handler->GetKeySet(-2), nullptr);
+}
+
 }  // namespace webrtc


### PR DESCRIPTION
Fixes livekit/client-sdk-swift#1030 (companion test reproducer: livekit/client-sdk-swift#1032).

The Swift/Android/Flutter/Rust SDKs abort the process with `libc++ Hardening assertion __n < size() failed: vector[] index out of bounds` when a caller looks up key index 255 in a key ring configured for size 256. The root cause is `MAX_KEYRING_SIZE = 255` silently clamping a requested 256 to a 255-entry vector, combined with `GetKeySet()` indexing the vector with no bounds check. The JS reference implementation already validates `keyringSize` as `1..=256` ([client-sdk-js ParticipantKeyHandler.ts L43–L46](https://github.com/livekit/client-sdk-js/blob/main/src/e2ee/worker/ParticipantKeyHandler.ts#L43-L46)) and its lookup returns `undefined` rather than aborting on out-of-range reads ([L210](https://github.com/livekit/client-sdk-js/blob/main/src/e2ee/worker/ParticipantKeyHandler.ts#L210)). This PR bumps `MAX_KEYRING_SIZE` to 256 — matching both the documented contract ("Keyring size needs to be between 1 and 256") and the JS reference — and makes `GetKeySet()` return `nullptr` for out-of-range indices. Every existing caller (`ExportSharedKey`, `ExportKey`, `RatchetKey`, the decrypt path) already null-checks the result, so this turns the abort into the same observable failure JS produces.