### PR TITLE
Fix AudioEngineDevice crash from null FineAudioBuffer on playout/record start

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -486,6 +486,10 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   int32_t ApplyDeviceEngineState(EngineStateUpdate state);
   int32_t ApplyManualEngineState(EngineStateUpdate state);
 
+  // Recreates `fine_audio_buffer_` if null: the enable steps that create it and
+  // the buffer-start steps that use it have different conditions.
+  void EnsureFineAudioBuffer();
+
   // AudioEngine observer methods. May be called from any thread.
   void ReconfigureEngine();
 

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1620,6 +1620,14 @@ void AudioEngineDevice::ReconfigureEngine() {
   }));
 }
 
+void AudioEngineDevice::EnsureFineAudioBuffer() {
+  RTC_DCHECK_RUN_ON(thread_);
+  if (fine_audio_buffer_ == nullptr) {
+    LOGE() << "fine_audio_buffer_ was null at buffer start; recreating";
+    fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
+  }
+}
+
 int32_t AudioEngineDevice::ModifyEngineState(
     std::function<EngineState(EngineState)> state_transform) {
   RTC_DCHECK_RUN_ON(thread_);
@@ -1915,6 +1923,7 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
     }
     LOGI() << "Starting playout buffer (Manual)...";
     audio_device_buffer_->StartPlayout();
+    EnsureFineAudioBuffer();
     fine_audio_buffer_->ResetPlayout();
 
     rollback_actions.push_back([this]() {
@@ -1934,6 +1943,7 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
     }
     LOGI() << "Starting record buffer (Manual)...";
     audio_device_buffer_->StartRecording();
+    EnsureFineAudioBuffer();
     fine_audio_buffer_->ResetRecord();
 
     rollback_actions.push_back([this]() {
@@ -2875,6 +2885,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     }
     LOGI() << "Starting Playout buffer...";
     audio_device_buffer_->StartPlayout();
+    EnsureFineAudioBuffer();
     fine_audio_buffer_->ResetPlayout();
 
     rollback_actions.push_back([this]() {
@@ -2896,6 +2907,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     }
     LOGI() << "Starting Record buffer...";
     audio_device_buffer_->StartRecording();
+    EnsureFineAudioBuffer();
     fine_audio_buffer_->ResetRecord();
 
     rollback_actions.push_back([this]() {


### PR DESCRIPTION
## Summary
Fixes the `worker_thread` crash in **livekit/client-sdk-swift#929** (mis-titled "`webrtc::FrequencyTracker`"). Re-symbolicating the reports shows the fault is a **null `fine_audio_buffer_->ResetPlayout()`/`ResetRecord()`** in `AudioEngineDevice`'s buffer-start path — not `FrequencyTracker`/BWE/ICE (nearest-exported symbols in a stripped build).

## Root cause
In Device mode `IsOutputEnabled()` is `IsInputEnabled() || output_enabled`, so `StopPlayout()` with the mic still on keeps `next.IsOutputEnabled() == true` and routes into the buffer-start branch. That branch derefs `fine_audio_buffer_`, but the step that *creates* it has a different condition and is skipped; the buffer is reset to null on rollback paths (device-unavailable/connect failure during a route change) without committing `engine_state_`, so a later `StopPlayout` hits the deref with `nullptr`.

m144 is likely hit more often than m137: m137 gated the `IsInputEnabled() || output_enabled` form behind `voice_processing_enabled`, whereas m144 made it unconditional, so the paradox routing now fires even without voice processing.

The fix recreates the buffer at the point of use rather than widening the enable-block condition: the buffer is a cheap, side-effect-free adapter over the always-valid `audio_device_buffer_`, whereas the enable block also does irreversible AVFoundation node setup and the (shared) buffer can be nulled independently by *either* the output or input rollback.

A complementary hardening — making `fine_audio_buffer_` a `shared_ptr` that the realtime render/record callbacks capture by value, so a `reset()` on `thread_` can't free a buffer mid-callback — addresses a *distinct* engine-restart race (not this crash) and will follow separately.

## Reports validated (same bug in all three)

| Report | SDK | WebRTC | Faulting call |
|---|---|---|---|
| Initial report — https://github.com/livekit/client-sdk-swift/issues/929 (+ attached Crashlytics dump) | 2.11.0 | 137.7151.10 | `fine_audio_buffer_->ResetRecord()` |
| https://github.com/livekit/client-sdk-swift/issues/929#issuecomment-4510280050 | 2.14.0 | 144.7559.04 | `fine_audio_buffer_->ResetPlayout()` |
| https://github.com/livekit/client-sdk-swift/issues/929#issuecomment-4692858816 (still crashing after the ICE fix) | 2.15.0 | 144.7559.08 | `fine_audio_buffer_->ResetPlayout()` |

## Symbolication (real identity vs. nearest-export name)

| Frame | 2.11 | 2.14 | 2.15 | Real identity |
|---|---|---|---|---|
| 0 | `0x3fe8e4` | `0x33cc5c` | `0x33f9b8` | `FineAudioBuffer::Reset{Record,Playout}` leaf — faulting `str xzr,[x0,#…]` |
| 1 | `0x3f6744` | `0x333858` | `0x335fb4` | `ApplyDeviceEngineState` (buffer-start) |
| 2 | `0x3f0534` | `0x32d414` | `0x32f5e4` | `ModifyEngineState` |
| 3 | `0x3f0a80` | `0x32d960` | `0x32fb30` | `AudioEngineDevice::StopPlayout` |
| 4 | `0x49e940` | `0x3e52cc` | `0x3e9b54` | ADM vtable dispatch (`SetPlayout`/`SetRecording`) |
| 5 | `0x450088` | `0x391334` | `0x395bbc` | `WebRtcVoiceMediaChannel::SetPlayout` |
| 6 | `0x1a89a4` | `0x826ae4` | `0x82c2b8` | `VoiceChannel::ChangeState` |
| 7 | `0x1a73a4` | `0x825494` | `0x82ac68` | `BaseChannel::Disable` |
| 8 | `0x1a885c` | `0x8269a0` | `0x82c174` | `VoiceChannel::~VoiceChannel` |
| 9 | `0x1a8914` | `0x826a54` | `0x82c228` | channel-teardown thunk |
| top | `Thread::Dispatch` → `ProcessMessages` → `PreRun` | ← | ← | worker thread running a posted task |

Validated against each exact `ios-arm64` binary (`ProcessMessages`/`PreRun` anchors match `nm`; every frame connects via a real `bl`/`blr`). m137 faulted in the record twin, m144 in the playout twin — same null `fine_audio_buffer_`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
