### PR TITLE
Fix TaskQueueGcd self-deadlock when a task queue is deleted from its own task

### DIFF
--- a/api/crypto/frame_crypto_transformer_unittest.cc
+++ b/api/crypto/frame_crypto_transformer_unittest.cc
@@ -1,10 +1,11 @@
 #include "api/crypto/frame_crypto_transformer.h"
 
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "rtc_base/logging.h"
-#include "system_wrappers/include/sleep.h"
 #include "test/gmock.h"
 #include "test/gtest.h"
 
@@ -194,13 +195,13 @@ TEST(DataPacketCryptor, IVGeneration) {
   auto data_packet_cryptor = webrtc::make_ref_counted<DataPacketCryptor>(
       FrameCryptorTransformer::Algorithm::kAesGcm, key_provider);
   EXPECT_NE(data_packet_cryptor, nullptr);
-  SleepMs(200);
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
   auto encrypted_data = data_packet_cryptor->Encrypt(
       participant_id, 0,
       std::vector<uint8_t>(
           {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}));
   EXPECT_TRUE(encrypted_data.ok());
-  SleepMs(200);  // ensure different timestamp for IV generation
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));  // ensure different timestamp for IV generation
   auto encrypted_data2 = data_packet_cryptor->Encrypt(
       participant_id, 0,
       std::vector<uint8_t>(
@@ -225,13 +226,13 @@ TEST(KeyProvider, KeyDerivationAlgorithm) {
   auto data_packet_cryptor = webrtc::make_ref_counted<DataPacketCryptor>(
       FrameCryptorTransformer::Algorithm::kAesGcm, key_provider);
   EXPECT_NE(data_packet_cryptor, nullptr);
-  SleepMs(200);
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
   auto encrypted_data = data_packet_cryptor->Encrypt(
       participant_id, 0,
       std::vector<uint8_t>(
           {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}));
   EXPECT_TRUE(encrypted_data.ok());
-  SleepMs(200);  // ensure different timestamp for IV generation
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));  // ensure different timestamp for IV generation
   auto encrypted_data2 = data_packet_cryptor->Encrypt(
       participant_id, 0,
       std::vector<uint8_t>(

--- a/modules/audio_device/audio_device_unittest.cc
+++ b/modules/audio_device/audio_device_unittest.cc
@@ -595,7 +595,8 @@ class MAYBE_AudioDeviceTest
     // The value of `audio_layer_` is set at construction by GetParam() and two
     // different layers are tested on Windows only.
     if (audio_layer_ == AudioDeviceModule::kPlatformDefaultAudio) {
-      return AudioDeviceModuleImpl::Create(env_, audio_layer_);
+      return AudioDeviceModuleImpl::Create(env_, audio_layer_,
+                                           /*bypass_voice_processing=*/false);
     } else if (audio_layer_ == AudioDeviceModule::kWindowsCoreAudio2) {
 #ifdef WEBRTC_WIN
       // We must initialize the COM library on a thread before we calling any of

--- a/rtc_base/BUILD.gn
+++ b/rtc_base/BUILD.gn
@@ -2196,6 +2196,7 @@ if (rtc_include_tests) {
         ":task_queue_for_test",
         ":timeutils",
         "../api/task_queue",
+        "../api/task_queue:default_task_queue_factory",
         "../api/units:time_delta",
         "../test:test_main",
         "../test:test_support",

--- a/rtc_base/task_queue_gcd.cc
+++ b/rtc_base/task_queue_gcd.cc
@@ -91,7 +91,6 @@ TaskQueueGcd::TaskQueueGcd(absl::string_view queue_name, int gcd_priority)
 TaskQueueGcd::~TaskQueueGcd() = default;
 
 void TaskQueueGcd::Delete() {
-  RTC_DCHECK(!IsCurrent());
   // Implementation/behavioral note:
   // Dispatch queues are reference counted via calls to dispatch_retain and
   // dispatch_release. Pending blocks submitted to a queue also hold a
@@ -99,9 +98,17 @@ void TaskQueueGcd::Delete() {
   // queue have been released, the queue will be deallocated by the system.
   // This is why we check the is_active_ before running tasks.
 
-  // Use dispatch_sync to set the is_active_ to guarantee that there's not a
-  // race with checking it from a task.
-  dispatch_sync_f(queue_, this, &SetNotActive);
+  if (IsCurrent()) {
+    // Called from a task running on this queue (e.g. the last reference to an
+    // object owning this queue is dropped by an in-flight task). We are already
+    // serialized on the queue, so set is_active_ directly; dispatch_sync onto
+    // the current queue would deadlock.
+    SetNotActive(this);
+  } else {
+    // Use dispatch_sync to set the is_active_ to guarantee that there's not a
+    // race with checking it from a task.
+    dispatch_sync_f(queue_, this, &SetNotActive);
+  }
   dispatch_release(queue_);
 }
 

--- a/rtc_base/task_queue_gcd.cc
+++ b/rtc_base/task_queue_gcd.cc
@@ -31,6 +31,12 @@
 namespace webrtc {
 namespace {
 
+// Key for dispatch_queue_set_specific(); the associated value identifies the
+// owning TaskQueueGcd. Unlike the TaskQueueBase thread-local, which is only
+// set while RunTask() executes, dispatch_get_specific() detects any code
+// running on the queue (or a queue targeting it).
+char queue_specific_key;
+
 int TaskQueuePriorityToGCD(TaskQueueFactory::Priority priority) {
   switch (priority) {
     case TaskQueueFactory::Priority::NORMAL:
@@ -83,6 +89,8 @@ TaskQueueGcd::TaskQueueGcd(absl::string_view queue_name, int gcd_priority)
       is_active_(true) {
   RTC_CHECK(queue_);
   dispatch_set_context(queue_, this);
+  dispatch_queue_set_specific(queue_, &queue_specific_key, this,
+                              /*destructor=*/nullptr);
   // Assign a finalizer that will delete the queue when the last reference
   // is released. This may run after the TaskQueue::Delete.
   dispatch_set_finalizer_f(queue_, &DeleteQueue);
@@ -98,8 +106,8 @@ void TaskQueueGcd::Delete() {
   // queue have been released, the queue will be deallocated by the system.
   // This is why we check the is_active_ before running tasks.
 
-  if (IsCurrent()) {
-    // Called from a task running on this queue (e.g. the last reference to an
+  if (dispatch_get_specific(&queue_specific_key) == this) {
+    // Called from code running on this queue (e.g. the last reference to an
     // object owning this queue is dropped by an in-flight task). We are already
     // serialized on the queue, so set is_active_ directly; dispatch_sync onto
     // the current queue would deadlock.

--- a/rtc_base/task_queue_gcd.cc
+++ b/rtc_base/task_queue_gcd.cc
@@ -31,10 +31,6 @@
 namespace webrtc {
 namespace {
 
-// Key for dispatch_queue_set_specific(); the associated value identifies the
-// owning TaskQueueGcd. Unlike the TaskQueueBase thread-local, which is only
-// set while RunTask() executes, dispatch_get_specific() detects any code
-// running on the queue (or a queue targeting it).
 char queue_specific_key;
 
 int TaskQueuePriorityToGCD(TaskQueueFactory::Priority priority) {
@@ -89,6 +85,10 @@ TaskQueueGcd::TaskQueueGcd(absl::string_view queue_name, int gcd_priority)
       is_active_(true) {
   RTC_CHECK(queue_);
   dispatch_set_context(queue_, this);
+  // Tag the queue so Delete() can detect being called from code running on
+  // this queue. Unlike the TaskQueueBase thread-local, which is only set
+  // while RunTask() executes, dispatch_get_specific() detects any code
+  // running on the queue (or a queue targeting it).
   dispatch_queue_set_specific(queue_, &queue_specific_key, this,
                               /*destructor=*/nullptr);
   // Assign a finalizer that will delete the queue when the last reference

--- a/rtc_base/task_queue_unittest.cc
+++ b/rtc_base/task_queue_unittest.cc
@@ -9,7 +9,10 @@
  */
 
 #include <cstdint>
+#include <utility>
 
+#include "api/task_queue/default_task_queue_factory.h"
+#include "api/task_queue/task_queue_base.h"
 #include "api/task_queue/task_queue_factory.h"
 #include "api/units/time_delta.h"
 #include "rtc_base/event.h"
@@ -72,5 +75,24 @@ TEST(TaskQueueTest, DISABLED_PostDelayedHighRes) {
   EXPECT_GE(end - start, 3u);
   EXPECT_NEAR(end - start, 3, 3u);
 }
+
+#if defined(WEBRTC_MAC) || defined(WEBRTC_IOS)
+// The GCD task queue supports deletion from a task running on it, which
+// happens when an in-flight task drops the last reference to an object that
+// owns the queue (e.g. RTPSenderVideoFrameTransformerDelegate during
+// teardown). Other backends join their worker thread in Delete() and cannot
+// support this.
+TEST(TaskQueueTest, DeleteQueueFromOwnTask) {
+  Event event;
+  auto queue = CreateDefaultTaskQueueFactory()->CreateTaskQueue(
+      "delete_from_own_task", TaskQueueFactory::Priority::NORMAL);
+  TaskQueueBase* raw = queue.get();
+  raw->PostTask([queue = std::move(queue), &event]() mutable {
+    queue = nullptr;
+    event.Set();
+  });
+  EXPECT_TRUE(event.Wait(TimeDelta::Seconds(10)));
+}
+#endif
 
 }  // namespace webrtc


### PR DESCRIPTION
## Problem

`TaskQueueGcd::Delete()` does an unconditional `dispatch_sync_f(queue_, …)`. When `Delete()` is reached from a task running on that queue, this is a `dispatch_sync` onto the current serial queue → GCD traps in `__DISPATCH_WAIT_FOR_QUEUE__`. The `RTC_DCHECK(!IsCurrent())` guarding it is compiled out in release, so release builds crash instead of asserting.

This happens in practice: `RTPSenderVideoFrameTransformerDelegate` owns its `video_frame_transformer` queue and posts tasks holding a strong self-ref. When the sender drops its reference during teardown/renegotiation while a frame is in flight, the task holds the last ref — so the delegate destructor runs on its own queue and destroys the queue it's running on. Requires a frame transformer (E2EE / Insertable Streams).

Fixes: livekit/client-sdk-swift#1054

## Fix

When already on the queue, set `is_active_` directly — we're serialized, so there's no reader to race with; queue teardown via the `dispatch_set_finalizer_f` callback is unchanged:

```cpp
if (dispatch_get_specific(&queue_specific_key) == this) {
  SetNotActive(this);
} else {
  dispatch_sync_f(queue_, this, &SetNotActive);
}
dispatch_release(queue_);
```

Detection uses a queue-specific (set at construction) rather than `IsCurrent()`: it sees any code running on the queue, not just tasks dispatched through `RunTask`, so the guard can't silently regress if a future dispatch site bypasses it. Off-queue callers are unchanged; the only behavior change is that on-queue `Delete()` (previously assert/deadlock) now completes.

## Tests

- New `TaskQueueTest.DeleteQueueFromOwnTask` (mac/iOS-only): passes with the fix; without it, DCHECK-abort in debug and the `__DISPATCH_WAIT_FOR_QUEUE__` SIGTRAP with DCHECKs compiled out. The off-queue branch is covered by the existing suite.
- Drive-by fixes so the m144 test suites build: `frame_crypto_transformer_unittest.cc` (upstream removed `sleep.h`) and `audio_device_unittest.cc` (fork-added `bypass_voice_processing` param).

<details>
<summary>Resymbolicated crash chain and minimal reproducer</summary>

The reporter's trace is nearest-export symbolicated (framework is stripped); re-symbolicated against the `144.7559.10` ios-arm64 binary:

| Reported | Real identity |
|---|---|
| `FieldTrialsRegistry::Lookup +956` | `TaskQueueGcd::RunTask` |
| `StatsReport::Value::bool_val +29084` | `RefCountedObject<…Delegate>::Release` (last ref) |
| `StatsReport::Value::bool_val +29276` | `~RTPSenderVideoFrameTransformerDelegate` |
| `FieldTrialsRegistry::Lookup +500` | `TaskQueueGcd::Delete` → `dispatch_sync_f` |

```c
// clang repro.c && ./a.out  →  SIGTRAP: __DISPATCH_WAIT_FOR_QUEUE__
#include <dispatch/dispatch.h>
#include <stdatomic.h>
#include <stdlib.h>

typedef struct { _Atomic int rc; dispatch_queue_t q; } Owner;

static void release(Owner *o) {
  if (atomic_fetch_sub(&o->rc, 1) == 1) {
    dispatch_sync(o->q, ^{});               // == TaskQueueGcd::Delete() on its own queue
    free(o);
  }
}

int main(void) {
  Owner *o = calloc(1, sizeof *o);
  o->rc = 1;
  o->q = dispatch_queue_create("video_frame_transformer", DISPATCH_QUEUE_SERIAL);
  atomic_fetch_add(&o->rc, 1);
  dispatch_async(o->q, ^{ release(o); });   // in-flight task holds a ref
  release(o);                               // sender drops its ref during teardown
  dispatch_main();
}
```

</details>
