### PR TITLE
Expose C++ factory for the AudioEngine audio device module

### DIFF
--- a/api/audio/BUILD.gn
+++ b/api/audio/BUILD.gn
@@ -57,8 +57,15 @@ if (rtc_include_internal_audio_device) {
       "create_audio_device_module.cc",
       "create_audio_device_module.h",
     ]
+    if (is_mac || is_ios) {
+      sources += [
+        "create_audio_engine_device_module.h",
+        "create_audio_engine_device_module.mm",
+      ]
+    }
     deps = [
       ":audio_device",
+      "..:make_ref_counted",
       "..:scoped_refptr",
       "../../modules/audio_device:audio_device_impl",
       "../environment",

--- a/api/audio/audio_device.h
+++ b/api/audio/audio_device.h
@@ -47,6 +47,9 @@ class AudioDeviceModule : public RefCountInterface {
     kAndroidAAudioAudio,
     kAndroidJavaInputAndAAudioOutputAudio,
     kDummyAudio,
+#if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
+    kAppleAudioEngine,
+#endif
   };
 
   enum WindowsDeviceType { kDefaultCommunicationDevice = -1, kDefaultDevice = -2 };

--- a/api/audio/create_audio_device_module.cc
+++ b/api/audio/create_audio_device_module.cc
@@ -12,6 +12,9 @@
 
 #include "absl/base/nullability.h"
 #include "api/audio/audio_device.h"
+#if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
+#include "api/audio/create_audio_engine_device_module.h"
+#endif
 #include "api/environment/environment.h"
 #include "api/scoped_refptr.h"
 #include "modules/audio_device/audio_device_impl.h"
@@ -22,6 +25,12 @@ absl_nullable scoped_refptr<AudioDeviceModule> CreateAudioDeviceModule(
     const Environment& env,
     AudioDeviceModule::AudioLayer audio_layer,
     bool bypass_voice_processing) {
+#if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
+  if (audio_layer == AudioDeviceModule::kAppleAudioEngine) {
+    return CreateAudioEngineDeviceModule(env, bypass_voice_processing);
+  }
+#endif
+
   return AudioDeviceModuleImpl::Create(env, audio_layer, bypass_voice_processing);
 }
 

--- a/api/audio/create_audio_engine_device_module.h
+++ b/api/audio/create_audio_engine_device_module.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef API_AUDIO_CREATE_AUDIO_ENGINE_DEVICE_MODULE_H_
+#define API_AUDIO_CREATE_AUDIO_ENGINE_DEVICE_MODULE_H_
+
+#include "absl/base/nullability.h"
+#include "api/audio/audio_device.h"
+#include "api/environment/environment.h"
+#include "api/scoped_refptr.h"
+
+namespace webrtc {
+
+#if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)
+// Creates an AVAudioEngine based AudioDeviceModule.
+//
+// The returned module binds to the thread it is created on and expects all
+// control calls (Init, StartPlayout, RegisterAudioCallback, destruction, ...)
+// on that same thread. Call this on the worker thread, as
+// RTCPeerConnectionFactory does for its AudioEngine device type.
+absl_nullable scoped_refptr<AudioDeviceModule> CreateAudioEngineDeviceModule(
+    const Environment& env,
+    bool bypass_voice_processing);
+#endif
+
+}  // namespace webrtc
+
+#endif  // API_AUDIO_CREATE_AUDIO_ENGINE_DEVICE_MODULE_H_

--- a/api/audio/create_audio_engine_device_module.mm
+++ b/api/audio/create_audio_engine_device_module.mm
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "api/audio/create_audio_engine_device_module.h"
+
+#include "api/make_ref_counted.h"
+#include "modules/audio_device/audio_engine_device.h"
+
+namespace webrtc {
+
+absl_nullable scoped_refptr<AudioDeviceModule> CreateAudioEngineDeviceModule(
+    const Environment& env,
+    bool bypass_voice_processing) {
+  return make_ref_counted<AudioEngineDevice>(env, bypass_voice_processing);
+}
+
+}  // namespace webrtc


### PR DESCRIPTION
## What

Exposes a plain C++ entry point for the AVAudioEngine based ADM so C++ consumers (the LiveKit Rust SDK) can create it without going through the Objective-C SDK layer:

- `api/audio/create_audio_engine_device_module.{h,mm}`: new `CreateAudioEngineDeviceModule(env, bypass_voice_processing)` factory, gated to `WEBRTC_IOS || WEBRTC_MAC`.
- `api/audio/audio_device.h`: new `AudioDeviceModule::kAppleAudioEngine` audio layer (appended after `kDummyAudio`, no existing enum values change).
- `api/audio/create_audio_device_module.cc`: `CreateAudioDeviceModule()` dispatches `kAppleAudioEngine` to the new factory.
- `api/audio/BUILD.gn`: adds the new sources to the existing `create_audio_device_module` target, which already depends on `modules/audio_device:audio_device_impl` where `AudioEngineDevice` lives, so the factory is part of the aggregated `webrtc` library with no new targets.

## Why

The LiveKit Rust SDK links libwebrtc through C++ APIs only. Its ADM proxy needs to create the AudioEngine ADM on the worker thread the same way `RTCPeerConnectionFactory` does for `RTCAudioDeviceModuleTypeAudioEngine`, and there was previously no way to reach `AudioEngineDevice` from outside the ObjC layer.

## Notes for review

- The factory mirrors the exact construction expression used in `RTCPeerConnectionFactory.mm` (`make_ref_counted<AudioEngineDevice>(env, bypass)`).
- `AudioEngineDevice` binds to its construction thread and DCHECKs all control calls on it. The header documents that callers must create and drive the module on the worker thread.
- Pure addition: no behavior change for existing consumers. `kPlatformDefaultAudio` still selects the AudioUnit/CoreAudio HAL ADMs.