### PR TITLE
Fix RTCStatsCollector crash for stopped transceivers

### DIFF
--- a/pc/rtc_stats_collector.cc
+++ b/pc/rtc_stats_collector.cc
@@ -1754,6 +1754,10 @@ void RTCStatsCollector::ProduceRTPStreamStats_n(
   Thread::ScopedDisallowBlockingCalls no_blocking_calls;
 
   for (const RtpTransceiverStatsInfo& stats : transceiver_stats_infos) {
+    if (stats.current_direction == RtpTransceiverDirection::kStopped) {
+      continue;
+    }
+
     if (stats.media_type == MediaType::AUDIO) {
       ProduceAudioRTPStreamStats_n(timestamp, stats, report);
     } else if (stats.media_type == MediaType::VIDEO) {

--- a/pc/rtc_stats_collector_unittest.cc
+++ b/pc/rtc_stats_collector_unittest.cc
@@ -964,6 +964,31 @@ TEST_F(RTCStatsCollectorTest, ToJsonProducesParseableJson) {
   EXPECT_EQ(report->size(), json_value.size());
 }
 
+TEST_F(RTCStatsCollectorTest, ProduceRTPStreamStatsWithStoppedTransceiver) {
+  const char kTransportName[] = "transport";
+  const char kMid[] = "VideoMid";
+
+  VideoMediaInfo video_media_info;
+  video_media_info.senders.emplace_back();
+  video_media_info.senders[0].add_ssrc(1);
+
+  pc_->AddVideoChannel(kMid, kTransportName, video_media_info);
+
+  // Get the transceiver and set it to stopped.
+  std::vector<scoped_refptr<RtpTransceiverProxyWithInternal<RtpTransceiver>>>
+      transceivers = pc_->GetTransceiversInternal();
+  ASSERT_FALSE(transceivers.empty());
+  scoped_refptr<RtpTransceiverProxyWithInternal<RtpTransceiver>> transceiver =
+      transceivers[0];
+  ASSERT_TRUE(transceiver);
+  transceiver->internal()->set_current_direction(
+      RtpTransceiverDirection::kStopped);
+
+  // This should not crash.
+  scoped_refptr<const RTCStatsReport> report = stats_->GetStatsReport();
+  EXPECT_TRUE(report);
+}
+
 TEST_F(RTCStatsCollectorTest, CollectRTCCertificateStatsSingle) {
   const char kTransportName[] = "transport";
 


### PR DESCRIPTION
Backport of upstream [`0b6045b38b`](https://webrtc-review.googlesource.com/c/src/+/458680) ("Prevent RTCStatsCollector crash for stopped transceivers", M147). A `getStats` issued between `transceiver.stopInternal()` and the answer applying the rejected m-section prepares an `RtpTransceiverStatsInfo` with `mid`/`transport_name` set but an uninitialized `TrackMediaInfoMap`, so `ProduceVideoRTPStreamStats_n` dereferences the disengaged `video_media_info()` optional on the network thread (libc++ hardening abort in release, `Check failed: is_initialized_` in debug). This adds the missing `kStopped` guard to `ProduceRTPStreamStats_n` plus the upstream regression test, which crashes before and passes after this change.

Resymbolicated crash stack (LiveKitWebRTC 144.7559.10; identical shape on 144.7559.08):

```
Thread name: network_thread — "optional:940 … operator-> called on a disengaged value"
3  LiveKitWebRTC  +0x941ae8  libc++ hardening assert → abort()
4  LiveKitWebRTC  +0x85ecbc  RTCStatsCollector::ProduceVideoRTPStreamStats_n  (video_media_info()->receivers)
5  LiveKitWebRTC  +0x85ad5c  RTCStatsCollector::ProduceRTPStreamStats_n  (loop over RtpTransceiverStatsInfo)
6  LiveKitWebRTC  +0x85a48c  RTCStatsCollector::ProducePartialResultsOnNetworkThread
7  LiveKitWebRTC  +0x860de4  absl::AnyInvocable thunk
8  LiveKitWebRTC             webrtc::Thread::Dispatch(absl::AnyInvocable<void () &&>) + 160
```

Fixes livekit/client-sdk-swift#1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)