### PR TITLE
Cast DEFAULT_KEYRING_SIZE to int in test

### DIFF
--- a/api/crypto/frame_crypto_transformer_unittest.cc
+++ b/api/crypto/frame_crypto_transformer_unittest.cc
@@ -124,7 +124,7 @@ TEST(DataPacketCryptor, DifferentKeyProvider) {
   RTC_LOG(LS_INFO) << "DataPacketCrypt shared_key default: "
                    << key_options.shared_key;
   EXPECT_EQ(key_options.shared_key, false);
-  EXPECT_EQ(key_options.key_ring_size, DEFAULT_KEYRING_SIZE);
+  EXPECT_EQ(key_options.key_ring_size, static_cast<int>(DEFAULT_KEYRING_SIZE));
   // support ratcheting
   key_options.ratchet_window_size = 4;
   key_options.ratchet_salt =

--- a/api/crypto/frame_crypto_transformer_unittest.cc
+++ b/api/crypto/frame_crypto_transformer_unittest.cc
@@ -16,7 +16,7 @@ TEST(FrameCryptor, KeyProvider) {
   RTC_LOG(LS_INFO) << "DataPacketCrypt shared_key default: "
                    << key_options.shared_key;
   EXPECT_EQ(key_options.shared_key, false);
-  EXPECT_EQ(key_options.key_ring_size, DEFAULT_KEYRING_SIZE);
+  EXPECT_EQ(key_options.key_ring_size, static_cast<int>(DEFAULT_KEYRING_SIZE));
 
   key_options.ratchet_salt =
       std::vector<uint8_t>({0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});


### PR DESCRIPTION
Was causing test build errors.

Failure here: https://github.com/webrtc-sdk/webrtc-build/actions/runs/28862776017/job/85605278136