### PR TITLE
Remove blocking mic permission request from AudioEngine pre-enable check (m144)

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -512,8 +512,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   std::vector<std::string> input_device_labels_;
 #endif
 
-  bool IsMicrophonePermissionGranted();
-  bool EnsureMicrophonePermissionSync();
+  bool IsMicrophonePermissionAuthorized();
 
 #if !TARGET_OS_OSX
   bool IsAudioSessionCategoryValid(NSString* category, bool is_input_enabled,

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -2283,8 +2283,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     if (state.DidEnableInput()) {
       LOGI() << "Checking microphone permission...";
       // Attempt to acquire mic permissions at this point to return an erorr early.
-      bool isAuthorized = EnsureMicrophonePermissionSync();
-      LOGI() << "AudioEngine pre-enable check, device permission: "
+      bool isAuthorized = IsMicrophonePermissionAuthorized();
+      LOGI() << "AudioEngine pre-enable check, mic permission authorized: "
              << (isAuthorized ? "true" : "false");
       if (!isAuthorized) {
         return rollback(kAudioEngineErrorInsufficientDevicePermission);
@@ -3183,36 +3183,9 @@ void AudioEngineDevice::UpdateAllDeviceIDs() {
 // ----------------------------------------------------------------------------------------------------
 // Private - Microphone permission
 
-bool AudioEngineDevice::IsMicrophonePermissionGranted() {
+bool AudioEngineDevice::IsMicrophonePermissionAuthorized() {
   AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
   return status == AVAuthorizationStatusAuthorized;
-}
-
-bool AudioEngineDevice::EnsureMicrophonePermissionSync() {
-  AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
-
-  if (status == AVAuthorizationStatusAuthorized) {
-    return true;
-  }
-
-  if (status == AVAuthorizationStatusNotDetermined) {
-    // Request permission synchronously - this will block WebRTC's worker thread
-    // but this is acceptable since instantiating AVAudioInputNode would block anyway
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-    __block BOOL granted = NO;
-
-    [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio
-                             completionHandler:^(BOOL granted_inner) {
-                               granted = granted_inner;
-                               dispatch_semaphore_signal(semaphore);
-                             }];
-
-    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-    return granted;
-  }
-
-  // Status is denied or restricted
-  return false;
 }
 
 // ----------------------------------------------------------------------------------------------------

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -2282,7 +2282,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     // At this point mic permissions / session should be configured for recording.
     if (state.DidEnableInput()) {
       LOGI() << "Checking microphone permission...";
-      // Attempt to acquire mic permissions at this point to return an erorr early.
+      // Passively check the current authorization status to fail early without blocking.
+      // Requesting permission is the SDK's responsibility (gated to the foreground).
       bool isAuthorized = IsMicrophonePermissionAuthorized();
       LOGI() << "AudioEngine pre-enable check, mic permission authorized: "
              << (isAuthorized ? "true" : "false");


### PR DESCRIPTION
Forward-port of #204 (originally targeting `m137_release`) to `m144_release`, which is the line currently shipped by the LiveKit Swift SDK (`main` pins `144.7559.10`). The blocking call was never ported forward, so it still lives on `m144_release`.

## Problem

`EnsureMicrophonePermissionSync()` blocks the WebRTC worker thread on a semaphore (`dispatch_semaphore_wait(…, DISPATCH_TIME_FOREVER)`) until the user answers the mic permission dialog. When the app is woken in the background (e.g. an incoming CallKit call), no dialog can appear, so `setEngineAvailability` hangs indefinitely.

Ref: livekit/client-sdk-swift#815

## Change

Replace the blocking request with a passive `IsMicrophonePermissionAuthorized()` check in the AudioEngine pre-enable path. When the mic is not authorized it returns `kAudioEngineErrorInsufficientDevicePermission` instead of blocking. The (dead) `IsMicrophonePermissionGranted()` is renamed into that check; it had no other callers.

Only the `.notDetermined` case changes behavior: previously it prompted and blocked the worker thread; now it returns an error immediately. `authorized` and `denied`/`restricted` are unchanged.