### PR TITLE
android: fix AudioRecord released under a live reader when the stop join times out

### DIFF
--- a/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
+++ b/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
@@ -663,11 +663,11 @@ class WebRtcAudioRecord {
     Logging.d(TAG, "stopRecordingIfNeeded");
     synchronized(audioRecordStateLock) {
       clientCalledStartRecording.set(false);
-      if(audioThread != null) {
-        return stopRecordingIfNeededImpl();
+      if (audioThread == null) {
+        return true;
       }
     }
-    return true;
+    return stopRecordingIfNeededImpl();
   }
 
   @CalledByNative
@@ -676,19 +676,25 @@ class WebRtcAudioRecord {
     synchronized(audioRecordStateLock) {
       nativeCalledStartRecording.set(false);
       nativeCalledInitRecording.set(false);
-      return stopRecordingIfNeededImpl();
     }
+    return stopRecordingIfNeededImpl();
   }
 
   private boolean stopRecordingIfNeededImpl() {
+    final AudioRecordThread stoppingThread;
+    final @Nullable AudioRecord stoppingRecord;
     synchronized(audioRecordStateLock) {
       if(clientCalledStartRecording.get() || nativeCalledStartRecording.get()) {
         // Someone has still requested recording, ignore stop request.
         return true;
       }
 
+      if (audioThread == null) {
+        // Already stopped by a concurrent caller.
+        return true;
+      }
+
       Logging.d(TAG, "stopping recording");
-      assertTrue(audioThread != null);
       if (future != null) {
         if (!future.isDone()) {
           // Might be needed if the client calls startRecording(), stopRecording() back-to-back.
@@ -696,15 +702,44 @@ class WebRtcAudioRecord {
         }
         future = null;
       }
-      audioThread.stopThread();
-      if (!ThreadUtils.joinUninterruptibly(audioThread, AUDIO_RECORD_THREAD_JOIN_TIMEOUT_MS)) {
-        Logging.e(TAG, "Join of AudioRecordJavaThread timed out");
-        WebRtcAudioUtils.logAudioState(TAG, context, audioManager);
-      }
+      stoppingThread = audioThread;
       audioThread = null;
-      releaseAudioResources();
-      return true;
+      stoppingThread.stopThread();
+
+      // Detach the AudioRecord from the shared state before waiting for the
+      // thread, so a subsequent init/start builds fresh state instead of
+      // touching a record the stopping thread may still be reading.
+      stoppingRecord = audioRecord;
+      audioRecord = null;
+      effects.release();
+      audioSourceMatchesRecordingSessionRef.set(null);
+
+      // Stop the record before joining the thread. A blocking
+      // AudioRecord.read() only returns promptly once the record leaves the
+      // recording state, so without this the join below times out whenever
+      // the reader is stuck inside read().
+      if (stoppingRecord != null) {
+        try {
+          stoppingRecord.stop();
+        } catch (IllegalStateException e) {
+          Logging.e(TAG, "AudioRecord.stop failed: " + e.getMessage());
+        }
+      }
     }
+
+    // Join outside audioRecordStateLock. The audio thread acquires that lock
+    // at the top of every loop iteration, so joining while holding it turns
+    // any stop that races a loop boundary into a guaranteed join timeout:
+    // the thread waits for the lock while the join waits for the thread.
+    if (!ThreadUtils.joinUninterruptibly(stoppingThread, AUDIO_RECORD_THREAD_JOIN_TIMEOUT_MS)) {
+      Logging.e(TAG, "Join of AudioRecordJavaThread timed out");
+      WebRtcAudioUtils.logAudioState(TAG, context, audioManager);
+    }
+
+    if (stoppingRecord != null) {
+      stoppingRecord.release();
+    }
+    return true;
   }
 
   @TargetApi(Build.VERSION_CODES.M)

--- a/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
+++ b/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
@@ -128,6 +128,11 @@ class WebRtcAudioRecord {
    */
   private class AudioRecordThread extends Thread {
     private volatile boolean keepAlive = true;
+    // Handoff slot for an AudioRecord whose stop path gave up waiting for
+    // this thread (see stopRecordingIfNeededImpl). Exactly one side wins the
+    // getAndSet and performs the release.
+    private final AtomicReference<AudioRecord> orphanedRecord = new AtomicReference<>();
+    private final AtomicBoolean cleanupDone = new AtomicBoolean(false);
 
     public AudioRecordThread(String name) {
       super(name);
@@ -255,14 +260,40 @@ class WebRtcAudioRecord {
       } catch (IllegalStateException e) {
         Logging.e(TAG, "AudioRecord.stop failed: " + e.getMessage());
       }
+      cleanupDone.set(true);
+      AudioRecord orphan = orphanedRecord.getAndSet(null);
+      if (orphan != null) {
+        // The stop path timed out joining this thread and transferred release
+        // responsibility here: releasing while this thread might still have
+        // been inside AudioRecord.read() would corrupt the platform client
+        // proxy state and abort the process.
+        Logging.w(TAG, "Releasing orphaned AudioRecord after delayed thread exit");
+        try {
+          orphan.stop();
+        } catch (IllegalStateException e) {
+          // Already stopped by the stop path.
+        }
+        orphan.release();
+      }
       doAudioRecordStateCallback(AUDIO_RECORD_STOP);
     }
 
-    // Stops the inner thread loop and also calls AudioRecord.stop().
-    // Does not block the calling thread.
+    // Stops the inner thread loop. Does not block the calling thread.
     public void stopThread() {
       Logging.d(TAG, "stopThread");
       keepAlive = false;
+    }
+
+    // Called by the stop path when its join timed out. Returns null when this
+    // thread will release the record on exit, or the record itself when this
+    // thread has already finished cleanup and the caller must release it.
+    // Exactly one side observes the record, in every interleaving.
+    public @Nullable AudioRecord transferRecordOwnership(AudioRecord record) {
+      orphanedRecord.set(record);
+      if (cleanupDone.get()) {
+        return orphanedRecord.getAndSet(null);
+      }
+      return null;
     }
   }
 
@@ -734,6 +765,19 @@ class WebRtcAudioRecord {
     if (!ThreadUtils.joinUninterruptibly(stoppingThread, AUDIO_RECORD_THREAD_JOIN_TIMEOUT_MS)) {
       Logging.e(TAG, "Join of AudioRecordJavaThread timed out");
       WebRtcAudioUtils.logAudioState(TAG, context, audioManager);
+      // The thread may still be inside AudioRecord.read(). Releasing the
+      // record here corrupts the platform AudioRecord client proxy and
+      // aborts the process (releaseBuffer: mUnreleased out of range), so
+      // hand release responsibility to the thread instead.
+      if (stoppingRecord != null) {
+        AudioRecord unclaimed = stoppingThread.transferRecordOwnership(stoppingRecord);
+        if (unclaimed != null) {
+          // The thread finished its cleanup during the handoff; no reader can
+          // be inside read() anymore, so releasing here is safe.
+          unclaimed.release();
+        }
+      }
+      return true;
     }
 
     if (stoppingRecord != null) {

--- a/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
+++ b/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
@@ -128,6 +128,12 @@ class WebRtcAudioRecord {
    */
   private class AudioRecordThread extends Thread {
     private volatile boolean keepAlive = true;
+    // The AudioRecord this thread most recently read from. Written only by
+    // this thread while running, read by it again during exit cleanup. The
+    // shared WebRtcAudioRecord.this.audioRecord field may already point at a
+    // newer record by the time this thread exits, so exit cleanup must not
+    // touch the shared field.
+    private @Nullable AudioRecord activeRecord;
     // Handoff slot for an AudioRecord whose stop path gave up waiting for
     // this thread (see stopRecordingIfNeededImpl). Exactly one side wins the
     // getAndSet and performs the release.
@@ -142,8 +148,14 @@ class WebRtcAudioRecord {
     public void run() {
       Process.setThreadPriority(Process.THREAD_PRIORITY_URGENT_AUDIO);
       Logging.d(TAG, "AudioRecordThread" + WebRtcAudioUtils.getThreadInfo());
-      if (audioRecord != null) {
-        assertTrue(audioRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING);
+      // Snapshot and assert under the lock so a concurrent stop (which sets
+      // keepAlive=false, detaches the record, and stops it under the same
+      // lock) cannot interleave between the null check and the state read.
+      synchronized (audioRecordStateLock) {
+        AudioRecord startupRecord = WebRtcAudioRecord.this.audioRecord;
+        if (keepAlive && startupRecord != null) {
+          assertTrue(startupRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING);
+        }
       }
 
       // Audio recording has started and the client is informed about it.
@@ -162,31 +174,67 @@ class WebRtcAudioRecord {
           audioRecord = WebRtcAudioRecord.this.audioRecord;
           shouldReportData = nativeCalledInitRecording.get();
         }
-        
-        if (audioRecord == null && useAudioRecord) {
-          boolean result = initAudioRecord();
+        // Re-check after the snapshot: a stop may have completed while this
+        // thread waited at the monitor, and a subsequent start may already
+        // have installed a NEW record into the shared field. The stop path
+        // publishes keepAlive=false before detaching, under the same lock, so
+        // a snapshot that can observe a successor record always observes
+        // keepAlive == false. Exit without touching the successor.
+        if (!keepAlive) {
+          break;
+        }
+
+        // Do not re-create the AudioRecord once stopThread() has been called
+        // (re-checked under the lock inside the branch): a dying thread that
+        // re-inits would leave behind a record that no stop path will ever
+        // release.
+        if (audioRecord == null && useAudioRecord && keepAlive) {
+          boolean result;
+          synchronized (audioRecordStateLock) {
+            // A stop may have completed while this thread was blocked on the
+            // monitor; the keepAlive read above is stale in that case.
+            result = keepAlive && initAudioRecord();
+          }
 
           if (!result) {
-            // Failed audio record init, don't try again.
-            useAudioRecord = false;
-          } else {
-            synchronized (audioRecordStateLock) {
-              audioRecord = WebRtcAudioRecord.this.audioRecord;
-            }
-
-            assertTrue(audioRecord != null);
-            try {
-              audioRecord.startRecording();
-            } catch (IllegalStateException e) {
-              reportWebRtcAudioRecordStartError(AudioRecordStartErrorCode.AUDIO_RECORD_START_EXCEPTION,
-                  "AudioRecord.startRecording failed: " + e.getMessage());
-              audioRecord = null;
+            if (keepAlive) {
+              // Failed audio record init, don't try again.
               useAudioRecord = false;
             }
-            if (useAudioRecord && audioRecord.getRecordingState() != AudioRecord.RECORDSTATE_RECORDING) {
-              reportWebRtcAudioRecordStartError(AudioRecordStartErrorCode.AUDIO_RECORD_START_STATE_MISMATCH,
-                  "AudioRecord.startRecording failed - incorrect state: "
-                      + audioRecord.getRecordingState());
+          } else {
+            boolean startFailed = false;
+            boolean stateMismatch = false;
+            synchronized (audioRecordStateLock) {
+              // Re-snapshot, start, and verify in one critical section, gated
+              // on keepAlive: a stop that completed in between must not let a
+              // dying reader adopt (and later stop) a successor record, and a
+              // record stopped by shutdown is not a start failure.
+              audioRecord = keepAlive ? WebRtcAudioRecord.this.audioRecord : null;
+              if (audioRecord != null) {
+                try {
+                  audioRecord.startRecording();
+                } catch (IllegalStateException e) {
+                  startFailed = true;
+                  reportWebRtcAudioRecordStartError(AudioRecordStartErrorCode.AUDIO_RECORD_START_EXCEPTION,
+                      "AudioRecord.startRecording failed: " + e.getMessage());
+                }
+                if (!startFailed
+                    && audioRecord.getRecordingState() != AudioRecord.RECORDSTATE_RECORDING) {
+                  stateMismatch = true;
+                  reportWebRtcAudioRecordStartError(AudioRecordStartErrorCode.AUDIO_RECORD_START_STATE_MISMATCH,
+                      "AudioRecord.startRecording failed - incorrect state: "
+                          + audioRecord.getRecordingState());
+                }
+              }
+            }
+            if (audioRecord == null) {
+              // A concurrent stop either detached the fresh record before this
+              // thread could start it or finished while this thread waited at
+              // the monitor; that stop owns the record's release. Exit via the
+              // loop condition.
+              continue;
+            }
+            if (startFailed || stateMismatch) {
               audioRecord = null;
               useAudioRecord = false;
             }
@@ -194,10 +242,19 @@ class WebRtcAudioRecord {
         }
 
         if (audioRecord != null && !useAudioRecord) {
+          synchronized (audioRecordStateLock) {
+            // Release through the shared path only while this record is still
+            // the shared one; a concurrent stop may have detached it already
+            // and taken over its release.
+            if (WebRtcAudioRecord.this.audioRecord == audioRecord) {
+              releaseAudioResources();
+            }
+          }
           audioRecord = null;
-          releaseAudioResources();
         }
         
+        activeRecord = audioRecord;
+
         int bytesRead = 0;
         if (audioRecord != null) {
           bytesRead = audioRecord.read(byteBuffer, byteBuffer.capacity());
@@ -216,6 +273,11 @@ class WebRtcAudioRecord {
               }
             }
           } else {
+            if (!keepAlive) {
+              // The stop path stopped this record to unblock the read; exit
+              // through the loop condition without reporting an error.
+              continue;
+            }
             String errorMessage = "AudioRecord.read failed: " + bytesRead;
             Logging.e(TAG, errorMessage);
             
@@ -253,9 +315,12 @@ class WebRtcAudioRecord {
         }
       }
 
+      // Stop only the record this thread was reading. The shared field may
+      // already point at a newer AudioRecord created by a subsequent start;
+      // stopping that one would corrupt the new reader's in-flight read.
       try {
-        if (audioRecord != null) {
-          audioRecord.stop();
+        if (activeRecord != null) {
+          activeRecord.stop();
         }
       } catch (IllegalStateException e) {
         Logging.e(TAG, "AudioRecord.stop failed: " + e.getMessage());


### PR DESCRIPTION
## Problem

Production crash on Android (Samsung SM-G766U1, Android 16, LiveKit consumer of `io.github.webrtc-sdk:android-prefixed:144.7559.05`) during rapid capture stop/start cycling while the capture HAL was under pressure (Bluetooth SCO route churn plus a second concurrent capture stack):

```
Abort message: 'releaseBuffer: mUnreleased out of range,
!(stepCount:480 <= mUnreleased:0 <= mFrameCount:3840), BufferSizeInFrames:3840'
  android::ClientProxy::releaseBuffer
  android::AudioRecord::read
  android.media.AudioRecord.read
  livekit.org.webrtc.audio.WebRtcAudioRecord$AudioRecordThread.run
```

`stopRecordingIfNeededImpl()` joins the reader thread while holding `audioRecordStateLock` and never stops the `AudioRecord` first:

1. The reader takes that lock at the top of every loop iteration, so a stop racing a loop boundary deadlocks against the join until its 2s timeout (thread waits for the lock, join waits for the thread). Device logs showed this ~2s stall on every stop cycle under churn.
2. A reader stuck inside a blocking `read()` (stalled HAL) has nothing to unblock it, so the join times out structurally.
3. On timeout the record is released anyway — **under a live reader potentially still inside `read()`** — corrupting the platform client proxy (the abort above). The leaked thread then re-snapshots the shared `audioRecord` field each iteration and its exit path stops whatever the field holds, so once a new start installs a successor record, two readers interleave on one record. The crash tombstone showed two of this class's reader threads alive, started ~400ms apart.

## Fix

One commit per hazard:

1. **Stop and detach the record before joining, join outside the lock** — a blocked `read()` returns once the record leaves the recording state, so the join actually succeeds; detaching under the lock means concurrent init/start builds fresh state.
2. **Never release under a live reader** — on join timeout, release ownership transfers to the reader via an atomic handoff (`orphanedRecord`/`cleanupDone`); exactly one side releases in every interleaving.
3. **Reader-side guards** — the reader re-checks `keepAlive` after the loop-top snapshot and around re-init/start (all under the lock), tracks the record it actually read (`activeRecord`) and stops only that on exit, takes the startup assert under the lock, and no longer misreports a shutdown-stopped record as a start failure (which permanently disabled `useAudioRecord`).

## Verification

Stalled-read reproduction (JVM harness emulating a blocked `read()` that only returns when the record leaves the recording state), unpatched vs patched:

- Unpatched: `release()` lands while a read is in flight — the abort's exact precondition — in 5/5 stop/restart cycles; every stop burns the full 2s join timeout.
- Patched: every stop completes in milliseconds, reads observe a clean `stop()`, no release-under-read, no leaked reader threads.

On-device stress (SM-G766U1, 400 init/start/stop cycles with a concurrent prewarm/init thread): unpatched **346/400** stops hit the 2s join timeout with leaked reader threads; patched **0/400**, max stop 189ms, no crash.

The harness is Robolectric-based (shadowed `AudioRecord` source) so it doesn't fit this tree's GN build; happy to contribute it in whatever form fits your test setup.

## Notes

- Bounded trade-offs: if a join still times out (pathologically stuck read), the orphaned record is released when the reader finally exits — if it never exits the record stays held, which is strictly better than the abort; in that same path the `AUDIO_RECORD_STOP` state callback can be delivered after a successor session's `AUDIO_RECORD_START` (it reflects the actual late stop).
- `m146_release` carries the same stop-path code; happy to open a matching PR there.
