### PR TITLE
Android: implement ADM SetMicrophoneMute and allow opting out of stop-on-mute

### DIFF
--- a/sdk/android/api/org/webrtc/audio/JavaAudioDeviceModule.java
+++ b/sdk/android/api/org/webrtc/audio/JavaAudioDeviceModule.java
@@ -55,6 +55,7 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
     private AudioAttributes audioAttributes;
     private boolean useLowLatency;
     private boolean enableVolumeLogger;
+    private boolean stopRecordingOnMute = true;
 
     private Builder(Context context) {
       this.context = context;
@@ -242,6 +243,17 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
     }
 
     /**
+     * Control whether recording is stopped while all audio tracks are muted. The default is
+     * enabled: muting releases the AudioRecord so the OS mic-in-use indicator turns off. When
+     * disabled, capture keeps running while muted and captured audio is replaced with silence,
+     * making unmute instant at the cost of the mic indicator staying on.
+     */
+    public Builder setStopRecordingOnMute(boolean stopRecordingOnMute) {
+      this.stopRecordingOnMute = stopRecordingOnMute;
+      return this;
+    }
+
+    /**
      * Construct an AudioDeviceModule based on the supplied arguments. The caller takes ownership
      * and is responsible for calling release().
      */
@@ -281,7 +293,8 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
           new WebRtcAudioTrack(context, audioManager, audioAttributes, audioTrackErrorCallback,
               audioTrackStateCallback, playbackSamplesReadyCallback, useLowLatency, enableVolumeLogger);
       return new JavaAudioDeviceModule(context, audioManager, audioInput, audioOutput,
-          inputSampleRate, outputSampleRate, useStereoInput, useStereoOutput);
+          inputSampleRate, outputSampleRate, useStereoInput, useStereoOutput,
+          stopRecordingOnMute);
     }
   }
 
@@ -440,13 +453,15 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
   private final int outputSampleRate;
   private final boolean useStereoInput;
   private final boolean useStereoOutput;
+  private final boolean stopRecordingOnMute;
 
   private final Object nativeLock = new Object();
   private long nativeAudioDeviceModule;
 
   private JavaAudioDeviceModule(Context context, AudioManager audioManager,
       WebRtcAudioRecord audioInput, WebRtcAudioTrack audioOutput, int inputSampleRate,
-      int outputSampleRate, boolean useStereoInput, boolean useStereoOutput) {
+      int outputSampleRate, boolean useStereoInput, boolean useStereoOutput,
+      boolean stopRecordingOnMute) {
     this.context = context;
     this.audioManager = audioManager;
     this.audioInput = audioInput;
@@ -455,6 +470,7 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
     this.outputSampleRate = outputSampleRate;
     this.useStereoInput = useStereoInput;
     this.useStereoOutput = useStereoOutput;
+    this.stopRecordingOnMute = stopRecordingOnMute;
   }
 
   @Override
@@ -463,7 +479,7 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
       if (nativeAudioDeviceModule == 0) {
         nativeAudioDeviceModule = nativeCreateAudioDeviceModule(context, audioManager, audioInput,
             audioOutput, webrtcEnvRef, inputSampleRate, outputSampleRate, useStereoInput,
-            useStereoOutput);
+            useStereoOutput, stopRecordingOnMute);
       }
       return nativeAudioDeviceModule;
     }
@@ -552,5 +568,5 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
   private static native long nativeCreateAudioDeviceModule(Context context,
       AudioManager audioManager, WebRtcAudioRecord audioInput, WebRtcAudioTrack audioOutput,
       long webrtcEnvRef, int inputSampleRate, int outputSampleRate, boolean useStereoInput,
-      boolean useStereoOutput);
+      boolean useStereoOutput, boolean stopRecordingOnMute);
 }

--- a/sdk/android/api/org/webrtc/audio/JavaAudioDeviceModule.java
+++ b/sdk/android/api/org/webrtc/audio/JavaAudioDeviceModule.java
@@ -244,9 +244,17 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
 
     /**
      * Control whether recording is stopped while all audio tracks are muted. The default is
-     * enabled: muting releases the AudioRecord so the OS mic-in-use indicator turns off. When
-     * disabled, capture keeps running while muted and captured audio is replaced with silence,
-     * making unmute instant at the cost of the mic indicator staying on.
+     * enabled: muting releases the AudioRecord so the OS mic-in-use indicator turns off, at the
+     * cost of a cold start on unmute.
+     *
+     * <p>When disabled, captured audio is replaced with silence while muted and unmute is instant.
+     * Note that recording then starts when the audio track is published and runs until it is
+     * unpublished, so the OS mic-in-use indicator stays on for the whole published lifetime of the
+     * track, not only while unmuted.
+     *
+     * <p>Apps that disable this should not also drive {@link #setMicrophoneMute(boolean)}
+     * themselves. Both write the same state, so an app level mute is cleared the next time a track
+     * is unmuted.
      */
     public Builder setStopRecordingOnMute(boolean stopRecordingOnMute) {
       this.stopRecordingOnMute = stopRecordingOnMute;

--- a/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
+++ b/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
@@ -950,6 +950,9 @@ class WebRtcAudioRecord {
   // the microphone is muted.
   @CalledByNative
   public void setMicrophoneMute(boolean mute) {
+    if (microphoneMute == mute) {
+      return;
+    }
     Logging.w(TAG, "setMicrophoneMute(" + mute + ")");
     microphoneMute = mute;
   }

--- a/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
+++ b/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
@@ -804,6 +804,7 @@ class WebRtcAudioRecord {
 
   // Sets all recorded samples to zero if `mute` is true, i.e., ensures that
   // the microphone is muted.
+  @CalledByNative
   public void setMicrophoneMute(boolean mute) {
     Logging.w(TAG, "setMicrophoneMute(" + mute + ")");
     microphoneMute = mute;

--- a/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
+++ b/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
@@ -954,6 +954,14 @@ class WebRtcAudioRecord {
     microphoneMute = mute;
   }
 
+  // Returns the current mute state. This class owns the state, so both native
+  // callers and app callers of JavaAudioDeviceModule.setMicrophoneMute read
+  // back the same value.
+  @CalledByNative
+  public boolean getMicrophoneMute() {
+    return microphoneMute;
+  }
+
   // Sets whether NoiseSuppressor should be enabled or disabled.
   // Returns true if the enabling was successful, otherwise false is returned (this is also the case
   // if the NoiseSuppressor effect is not supported).

--- a/sdk/android/src/jni/audio_device/audio_device_module.cc
+++ b/sdk/android/src/jni/audio_device/audio_device_module.cc
@@ -68,7 +68,8 @@ class AndroidAudioDeviceModule : public AudioDeviceModule {
                            bool is_stereo_record_supported,
                            uint16_t playout_delay_ms,
                            std::unique_ptr<AudioInput> audio_input,
-                           std::unique_ptr<AudioOutput> audio_output)
+                           std::unique_ptr<AudioOutput> audio_output,
+                           bool is_stop_on_mute_mode_enabled)
       : env_(env),
         audio_layer_(audio_layer),
         is_stereo_playout_supported_(is_stereo_playout_supported),
@@ -76,6 +77,7 @@ class AndroidAudioDeviceModule : public AudioDeviceModule {
         playout_delay_ms_(playout_delay_ms),
         input_(std::move(audio_input)),
         output_(std::move(audio_output)),
+        is_stop_on_mute_mode_enabled_(is_stop_on_mute_mode_enabled),
         initialized_(false) {
     RTC_CHECK(input_);
     RTC_CHECK(output_);
@@ -441,13 +443,18 @@ class AndroidAudioDeviceModule : public AudioDeviceModule {
   }
 
   int32_t SetMicrophoneMute(bool enable) override {
-    RTC_DLOG(LS_INFO) << __FUNCTION__ << "(" << enable << ")" << " - Not implemented";
-    return -1;
+    RTC_DLOG(LS_INFO) << __FUNCTION__ << "(" << enable << ")";
+    if (input_->SetMicrophoneMute(enable) != 0) {
+      return -1;
+    }
+    microphone_mute_ = enable;
+    return 0;
   }
 
   int32_t MicrophoneMute(bool* enabled) const override {
-    RTC_DLOG(LS_INFO) << __FUNCTION__ << " - Not implemented";
-    return -1;
+    RTC_DLOG(LS_INFO) << __FUNCTION__;
+    *enabled = microphone_mute_;
+    return 0;
   }
 
   int32_t StereoPlayoutIsAvailable(bool* available) const override {
@@ -607,6 +614,10 @@ class AndroidAudioDeviceModule : public AudioDeviceModule {
     return output_->GetStats();
   }
 
+  bool IsStopOnMuteModeEnabled() const override {
+    return is_stop_on_mute_mode_enabled_;
+  }
+
   int32_t AttachAudioBuffer() {
     RTC_DLOG(LS_INFO) << __FUNCTION__;
     output_->AttachAudioBuffer(audio_device_buffer_.get());
@@ -624,9 +635,11 @@ class AndroidAudioDeviceModule : public AudioDeviceModule {
   const uint16_t playout_delay_ms_;
   const std::unique_ptr<AudioInput> input_;
   const std::unique_ptr<AudioOutput> output_;
+  const bool is_stop_on_mute_mode_enabled_;
   std::unique_ptr<AudioDeviceBuffer> audio_device_buffer_;
 
   bool initialized_;
+  bool microphone_mute_ = false;
 };
 
 }  // namespace
@@ -682,11 +695,13 @@ scoped_refptr<AudioDeviceModule> CreateAudioDeviceModuleFromInputAndOutput(
     bool is_stereo_record_supported,
     uint16_t playout_delay_ms,
     std::unique_ptr<AudioInput> audio_input,
-    std::unique_ptr<AudioOutput> audio_output) {
+    std::unique_ptr<AudioOutput> audio_output,
+    bool is_stop_on_mute_mode_enabled) {
   RTC_DLOG(LS_INFO) << __FUNCTION__;
   return make_ref_counted<AndroidAudioDeviceModule>(
       env, audio_layer, is_stereo_playout_supported, is_stereo_record_supported,
-      playout_delay_ms, std::move(audio_input), std::move(audio_output));
+      playout_delay_ms, std::move(audio_input), std::move(audio_output),
+      is_stop_on_mute_mode_enabled);
 }
 
 }  // namespace jni

--- a/sdk/android/src/jni/audio_device/audio_device_module.cc
+++ b/sdk/android/src/jni/audio_device/audio_device_module.cc
@@ -438,22 +438,29 @@ class AndroidAudioDeviceModule : public AudioDeviceModule {
   }
 
   int32_t MicrophoneMuteIsAvailable(bool* available) override {
-    RTC_DLOG(LS_INFO) << __FUNCTION__ << " - Not implemented";
-    return -1;
+    RTC_DLOG(LS_INFO) << __FUNCTION__;
+    if (!initialized_)
+      return -1;
+    *available = input_->MicrophoneMute().has_value();
+    RTC_DLOG(LS_INFO) << "output: " << *available;
+    return 0;
   }
 
   int32_t SetMicrophoneMute(bool enable) override {
     RTC_DLOG(LS_INFO) << __FUNCTION__ << "(" << enable << ")";
-    if (input_->SetMicrophoneMute(enable) != 0) {
+    if (!initialized_)
       return -1;
-    }
-    microphone_mute_ = enable;
-    return 0;
+    return input_->SetMicrophoneMute(enable);
   }
 
   int32_t MicrophoneMute(bool* enabled) const override {
     RTC_DLOG(LS_INFO) << __FUNCTION__;
-    *enabled = microphone_mute_;
+    if (!initialized_)
+      return -1;
+    std::optional<bool> mute = input_->MicrophoneMute();
+    if (!mute.has_value())
+      return -1;
+    *enabled = *mute;
     return 0;
   }
 
@@ -639,7 +646,6 @@ class AndroidAudioDeviceModule : public AudioDeviceModule {
   std::unique_ptr<AudioDeviceBuffer> audio_device_buffer_;
 
   bool initialized_;
-  bool microphone_mute_ = false;
 };
 
 }  // namespace

--- a/sdk/android/src/jni/audio_device/audio_device_module.h
+++ b/sdk/android/src/jni/audio_device/audio_device_module.h
@@ -57,6 +57,12 @@ class AudioInput {
   // without stopping recording. Returns -1 if not supported.
   virtual int32_t SetMicrophoneMute(bool mute) { return -1; }
 
+  // Current capture source mute state, or nullopt if the input cannot mute.
+  // The input owns this state rather than the ADM caching it, so the value
+  // stays correct even when something other than SetMicrophoneMute changes it
+  // (for example JavaAudioDeviceModule.setMicrophoneMute from app code).
+  virtual std::optional<bool> MicrophoneMute() const { return std::nullopt; }
+
   virtual std::optional<bool> BuiltInAECIsRequested() const { return std::nullopt; }
   virtual std::optional<bool> BuiltInAECIsEnabled() const { return std::nullopt; }
   virtual std::optional<bool> BuiltInNSIsRequested() const { return std::nullopt; }

--- a/sdk/android/src/jni/audio_device/audio_device_module.h
+++ b/sdk/android/src/jni/audio_device/audio_device_module.h
@@ -53,6 +53,10 @@ class AudioInput {
   virtual int32_t EnableBuiltInAEC(bool enable) = 0;
   virtual int32_t EnableBuiltInNS(bool enable) = 0;
 
+  // Mutes at the capture source by replacing recorded audio with silence,
+  // without stopping recording. Returns -1 if not supported.
+  virtual int32_t SetMicrophoneMute(bool mute) { return -1; }
+
   virtual std::optional<bool> BuiltInAECIsRequested() const { return std::nullopt; }
   virtual std::optional<bool> BuiltInAECIsEnabled() const { return std::nullopt; }
   virtual std::optional<bool> BuiltInNSIsRequested() const { return std::nullopt; }
@@ -113,7 +117,8 @@ scoped_refptr<AudioDeviceModule> CreateAudioDeviceModuleFromInputAndOutput(
     bool is_stereo_record_supported,
     uint16_t playout_delay_ms,
     std::unique_ptr<AudioInput> audio_input,
-    std::unique_ptr<AudioOutput> audio_output);
+    std::unique_ptr<AudioOutput> audio_output,
+    bool is_stop_on_mute_mode_enabled = true);
 
 }  // namespace jni
 

--- a/sdk/android/src/jni/audio_device/audio_record_jni.cc
+++ b/sdk/android/src/jni/audio_device/audio_record_jni.cc
@@ -234,6 +234,13 @@ int32_t AudioRecordJni::EnableBuiltInAEC(bool enable) {
              : -1;
 }
 
+int32_t AudioRecordJni::SetMicrophoneMute(bool mute) {
+  RTC_LOG(LS_INFO) << "SetMicrophoneMute(" << mute << ")";
+  RTC_DCHECK(thread_checker_.IsCurrent());
+  Java_WebRtcAudioRecord_setMicrophoneMute(env_, j_audio_record_, mute);
+  return 0;
+}
+
 int32_t AudioRecordJni::EnableBuiltInNS(bool enable) {
   RTC_LOG(LS_INFO) << "EnableBuiltInNS(" << enable << ")";
   RTC_DCHECK(thread_checker_.IsCurrent());

--- a/sdk/android/src/jni/audio_device/audio_record_jni.cc
+++ b/sdk/android/src/jni/audio_device/audio_record_jni.cc
@@ -241,6 +241,11 @@ int32_t AudioRecordJni::SetMicrophoneMute(bool mute) {
   return 0;
 }
 
+std::optional<bool> AudioRecordJni::MicrophoneMute() const {
+  RTC_DCHECK(thread_checker_.IsCurrent());
+  return Java_WebRtcAudioRecord_getMicrophoneMute(env_, j_audio_record_);
+}
+
 int32_t AudioRecordJni::EnableBuiltInNS(bool enable) {
   RTC_LOG(LS_INFO) << "EnableBuiltInNS(" << enable << ")";
   RTC_DCHECK(thread_checker_.IsCurrent());

--- a/sdk/android/src/jni/audio_device/audio_record_jni.h
+++ b/sdk/android/src/jni/audio_device/audio_record_jni.h
@@ -78,6 +78,8 @@ class AudioRecordJni : public AudioInput {
   int32_t EnableBuiltInAEC(bool enable) override;
   int32_t EnableBuiltInNS(bool enable) override;
 
+  int32_t SetMicrophoneMute(bool mute) override;
+
   std::optional<bool> BuiltInAECIsRequested() const override;
   std::optional<bool> BuiltInAECIsEnabled() const override;
   std::optional<bool> BuiltInNSIsRequested() const override;

--- a/sdk/android/src/jni/audio_device/audio_record_jni.h
+++ b/sdk/android/src/jni/audio_device/audio_record_jni.h
@@ -79,6 +79,7 @@ class AudioRecordJni : public AudioInput {
   int32_t EnableBuiltInNS(bool enable) override;
 
   int32_t SetMicrophoneMute(bool mute) override;
+  std::optional<bool> MicrophoneMute() const override;
 
   std::optional<bool> BuiltInAECIsRequested() const override;
   std::optional<bool> BuiltInAECIsEnabled() const override;

--- a/sdk/android/src/jni/audio_device/java_audio_device_module.cc
+++ b/sdk/android/src/jni/audio_device/java_audio_device_module.cc
@@ -37,7 +37,8 @@ static jlong JNI_JavaAudioDeviceModule_CreateAudioDeviceModule(
     int input_sample_rate,
     int output_sample_rate,
     jboolean j_use_stereo_input,
-    jboolean j_use_stereo_output) {
+    jboolean j_use_stereo_output,
+    jboolean j_stop_recording_on_mute) {
   const Environment& webrtc_env = *reinterpret_cast<Environment*>(webrtcEnvRef);
   AudioParameters input_parameters;
   AudioParameters output_parameters;
@@ -54,7 +55,8 @@ static jlong JNI_JavaAudioDeviceModule_CreateAudioDeviceModule(
       CreateAudioDeviceModuleFromInputAndOutput(
           webrtc_env, AudioDeviceModule::kAndroidJavaAudio, j_use_stereo_input,
           j_use_stereo_output, kHighLatencyModeDelayEstimateInMilliseconds,
-          std::move(audio_input), std::move(audio_output))
+          std::move(audio_input), std::move(audio_output),
+          j_stop_recording_on_mute)
           .release());
 }
 


### PR DESCRIPTION
## Summary

Since #206, `WebRtcVoiceSendChannel::MuteStream` stops the ADM's recording when all send streams are muted, unless the ADM overrides `IsStopOnMuteModeEnabled()` to false. The iOS/macOS `AudioEngineDevice` opts out and mutes internally while keeping capture alive; the Android ADM has no override, so muting an audio track now fully releases `AudioRecord`.

Per the guidance on #206 — platforms that properly implement the ADM's Mute API can opt out individually — this PR does exactly that for Android, keeping stop-on-mute as the default.

## Problem

For push-to-talk style apps, re-enabling the mic is a cold start: a new `AudioRecord`, AGC reconvergence, and on USB audio devices a full interface renegotiation (alternate setting selection, bandwidth reservation, sample rate setup). Speech during that window is lost, heard as a clipped first word on every transmission. Before #206, muting kept capture warm on Android. We bisected across LiveKit Android v2.23.0 (webrtc 137.7151.04) / v2.23.1 (137.7151.05) and confirmed the boundary matches this change.

Android already had a working warm-mute implementation — `WebRtcAudioRecord.setMicrophoneMute()` zero-fills the capture buffer on the record thread — but it was only reachable from Java. The C++ `AndroidAudioDeviceModule::SetMicrophoneMute()` returned -1, so the non-stop mute path in `MuteStream` was a no-op on Android, and there was no way to opt out of stop-on-mute.

## Changes

1. **Wire `SetMicrophoneMute` through to `WebRtcAudioRecord`.** New `AudioInput::SetMicrophoneMute` (default -1 for other inputs, preserving behavior) and `AudioRecordJni::SetMicrophoneMute` bridge the C++ ADM to the existing Java zero-fill logic. `AndroidAudioDeviceModule::SetMicrophoneMute` now returns 0 and delegates; `MicrophoneMute()` reports the cached state. This is the same "mute inside the engine, capture stays alive" semantics as iOS `AudioEngineDevice`.
2. **Add builder opt-out.** `JavaAudioDeviceModule.Builder.setStopRecordingOnMute(boolean)` — default `true`, current behavior unchanged. Plumbed through `nativeCreateAudioDeviceModule` into `AndroidAudioDeviceModule`, which overrides `IsStopOnMuteModeEnabled()`. The `CreateAudioDeviceModuleFromInputAndOutput` parameter defaults to `true`, so AAudio/OpenSLES callers are unaffected.

Apps that opt out accept the OS mic-in-use indicator staying on while muted, in exchange for instant unmute.

## Flow-through for LiveKit consumers

This change is transparent — no client-side API change required. LiveKit's `LocalParticipant.setMicrophoneEnabled(false)` already flows into WebRTC's mute path:

```
LocalParticipant.setMicrophoneEnabled(false)
  → LocalTrackPublication.muted = true              (LocalTrackPublication.kt:44)
  → mediaTrack.enabled = false
  → AudioRtpSender::SetAudioSend(ssrc, enable=false, ...)
  → WebRtcVoiceSendChannel::SetAudioSend            (webrtc_voice_engine.cc:1521)
  → MuteStream(ssrc, muted=true)                    (line 1531)
  → adm->IsStopOnMuteModeEnabled() branch           (line 1736)
       ├─ true (default):  adm->StopRecording()           ← cold start
       └─ false (this PR): adm->SetMicrophoneMute(true)   ← warm mute
```

Apps opt in at ADM construction time:

```kotlin
LiveKit.create(
    appContext = context,
    overrides = LiveKitOverrides(
        audioOptions = AudioOptions(
            javaAudioDeviceModuleCustomizer = { it.setStopRecordingOnMute(false) }
        )
    )
)
```

Existing `setMicrophoneEnabled(...)` call sites keep working. Peers still see the mute indicator, the SFU still drops disabled-track RTP, LiveKit `TrackMuted`/`TrackUnmuted` events fire as before — the only difference is that `AudioRecord` stays warm across the mute cycle.

## Testing

Verified end-to-end on Pixel 6 and USB PTT handset against a `livekit-server --dev` room:

**With `stopRecordingOnMute=false` (this PR's opt-out):**
```
WebRtcVoiceSendChannel::MuteStream: ADM:1
WebRtcAudioRecord: setMicrophoneMute(true)
(AudioRecord stays in STATE_RECORDING; no stopThread / startRecording)
```

**With `stopRecordingOnMute=true` (default, pre-PR behavior):**
```
WebRtcVoiceSendChannel::MuteStream: ADM:1
WebRtcAudioRecord: stopThread
WebRtcAudioRecord: joinAudioRecordThread
(then on unmute: InitRecording + startRecording, audible cold-start delay)
```

Cold-start measured 120–280 ms of dropped speech on Pixel 6, up to 600 ms on a USB gaming headset — vanishes entirely with the opt-out.

**Reproduction:** [maxmini-dev/webrtc-sdk-pr269-test](https://github.com/maxmini-dev/webrtc-sdk-pr269-test) — prebuilt `android_prefixed` AAR at PR HEAD, LiveKit sample app with a runtime toggle for the opt-out, and a step-by-step README (`livekit-server --dev`, `adb install`, log filters).

## Related

- #206 — introduced WebRtcVoiceSendChannel::MuteStream stop-on-mute along with the IsStopOnMuteModeEnabled opt-out that iOS AudioEngineDevice uses; this PR follows the same pattern on Android.