### PR TITLE
iOS: notify the ADM observer when an enable operation rolls back after will-enable

### DIFF
--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1844,6 +1844,20 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
       LOGE() << "Call to OnEngineWillEnable returned error: " << result;
       return rollback(result);
     }
+    rollback_actions.push_back([this, state]() {
+      RTC_DCHECK_RUN_ON(thread_);
+      // Compensate the observer if a later step of this enable operation fails.
+      // It may have configured and activated the audio session for the enable
+      // that will now never happen, and without this call it is never told the
+      // engine rolled back. Reuses OnEngineDidDisable with the previous state so
+      // existing observers release what they acquired without adopting a new
+      // callback. The result is ignored, the rollback itself cannot be aborted.
+      if (observer_ != nullptr) {
+        LOGW() << "Enable rolled back after OnEngineWillEnable, notifying observer (Manual)";
+        observer_->OnEngineDidDisable(engine_manual_input_, state.prev.IsOutputEnabled(),
+                                      state.prev.IsInputEnabled());
+      }
+    });
   }
 
   if (state.next.IsOutputEnabled() && !state.prev.IsOutputEnabled()) {
@@ -2272,6 +2286,20 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       LOGE() << "Call to OnEngineWillEnable returned error: " << result;
       return rollback(result);
     }
+    rollback_actions.push_back([this, state]() {
+      RTC_DCHECK_RUN_ON(thread_);
+      // Compensate the observer if a later step of this enable operation fails.
+      // It may have configured and activated the audio session for the enable
+      // that will now never happen, and without this call it is never told the
+      // engine rolled back. Reuses OnEngineDidDisable with the previous state so
+      // existing observers release what they acquired without adopting a new
+      // callback. The result is ignored, the rollback itself cannot be aborted.
+      if (observer_ != nullptr) {
+        LOGW() << "Enable rolled back after OnEngineWillEnable, notifying observer";
+        observer_->OnEngineDidDisable(engine_device_, state.prev.IsOutputEnabled(),
+                                      state.prev.IsInputEnabled());
+      }
+    });
   }
 
   // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`OnEngineWillEnable` runs before permission and category checks, node configuration, and engine startup. If a later step fails, rollback never notifies the observer. Observers that configure or activate the audio session in `willEnable` can therefore retain resources for an engine state that was never applied.

## Change

After a successful `OnEngineWillEnable`, register a rollback action that calls `OnEngineDidDisable` with the previous state. This covers both device and manual rendering paths. The result is ignored because rollback cannot be cancelled.

`OnEngineDidDisable` may now represent an attempted enable returning to the previous state, not only a completed disable.

## Testing

Built `framework_objc` for an arm64 iOS device. Reproduced by enabling input with an incompatible playback-only category and verified that rollback now notifies the observer.