### PR TITLE
iOS: decouple AudioEngineDevice from RTCAudioSession, surface interruption events

### DIFF
--- a/api/audio/audio_device.h
+++ b/api/audio/audio_device.h
@@ -314,6 +314,14 @@ class AudioDeviceObserver {
 
   virtual int32_t OnEngineWillRelease(AVAudioEngine* engine) { return 0; }
 
+  // Audio session interruption events (iOS). Fired on the device thread before
+  // the engine reacts to the event, so an observer that owns the audio session
+  // lifecycle can act first. In particular OnAudioSessionInterruptionEnded fires
+  // before the engine restarts, giving the owner a chance to reactivate the
+  // session. Implementations must not block.
+  virtual void OnAudioSessionInterruptionBegan() {}
+  virtual void OnAudioSessionInterruptionEnded(bool should_resume) {}
+
   // Override the input node configuration with a custom implementation.
   virtual int32_t OnEngineWillConnectInput(AVAudioEngine* engine, AVAudioNode* src,
                                            AVAudioNode* dst, AVAudioFormat* format,

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -38,7 +38,7 @@
 #import <AVFAudio/AVFAudio.h>
 #import <AudioToolbox/AudioToolbox.h>
 
-RTC_FWD_DECL_OBJC_CLASS(RTC_OBJC_TYPE(RTCNativeAudioSessionDelegateAdapter));
+RTC_FWD_DECL_OBJC_CLASS(RTC_OBJC_TYPE(RTCAudioEngineSessionNotificationObserver));
 
 namespace webrtc {
 
@@ -542,8 +542,11 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   AudioDeviceObserver* observer_ RTC_GUARDED_BY(thread_) = nullptr;
 
 #if defined(WEBRTC_IOS)
-  // Audio interruption observer instance.
-  RTC_OBJC_TYPE(RTCNativeAudioSessionDelegateAdapter) * audio_session_observer_
+  // Audio session notification observer instance. Observes NSNotificationCenter
+  // directly rather than subscribing to RTCAudioSession, so creating this
+  // device does not instantiate that singleton or its autonomous session
+  // management.
+  RTC_OBJC_TYPE(RTCAudioEngineSessionNotificationObserver) * audio_session_observer_
       RTC_GUARDED_BY(thread_);
 #endif
 

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -35,15 +35,109 @@
 #include "rtc_base/time_utils.h"
 
 #if defined(WEBRTC_IOS)
-#import "components/audio/RTCAudioSession+Private.h"
-#import "components/audio/RTCAudioSession.h"
 #import "components/audio/RTCAudioSessionConfiguration.h"
-#import "components/audio/RTCNativeAudioSessionDelegateAdapter.h"
 #endif
 
 #if TARGET_OS_OSX
 #import "./mac/audio_device_utils_mac.h"
 #endif
+
+#if defined(WEBRTC_IOS)
+// Observes AVAudioSession notifications directly and forwards the events the
+// engine consumes to the AudioSessionObserver interface. This intentionally
+// does not go through RTCAudioSession: subscribing to its delegate instantiated
+// the singleton in every app, forcing all audio-session regimes in the process
+// to keep its activation refcount truthful because it manages the session
+// autonomously from its own notification handlers. The engine only needs the
+// events. Session lifecycle and configuration stay owned by higher layers.
+@interface RTC_OBJC_TYPE (RTCAudioEngineSessionNotificationObserver) : NSObject
+- (instancetype)initWithObserver:(webrtc::AudioSessionObserver *)observer;
+- (void)invalidate;
+@end
+
+@implementation RTC_OBJC_TYPE (RTCAudioEngineSessionNotificationObserver) {
+  webrtc::AudioSessionObserver *_observer;
+}
+
+- (instancetype)initWithObserver:(webrtc::AudioSessionObserver *)observer {
+  RTC_DCHECK(observer);
+  self = [super init];
+  if (self) {
+    _observer = observer;
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center addObserver:self
+               selector:@selector(handleInterruptionNotification:)
+                   name:AVAudioSessionInterruptionNotification
+                 object:nil];
+    [center addObserver:self
+               selector:@selector(handleRouteChangeNotification:)
+                   name:AVAudioSessionRouteChangeNotification
+                 object:nil];
+  }
+  return self;
+}
+
+// Called by the owner before it goes away. Notifications are delivered on the
+// posting thread, and the forwarded observer methods are documented as callable
+// from any thread (they post to the device thread internally).
+- (void)invalidate {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+  _observer = nullptr;
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)handleInterruptionNotification:(NSNotification *)notification {
+  webrtc::AudioSessionObserver *observer = _observer;
+  if (observer == nullptr) {
+    return;
+  }
+  NSNumber *typeNumber = notification.userInfo[AVAudioSessionInterruptionTypeKey];
+  AVAudioSessionInterruptionType type =
+      (AVAudioSessionInterruptionType)typeNumber.unsignedIntegerValue;
+  switch (type) {
+    case AVAudioSessionInterruptionTypeBegan:
+      observer->OnInterruptionBegin();
+      break;
+    case AVAudioSessionInterruptionTypeEnded: {
+      NSNumber *optionsNumber = notification.userInfo[AVAudioSessionInterruptionOptionKey];
+      AVAudioSessionInterruptionOptions options = optionsNumber.unsignedIntegerValue;
+      bool shouldResume = options & AVAudioSessionInterruptionOptionShouldResume;
+      observer->OnInterruptionEnd(shouldResume);
+      break;
+    }
+  }
+}
+
+- (void)handleRouteChangeNotification:(NSNotification *)notification {
+  webrtc::AudioSessionObserver *observer = _observer;
+  if (observer == nullptr) {
+    return;
+  }
+  NSNumber *reasonNumber = notification.userInfo[AVAudioSessionRouteChangeReasonKey];
+  AVAudioSessionRouteChangeReason reason =
+      (AVAudioSessionRouteChangeReason)reasonNumber.unsignedIntegerValue;
+  switch (reason) {
+    case AVAudioSessionRouteChangeReasonUnknown:
+    case AVAudioSessionRouteChangeReasonNewDeviceAvailable:
+    case AVAudioSessionRouteChangeReasonOldDeviceUnavailable:
+    case AVAudioSessionRouteChangeReasonCategoryChange:
+    case AVAudioSessionRouteChangeReasonOverride:
+    case AVAudioSessionRouteChangeReasonWakeFromSleep:
+    case AVAudioSessionRouteChangeReasonNoSuitableRouteForCategory:
+      // Same valid-reason filter the RTCAudioSession delegate adapter applied.
+      observer->OnValidRouteChange();
+      break;
+    case AVAudioSessionRouteChangeReasonRouteConfigurationChange:
+      // Port configuration only, not a device change.
+      break;
+  }
+}
+
+@end
+#endif  // defined(WEBRTC_IOS)
 
 namespace webrtc {
 
@@ -189,11 +283,12 @@ AudioEngineDevice::AudioEngineDevice(const Environment& env, bool voice_processi
   audio_device_buffer_.reset(new webrtc::AudioDeviceBuffer(env));
 
 #if defined(WEBRTC_IOS)
+  // Subscribe to audio session events straight from NSNotificationCenter. Going
+  // through RTCAudioSession's delegate would instantiate that singleton and its
+  // autonomous session management, which higher layers should not be forced to
+  // participate in.
   audio_session_observer_ =
-      [[RTC_OBJC_TYPE(RTCNativeAudioSessionDelegateAdapter) alloc] initWithObserver:this];
-  // Subscribe to audio session events.
-  RTC_OBJC_TYPE(RTCAudioSession)* session = [RTC_OBJC_TYPE(RTCAudioSession) sharedInstance];
-  [session addDelegate:audio_session_observer_];
+      [[RTC_OBJC_TYPE(RTCAudioEngineSessionNotificationObserver) alloc] initWithObserver:this];
 #endif
 
   mach_timebase_info_data_t tinfo;
@@ -228,8 +323,7 @@ AudioEngineDevice::~AudioEngineDevice() {
   Terminate();
 
 #if defined(WEBRTC_IOS)
-  RTC_OBJC_TYPE(RTCAudioSession)* session = [RTC_OBJC_TYPE(RTCAudioSession) sharedInstance];
-  [session removeDelegate:audio_session_observer_];
+  [audio_session_observer_ invalidate];
   audio_session_observer_ = nil;
 #endif
 }

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -678,6 +678,12 @@ void AudioEngineDevice::OnInterruptionBegin() {
 
   RTC_DCHECK(thread_);
   thread_->PostTask(SafeTask(safety_, [this] {
+    RTC_DCHECK_RUN_ON(thread_);
+    // Notify the observer before the engine reacts, so a higher layer that owns
+    // the audio session lifecycle sees the event first.
+    if (observer_ != nullptr) {
+      observer_->OnAudioSessionInterruptionBegan();
+    }
     int32_t result = this->ModifyEngineState([](EngineState state) -> EngineState {
       state.is_interrupted = true;
       return state;
@@ -692,7 +698,14 @@ void AudioEngineDevice::OnInterruptionEnd(bool should_resume) {
   LOGI() << "OnInterruptionEnd should_resume: " << should_resume;
 
   RTC_DCHECK(thread_);
-  thread_->PostTask(SafeTask(safety_, [this] {
+  thread_->PostTask(SafeTask(safety_, [this, should_resume] {
+    RTC_DCHECK_RUN_ON(thread_);
+    // Notify the observer before the engine restarts, so a higher layer that
+    // owns the audio session lifecycle can reactivate the session first. Apple
+    // guidance is to activate the session before restarting audio I/O.
+    if (observer_ != nullptr) {
+      observer_->OnAudioSessionInterruptionEnded(should_resume);
+    }
     int32_t result = this->ModifyEngineState([](EngineState state) -> EngineState {
       state.is_interrupted = false;
       return state;

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -187,6 +187,19 @@ RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
 - (void)audioDeviceModuleDidUpdateDevices:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
     NS_SWIFT_NAME(audioDeviceModuleDidUpdateDevices(_:));
 
+@optional
+
+// Audio session interruption events. Fired on the device thread before the
+// engine reacts to the event, in particular before the engine restarts on
+// interruption end, so a delegate that owns the audio session lifecycle can
+// reactivate the session first. Implementations must not block.
+- (void)audioDeviceModuleDidBeginInterruption:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+    NS_SWIFT_NAME(audioDeviceModuleDidBeginInterruption(_:));
+
+- (void)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+    didEndInterruptionWithShouldResume:(BOOL)shouldResume
+    NS_SWIFT_NAME(audioDeviceModule(_:didEndInterruptionWithShouldResume:));
+
 @end
 
 RTC_OBJC_EXPORT

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -157,6 +157,24 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
                                 context:context];
   }
 
+  // Optional protocol methods, so guard with respondsToSelector to keep
+  // existing delegates working unchanged.
+  void OnAudioSessionInterruptionBegan() override {
+    id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)> delegate = delegate_;
+    if (delegate == nil) return;
+    if ([delegate respondsToSelector:@selector(audioDeviceModuleDidBeginInterruption:)]) {
+      [delegate audioDeviceModuleDidBeginInterruption:adm_];
+    }
+  }
+
+  void OnAudioSessionInterruptionEnded(bool should_resume) override {
+    id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)> delegate = delegate_;
+    if (delegate == nil) return;
+    if ([delegate respondsToSelector:@selector(audioDeviceModule:didEndInterruptionWithShouldResume:)]) {
+      [delegate audioDeviceModule:adm_ didEndInterruptionWithShouldResume:should_resume];
+    }
+  }
+
   __weak id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)> delegate_;
 
  private:


### PR DESCRIPTION
## Problem

`AudioEngineDevice`'s constructor subscribes to `RTCAudioSession`'s delegate to receive interruption and route-change events. That instantiates the `RTCAudioSession` singleton in every app that creates the engine ADM, and the singleton manages the audio session autonomously from its own notification handlers: `updateAudioSessionAfterEvent` calls `setActive:(activationCount > 0)` on interruption end and media-services events. Any audio-session regime in the process that does not keep that activation refcount truthful gets fought by it (a raw-`AVAudioSession` regime reads count 0 and is actively deactivated mid-call). Higher layers that want to own the session lifecycle against plain `AVAudioSession` are forced into refcount bookkeeping purely because the ADM woke the singleton up.

The engine only needs the events, not the session management. Session lifecycle and configuration belong to higher layers, which know about CallKit ownership, background modes, and app audio policy.

## Change

- Observe `NSNotificationCenter` directly with a file-local forwarder feeding the same `AudioSessionObserver` methods, using the same valid-reason filter for route changes that the delegate adapter applied. The `canPlayOrRecord` and output-volume events are dropped: both were log-only no-ops here and are concepts of `RTCAudioSession` itself. Creating the ADM no longer instantiates the singleton; apps that use `RTCAudioSession` directly are unaffected.
- Surface interruption began/ended (with `shouldResume`) through `AudioDeviceObserver` and new optional `RTCAudioDeviceModuleDelegate` methods. With the singleton's implicit count-gated recovery out of the picture, a session-owning layer needs the signal to reactivate on resume. The events fire on the device thread before the engine reacts (in particular before the engine restarts on interruption end), matching the guidance to activate the session before restarting audio I/O. They are fire-and-forget and must not block, unlike the engine lifecycle hooks. Optional and `respondsToSelector`-guarded, so existing delegates keep working unchanged.

## Compatibility

- The legacy `AudioDeviceIOS` path still uses `RTCAudioSession` and is untouched.
- Existing delegates (LiveKit Swift SDK, React Native) compile and behave as before; adopting the new interruption events is opt-in.
- No session `setActive:` or configuration calls are added to the ADM.

## Testing

Compile-verified for iOS device (arm64, debug) per object and as the full `framework_objc` build. Runtime verification of interruption flows on device is pending; downstream SDK adoption (moving the LiveKit session observers to plain `AVAudioSession` and the new events) will follow in the SDK repos.

Related: #270 (enable-rollback compensation, standalone) completes the delegate contract for session-owning observers.