### PR TITLE
Fix Android audio-record lifecycle races

### DIFF
--- a/sdk/android/BUILD.gn
+++ b/sdk/android/BUILD.gn
@@ -1899,6 +1899,7 @@ if (is_android) {
       "tests/src/org/webrtc/RenderSynchronizerTest.java",
       "tests/src/org/webrtc/ScalingSettingsTest.java",
       "tests/src/org/webrtc/audio/LowLatencyAudioBufferManagerTest.java",
+      "tests/src/org/webrtc/audio/WebRtcAudioRecordTest.java",
     ]
 
     deps = [

--- a/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
+++ b/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
@@ -127,10 +127,22 @@ class WebRtcAudioRecord {
    * This thread uses a Process.THREAD_PRIORITY_URGENT_AUDIO priority.
    */
   private class AudioRecordThread extends Thread {
+    private final ByteBuffer byteBuffer;
+    private final byte[] emptyBytes;
+    private final int sampleRate;
+    private final int channelCount;
     private volatile boolean keepAlive = true;
 
-    public AudioRecordThread(String name) {
+    private AudioRecordThread(String name, ByteBuffer byteBuffer, byte[] emptyBytes,
+        int sampleRate, int channelCount) {
       super(name);
+      assertTrue(byteBuffer.capacity() == emptyBytes.length);
+      assertTrue(byteBuffer.capacity()
+          == getBytesPerFrame(channelCount, audioFormat) * getFramesPerBuffer(sampleRate));
+      this.byteBuffer = byteBuffer;
+      this.emptyBytes = emptyBytes;
+      this.sampleRate = sampleRate;
+      this.channelCount = channelCount;
     }
 
     @Override
@@ -264,6 +276,18 @@ class WebRtcAudioRecord {
       Logging.d(TAG, "stopThread");
       keepAlive = false;
     }
+
+    private boolean isStopping() {
+      return !keepAlive;
+    }
+
+    private boolean hasMatchingConfiguration(int sampleRate, int channelCount) {
+      return this.sampleRate == sampleRate && this.channelCount == channelCount;
+    }
+
+    private ByteBuffer getByteBuffer() {
+      return byteBuffer;
+    }
   }
 
   @CalledByNative
@@ -368,36 +392,69 @@ class WebRtcAudioRecord {
    * @return true if recording was initialized correctly.
    */
   public boolean initRecordingIfNeeded() {
-    synchronized (audioRecordStateLock) {
-      if (audioRecord == null){
-        return initRecordingImpl(expectedSampleRate, expectedChannelCount, false) >= 0;
+    synchronized (audioThreadStateLock) {
+      if (audioThread != null && audioThread.isStopping()) {
+        return false;
+      }
+      synchronized (audioRecordStateLock) {
+        if (audioThread != null) {
+          // A prewarmed recordingless thread already owns the buffer generation. Reuse it rather
+          // than replacing the outer fields underneath the running thread.
+          return audioThread.hasMatchingConfiguration(
+              expectedSampleRate, expectedChannelCount);
+        }
+        if (audioRecord == null){
+          return initRecordingImpl(expectedSampleRate, expectedChannelCount, false) >= 0;
+        }
+        return hasMatchingBufferConfiguration(expectedSampleRate, expectedChannelCount);
       }
     }
-    return true;
   }
 
   @CalledByNative
   private int initRecording(int sampleRate, int channels) {
     Logging.d(TAG, "initRecording(sampleRate=" + sampleRate + ", channels=" + channels + ")");
 
-    synchronized (audioRecordStateLock) {
-      if (!nativeCalledInitRecording.compareAndSet(false, true)) {
-        reportWebRtcAudioRecordInitError("InitRecording called twice without StopRecording.");
+    synchronized (audioThreadStateLock) {
+      if (audioThread != null && audioThread.isStopping()) {
+        Logging.w(TAG, "InitRecording called while recording is stopping.");
         return -1;
       }
-  
-      if (audioRecord == null){
-        return initRecordingImpl(sampleRate, channels, true);
-      }
+      synchronized (audioRecordStateLock) {
+        if (!nativeCalledInitRecording.compareAndSet(false, true)) {
+          reportWebRtcAudioRecordInitError("InitRecording called twice without StopRecording.");
+          return -1;
+        }
 
-      // initRecording was already called previously by client.
-      // Handle required steps for native libwebrtc.
-      final int framesPerBuffer = getFramesPerBuffer(sampleRate);
-      if (byteBuffer == null) {
-        throw new IllegalStateException("initRecording: byteBuffer is null!");
+        final int framesPerBuffer = getFramesPerBuffer(sampleRate);
+        if (audioThread != null) {
+          if (!audioThread.hasMatchingConfiguration(sampleRate, channels)) {
+            reportWebRtcAudioRecordInitError(
+                "InitRecording cannot replace the active audio buffer configuration.");
+            nativeCalledInitRecording.set(false);
+            return -1;
+          }
+          // The thread and JNI must use the same direct-buffer generation. This is the normal
+          // native-init-after-prewarm path when AudioRecord is intentionally disabled.
+          cacheDirectBufferAddress(audioThread.getByteBuffer());
+          return framesPerBuffer;
+        }
+  
+        if (audioRecord == null){
+          return initRecordingImpl(sampleRate, channels, true);
+        }
+
+        // initRecording was already called previously by client.
+        // Handle required steps for native libwebrtc.
+        if (!hasMatchingBufferConfiguration(sampleRate, channels)) {
+          reportWebRtcAudioRecordInitError(
+              "InitRecording configuration differs from the initialized AudioRecord.");
+          nativeCalledInitRecording.set(false);
+          return -1;
+        }
+        cacheDirectBufferAddress(byteBuffer);
+        return framesPerBuffer;
       }
-      nativeCacheDirectBufferAddress(nativeAudioRecord, byteBuffer);
-      return framesPerBuffer;
     }
   }
 
@@ -407,23 +464,25 @@ class WebRtcAudioRecord {
       reportWebRtcAudioRecordInitError("InitRecording called twice without StopRecording.");
       return -1;
     }
-    this.sampleRate = sampleRate;
-    this.channelCount = channels;
     final int bytesPerFrame = getBytesPerFrame(channels, this.audioFormat);
     final int framesPerBuffer = getFramesPerBuffer(sampleRate);
-    byteBuffer = ByteBuffer.allocateDirect(bytesPerFrame * framesPerBuffer);
-    if (!byteBuffer.hasArray()) {
+    final ByteBuffer newByteBuffer = ByteBuffer.allocateDirect(bytesPerFrame * framesPerBuffer);
+    if (!newByteBuffer.hasArray()) {
       reportWebRtcAudioRecordInitError("ByteBuffer does not have backing array.");
       return -1;
     }
+    final byte[] newEmptyBytes = new byte[newByteBuffer.capacity()];
+    this.sampleRate = sampleRate;
+    this.channelCount = channels;
+    byteBuffer = newByteBuffer;
+    emptyBytes = newEmptyBytes;
     Logging.d(TAG, "byteBuffer.capacity: " + byteBuffer.capacity());
-    emptyBytes = new byte[byteBuffer.capacity()];
     // Rather than passing the ByteBuffer with every callback (requiring
     // the potentially expensive GetDirectBufferAddress) we simply have the
     // the native class cache the address to the memory once.
     // Caching can only be done on the native thread.
     if (nativeCall) {
-      nativeCacheDirectBufferAddress(nativeAudioRecord, byteBuffer);
+      cacheDirectBufferAddress(byteBuffer);
     }
 
     if(useAudioRecord) {
@@ -528,30 +587,25 @@ class WebRtcAudioRecord {
   }
 
   public boolean prewarmRecordingIfNeeded() {
-    if(audioThread == null) {
-      synchronized(audioRecordStateLock) {
-        synchronized (audioThreadStateLock) {
-          if (audioThread == null) {
-            return startRecordingImpl();
-          }
-        }
+    synchronized (audioThreadStateLock) {
+      if (audioThread == null) {
+        return startRecordingImpl();
       }
+      if (audioThread.isStopping() && !audioThread.isAlive()) {
+        // A previous timed-out stop retained the AudioRecord. Once its thread has terminated, a
+        // prewarm can safely transfer those resources to a replacement thread.
+        audioThread = null;
+        return startRecordingImpl();
+      }
+      // A prewarm is not an ongoing request for recording, so do not race a stop by reviving a
+      // thread which is already shutting down. The caller can retry after stop completes.
+      return !audioThread.isStopping();
     }
-    return true;
   }
 
   public boolean startRecordingIfNeeded() {
     clientCalledStartRecording.set(true);
-    if(audioThread == null) {
-      synchronized(audioRecordStateLock) {
-        synchronized (audioThreadStateLock) {
-          if (audioThread == null) {
-            return startRecordingImpl();
-          }
-        }
-      }
-    }
-    return true;
+    return startRecordingAfterPreviousThreadStops();
   }
 
   @CalledByNative
@@ -559,24 +613,67 @@ class WebRtcAudioRecord {
     if (!nativeCalledStartRecording.compareAndSet(false, true)) {
       throw new IllegalStateException("startRecording called twice without stopRecording");
     }
-    if (audioThread == null) {
-      synchronized(audioRecordStateLock) {
-        synchronized (audioThreadStateLock) {
-          if (audioThread == null) {
-            return startRecordingImpl();
+    return startRecordingAfterPreviousThreadStops();
+  }
+
+  private boolean startRecordingAfterPreviousThreadStops() {
+    while (true) {
+      final AudioRecordThread threadToJoin;
+      synchronized (audioThreadStateLock) {
+        if (!isRecordingRequested()) {
+          // A concurrent stop canceled this start before it acquired the state lock.
+          return false;
+        }
+        if (audioThread == null) {
+          return startRecordingImpl();
+        }
+        if (!audioThread.isStopping()) {
+          return true;
+        }
+        if (!audioThread.isAlive()) {
+          // A failed stop deliberately keeps the AudioRecord resources owned by audioThread. Once
+          // the thread has terminated, transfer that ownership to the replacement thread instead
+          // of releasing an AudioRecord which the new start can safely reuse.
+          audioThread = null;
+          return startRecordingImpl();
+        }
+        if (audioThread == Thread.currentThread()) {
+          // A stop-state callback runs on AudioRecordJavaThread. The stop caller will observe the
+          // request flag after join and restart recording once this callback returns.
+          return true;
+        }
+        threadToJoin = audioThread;
+      }
+
+      // Do not hold either state lock while waiting. AudioRecordJavaThread takes
+      // audioRecordStateLock while reading and may re-enter start/stop through its state callback.
+      if (!joinAudioRecordThread(threadToJoin)) {
+        Logging.e(TAG, "Join of previous AudioRecordJavaThread timed out during start");
+        WebRtcAudioUtils.logAudioState(TAG, context, audioManager);
+        return false;
+      }
+      synchronized (audioThreadStateLock) {
+        if (audioThread == threadToJoin) {
+          audioThread = null;
+          if (!isRecordingRequested()) {
+            synchronized (audioRecordStateLock) {
+              if (!nativeCalledInitRecording.get()) {
+                releaseAudioResources();
+              }
+            }
+            return false;
           }
         }
       }
     }
-    return true;
   }
 
   private boolean startRecordingImpl() {
     Logging.d(TAG, "startRecording");
-    synchronized (audioRecordStateLock) {
-      synchronized (audioThreadStateLock) {
+    synchronized (audioThreadStateLock) {
+      synchronized (audioRecordStateLock) {
         assertTrue(audioThread == null);
-        // Disabling useAudioRecord allows for "recordingless" recording, 
+        // Disabling useAudioRecord allows for "recordingless" recording,
         // where we emit audio buffers to be mixed in by client.
         if (useAudioRecord) {
           assertTrue(audioRecord != null);
@@ -594,7 +691,10 @@ class WebRtcAudioRecord {
             return false;
           }
         }
-        audioThread = new AudioRecordThread("AudioRecordJavaThread");
+        assertTrue(byteBuffer != null);
+        assertTrue(emptyBytes != null);
+        audioThread = new AudioRecordThread(
+            "AudioRecordJavaThread", byteBuffer, emptyBytes, sampleRate, channelCount);
         audioThread.start();
         scheduleLogRecordingConfigurationsTask(audioRecord);
         return true;
@@ -606,52 +706,85 @@ class WebRtcAudioRecord {
   private AtomicBoolean nativeCalledInitRecording = new AtomicBoolean(false);
   private AtomicBoolean nativeCalledStartRecording = new AtomicBoolean(false);
 
+  private boolean isRecordingRequested() {
+    return clientCalledStartRecording.get() || nativeCalledStartRecording.get();
+  }
+
   public boolean stopRecordingIfNeeded() {
     Logging.d(TAG, "stopRecordingIfNeeded");
-    synchronized(audioRecordStateLock) {
-      clientCalledStartRecording.set(false);
-      if(audioThread != null) {
-        return stopRecordingIfNeededImpl();
-      }
-    }
-    return true;
+    clientCalledStartRecording.set(false);
+    return stopRecordingIfNeededImpl();
   }
 
   @CalledByNative
   private boolean stopRecording() {
     Logging.d(TAG, "stopRecording");
-    synchronized(audioRecordStateLock) {
-      nativeCalledStartRecording.set(false);
-      nativeCalledInitRecording.set(false);
-      return stopRecordingIfNeededImpl();
-    }
+    nativeCalledStartRecording.set(false);
+    nativeCalledInitRecording.set(false);
+    return stopRecordingIfNeededImpl();
   }
 
   private boolean stopRecordingIfNeededImpl() {
-    synchronized(audioRecordStateLock) {
-      if(clientCalledStartRecording.get() || nativeCalledStartRecording.get()) {
-        // Someone has still requested recording, ignore stop request.
+    final AudioRecordThread threadToStop;
+    synchronized (audioThreadStateLock) {
+      synchronized (audioRecordStateLock) {
+        if (isRecordingRequested()) {
+          // Someone has still requested recording, ignore stop request.
+          return true;
+        }
+
+        Logging.d(TAG, "stopping recording");
+        if (audioThread == null) {
+          if (audioRecord != null && !nativeCalledInitRecording.get()) {
+            releaseAudioResources();
+          }
+          return true;
+        }
+        if (future != null) {
+          if (!future.isDone()) {
+            // Might be needed if the client calls startRecording(), stopRecording() back-to-back.
+            future.cancel(true /* mayInterruptIfRunning */);
+          }
+          future = null;
+        }
+        threadToStop = audioThread;
+        threadToStop.stopThread();
+      }
+    }
+
+    // The recording thread acquires audioRecordStateLock once per read and invokes the state
+    // callback before exiting. Never wait while holding either state lock.
+    if (!joinAudioRecordThread(threadToStop)) {
+      Logging.e(TAG, "Join of AudioRecordJavaThread timed out");
+      WebRtcAudioUtils.logAudioState(TAG, context, audioManager);
+      return false;
+    }
+
+    synchronized (audioThreadStateLock) {
+      if (audioThread != threadToStop) {
+        // A concurrent start already transferred the retained resources to a replacement thread.
         return true;
       }
-
-      Logging.d(TAG, "stopping recording");
-      assertTrue(audioThread != null);
-      if (future != null) {
-        if (!future.isDone()) {
-          // Might be needed if the client calls startRecording(), stopRecording() back-to-back.
-          future.cancel(true /* mayInterruptIfRunning */);
+      synchronized (audioRecordStateLock) {
+        audioThread = null;
+        if (isRecordingRequested()) {
+          // A start raced the join or was requested from the stop-state callback. Reuse the stopped
+          // AudioRecord rather than releasing it between the request and the replacement thread.
+          return startRecordingImpl();
         }
-        future = null;
+        if (nativeCalledInitRecording.get()) {
+          // A new native init won the race with the old stop before it marked the thread stopping.
+          // Keep its initialized AudioRecord for the corresponding future start.
+          return true;
+        }
+        releaseAudioResources();
       }
-      audioThread.stopThread();
-      if (!ThreadUtils.joinUninterruptibly(audioThread, AUDIO_RECORD_THREAD_JOIN_TIMEOUT_MS)) {
-        Logging.e(TAG, "Join of AudioRecordJavaThread timed out");
-        WebRtcAudioUtils.logAudioState(TAG, context, audioManager);
-      }
-      audioThread = null;
-      releaseAudioResources();
-      return true;
     }
+    return true;
+  }
+
+  boolean joinAudioRecordThread(Thread thread) {
+    return ThreadUtils.joinUninterruptibly(thread, AUDIO_RECORD_THREAD_JOIN_TIMEOUT_MS);
   }
 
   @TargetApi(Build.VERSION_CODES.M)
@@ -742,6 +875,10 @@ class WebRtcAudioRecord {
 
   private int channelCountToConfiguration(int channels) {
     return (channels == 1 ? AudioFormat.CHANNEL_IN_MONO : AudioFormat.CHANNEL_IN_STEREO);
+  }
+
+  void cacheDirectBufferAddress(ByteBuffer byteBuffer) {
+    nativeCacheDirectBufferAddress(nativeAudioRecord, byteBuffer);
   }
 
   private native void nativeCacheDirectBufferAddress(
@@ -846,6 +983,17 @@ class WebRtcAudioRecord {
 
   private static int getFramesPerBuffer(int sampleRate) {
     return sampleRate / BUFFERS_PER_SECOND;
+  }
+
+  private boolean hasMatchingBufferConfiguration(int sampleRate, int channelCount) {
+    if (byteBuffer == null || emptyBytes == null) {
+      return false;
+    }
+    final int expectedCapacity =
+        getBytesPerFrame(channelCount, audioFormat) * getFramesPerBuffer(sampleRate);
+    return this.sampleRate == sampleRate && this.channelCount == channelCount
+        && byteBuffer.capacity() == expectedCapacity
+        && emptyBytes.length == expectedCapacity;
   }
 
   // Use an ExecutorService to schedule a task after a given delay where the task consists of

--- a/sdk/android/tests/src/org/webrtc/audio/WebRtcAudioRecordTest.java
+++ b/sdk/android/tests/src/org/webrtc/audio/WebRtcAudioRecordTest.java
@@ -1,0 +1,494 @@
+/*
+ *  Copyright 2026 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+package org.webrtc.audio;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioRecord;
+import android.media.MediaRecorder.AudioSource;
+import android.os.Build;
+import androidx.test.runner.AndroidJUnit4;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.webrtc.audio.JavaAudioDeviceModule.AudioBufferCallback;
+import org.webrtc.audio.JavaAudioDeviceModule.AudioRecordStateCallback;
+
+@RunWith(AndroidJUnit4.class)
+@Config(manifest = Config.NONE, sdk = Build.VERSION_CODES.M)
+public class WebRtcAudioRecordTest {
+  @Test
+  public void stopRecordingDoesNotHoldStateLocksWhileJoining() throws Exception {
+    Context context = RuntimeEnvironment.getApplication();
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    TestWebRtcAudioRecord audioRecord = new TestWebRtcAudioRecord(context, audioManager);
+    prepareRecordinglessInput(audioRecord);
+
+    assertTrue(audioRecord.prewarmRecordingIfNeeded());
+    assertTrue(audioRecord.stopRecordingIfNeeded());
+
+    assertFalse(audioRecord.audioRecordStateLockWasHeldWhileJoining);
+    assertFalse(audioRecord.audioThreadStateLockWasHeldWhileJoining);
+    assertNull(getField(audioRecord, "audioThread"));
+  }
+
+  @Test
+  public void startRecordingReusesResourcesAfterTimedOutStopThreadExits() throws Exception {
+    Context context = RuntimeEnvironment.getApplication();
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    TimeoutWebRtcAudioRecord audioRecord = new TimeoutWebRtcAudioRecord(context, audioManager);
+    AudioRecord platformAudioRecord = prepareMockedAudioRecord(audioRecord);
+
+    assertTrue(audioRecord.prewarmRecordingIfNeeded());
+    Thread stoppedThread = (Thread) getField(audioRecord, "audioThread");
+    assertFalse(audioRecord.stopRecordingIfNeeded());
+
+    assertSame(stoppedThread, getField(audioRecord, "audioThread"));
+    assertFalse(stoppedThread.isAlive());
+    verify(platformAudioRecord, never()).release();
+
+    assertTrue(audioRecord.startRecordingIfNeeded());
+    Thread restartedThread = (Thread) getField(audioRecord, "audioThread");
+    assertNotNull(restartedThread);
+    assertNotSame(stoppedThread, restartedThread);
+    assertTrue(restartedThread.isAlive());
+    verify(platformAudioRecord, times(2)).startRecording();
+    verify(platformAudioRecord, never()).release();
+
+    assertTrue(audioRecord.stopRecordingIfNeeded());
+    assertNull(getField(audioRecord, "audioThread"));
+    verify(platformAudioRecord).release();
+  }
+
+  @Test
+  public void prewarmReusesResourcesAfterTimedOutStopThreadExits() throws Exception {
+    Context context = RuntimeEnvironment.getApplication();
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    TimeoutWebRtcAudioRecord audioRecord = new TimeoutWebRtcAudioRecord(context, audioManager);
+    AudioRecord platformAudioRecord = prepareMockedAudioRecord(audioRecord);
+
+    assertTrue(audioRecord.prewarmRecordingIfNeeded());
+    Thread stoppedThread = (Thread) getField(audioRecord, "audioThread");
+    assertFalse(audioRecord.stopRecordingIfNeeded());
+
+    assertSame(stoppedThread, getField(audioRecord, "audioThread"));
+    assertFalse(stoppedThread.isAlive());
+    verify(platformAudioRecord, never()).release();
+
+    assertTrue(audioRecord.prewarmRecordingIfNeeded());
+    Thread restartedThread = (Thread) getField(audioRecord, "audioThread");
+    assertNotNull(restartedThread);
+    assertNotSame(stoppedThread, restartedThread);
+    assertTrue(restartedThread.isAlive());
+    verify(platformAudioRecord, times(2)).startRecording();
+    verify(platformAudioRecord, never()).release();
+
+    assertTrue(audioRecord.stopRecordingIfNeeded());
+    assertNull(getField(audioRecord, "audioThread"));
+    verify(platformAudioRecord).release();
+  }
+
+  @Test
+  public void stopCallbackCanRequestRestartWithoutDeadlockingJoin() throws Exception {
+    Context context = RuntimeEnvironment.getApplication();
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    RestartOnStopCallback callback = new RestartOnStopCallback();
+    CallbackWebRtcAudioRecord audioRecord =
+        new CallbackWebRtcAudioRecord(context, audioManager, callback);
+    callback.audioRecord = audioRecord;
+    prepareRecordinglessInput(audioRecord);
+
+    assertTrue(audioRecord.prewarmRecordingIfNeeded());
+    Thread stoppedThread = (Thread) getField(audioRecord, "audioThread");
+    assertTrue(audioRecord.stopRecordingIfNeeded());
+
+    assertTrue(callback.restartResult);
+    Thread restartedThread = (Thread) getField(audioRecord, "audioThread");
+    assertNotNull(restartedThread);
+    assertNotSame(stoppedThread, restartedThread);
+    assertTrue(restartedThread.isAlive());
+
+    assertTrue(audioRecord.stopRecordingIfNeeded());
+    assertNull(getField(audioRecord, "audioThread"));
+  }
+
+  @Test
+  public void audioRecordThreadKeepsBufferGenerationPairedDuringReplacement() throws Exception {
+    Context context = RuntimeEnvironment.getApplication();
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    BlockingAudioBufferCallback callback = new BlockingAudioBufferCallback();
+    GenerationWebRtcAudioRecord audioRecord =
+        new GenerationWebRtcAudioRecord(context, audioManager, callback);
+    prepareRecordinglessInput(audioRecord);
+
+    assertTrue(audioRecord.prewarmRecordingIfNeeded());
+    assertTrue(callback.firstBufferReady.await(5, TimeUnit.SECONDS));
+    Thread oldThread = (Thread) getField(audioRecord, "audioThread");
+    AtomicReference<Throwable> threadFailure = new AtomicReference<>();
+    oldThread.setUncaughtExceptionHandler((thread, error) -> threadFailure.set(error));
+    try {
+      // Simulate overlapping publication of a smaller next-generation buffer. The running thread
+      // must continue to use the immutable buffer/silence pair it captured at construction.
+      setField(audioRecord, "byteBuffer", ByteBuffer.allocate(480));
+      callback.continueFirstBuffer.countDown();
+
+      assertTrue(callback.secondBufferReady.await(5, TimeUnit.SECONDS));
+      assertNull(threadFailure.get());
+    } finally {
+      callback.continueFirstBuffer.countDown();
+      setField(audioRecord, "emptyBytes", new byte[480]);
+      audioRecord.stopRecordingIfNeeded();
+    }
+  }
+
+  @Test
+  public void audioRecordThreadKeepsMutedBufferGenerationPairedDuringReplacement()
+      throws Exception {
+    Context context = RuntimeEnvironment.getApplication();
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    BlockingAudioBufferCallback callback = new BlockingAudioBufferCallback();
+    GenerationWebRtcAudioRecord audioRecord =
+        new GenerationWebRtcAudioRecord(context, audioManager, callback);
+    prepareMockedAudioRecord(audioRecord);
+    audioRecord.setMicrophoneMute(true);
+
+    assertTrue(audioRecord.prewarmRecordingIfNeeded());
+    assertTrue(callback.firstBufferReady.await(5, TimeUnit.SECONDS));
+    Thread oldThread = (Thread) getField(audioRecord, "audioThread");
+    AtomicReference<Throwable> threadFailure = new AtomicReference<>();
+    oldThread.setUncaughtExceptionHandler((thread, error) -> threadFailure.set(error));
+    try {
+      setField(audioRecord, "byteBuffer", ByteBuffer.allocate(480));
+      callback.continueFirstBuffer.countDown();
+
+      assertTrue(callback.secondBufferReady.await(5, TimeUnit.SECONDS));
+      assertNull(threadFailure.get());
+    } finally {
+      callback.continueFirstBuffer.countDown();
+      setField(audioRecord, "emptyBytes", new byte[480]);
+      audioRecord.stopRecordingIfNeeded();
+    }
+  }
+
+  @Test
+  public void nativeInitDuringPrewarmCachesRunningThreadBufferGeneration() throws Exception {
+    Context context = RuntimeEnvironment.getApplication();
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    BlockingAudioBufferCallback callback = new BlockingAudioBufferCallback();
+    GenerationWebRtcAudioRecord audioRecord =
+        new GenerationWebRtcAudioRecord(context, audioManager, callback);
+    ByteBuffer prewarmBuffer = prepareRecordinglessInput(audioRecord);
+
+    assertTrue(audioRecord.prewarmRecordingIfNeeded());
+    AtomicReference<Boolean> stopResult = new AtomicReference<>();
+    Thread stopper = new Thread(() -> stopResult.set(audioRecord.stopRecordingIfNeeded()));
+    try {
+      assertTrue(callback.firstBufferReady.await(5, TimeUnit.SECONDS));
+      assertSame(prewarmBuffer, callback.firstBuffer.get());
+
+      assertEquals(480, invokeInitRecording(audioRecord, 48000, 1));
+      assertSame(prewarmBuffer, audioRecord.cachedBuffer.get());
+
+      stopper.start();
+      assertTrue(audioRecord.joinStarted.await(5, TimeUnit.SECONDS));
+      callback.continueFirstBuffer.countDown();
+      stopper.join(TimeUnit.SECONDS.toMillis(5));
+
+      assertFalse(stopper.isAlive());
+      assertEquals(Boolean.TRUE, stopResult.get());
+      assertNull(getField(audioRecord, "audioThread"));
+    } finally {
+      if (stopper.getState() == Thread.State.NEW) {
+        stopper.start();
+        audioRecord.joinStarted.await(5, TimeUnit.SECONDS);
+      }
+      callback.continueFirstBuffer.countDown();
+      stopper.join(TimeUnit.SECONDS.toMillis(5));
+      audioRecord.stopRecordingIfNeeded();
+    }
+  }
+
+  @Test
+  public void nativeInitDuringPrewarmRejectsDifferentBufferConfiguration() throws Exception {
+    Context context = RuntimeEnvironment.getApplication();
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    BlockingAudioBufferCallback callback = new BlockingAudioBufferCallback();
+    GenerationWebRtcAudioRecord audioRecord =
+        new GenerationWebRtcAudioRecord(context, audioManager, callback);
+    ByteBuffer prewarmBuffer = prepareRecordinglessInput(audioRecord);
+
+    assertTrue(audioRecord.prewarmRecordingIfNeeded());
+    AtomicReference<Boolean> stopResult = new AtomicReference<>();
+    Thread stopper = new Thread(() -> stopResult.set(audioRecord.stopRecordingIfNeeded()));
+    try {
+      assertTrue(callback.firstBufferReady.await(5, TimeUnit.SECONDS));
+
+      assertEquals(-1, invokeInitRecording(audioRecord, 24000, 1));
+      assertNull(audioRecord.cachedBuffer.get());
+      assertSame(prewarmBuffer, getField(audioRecord, "byteBuffer"));
+      assertFalse(
+          ((AtomicBoolean) getField(audioRecord, "nativeCalledInitRecording")).get());
+
+      stopper.start();
+      assertTrue(audioRecord.joinStarted.await(5, TimeUnit.SECONDS));
+      callback.continueFirstBuffer.countDown();
+      stopper.join(TimeUnit.SECONDS.toMillis(5));
+
+      assertFalse(stopper.isAlive());
+      assertEquals(Boolean.TRUE, stopResult.get());
+    } finally {
+      if (stopper.getState() == Thread.State.NEW) {
+        stopper.start();
+        audioRecord.joinStarted.await(5, TimeUnit.SECONDS);
+      }
+      callback.continueFirstBuffer.countDown();
+      stopper.join(TimeUnit.SECONDS.toMillis(5));
+      audioRecord.stopRecordingIfNeeded();
+    }
+  }
+
+  private static ByteBuffer prepareRecordinglessInput(WebRtcAudioRecord audioRecord)
+      throws Exception {
+    ByteBuffer byteBuffer = ByteBuffer.allocate(960);
+    setField(audioRecord, "byteBuffer", byteBuffer);
+    setField(audioRecord, "emptyBytes", new byte[960]);
+    setField(audioRecord, "sampleRate", 48000);
+    setField(audioRecord, "channelCount", 1);
+    audioRecord.setUseAudioRecord(false);
+    return byteBuffer;
+  }
+
+  private static AudioRecord prepareMockedAudioRecord(WebRtcAudioRecord audioRecord)
+      throws Exception {
+    AudioRecord platformAudioRecord = mock(AudioRecord.class);
+    when(platformAudioRecord.getRecordingState()).thenReturn(AudioRecord.RECORDSTATE_RECORDING);
+    when(platformAudioRecord.read(any(ByteBuffer.class), anyInt()))
+        .thenAnswer(invocation -> ((ByteBuffer) invocation.getArgument(0)).capacity());
+    setField(audioRecord, "byteBuffer", ByteBuffer.allocate(960));
+    setField(audioRecord, "emptyBytes", new byte[960]);
+    setField(audioRecord, "sampleRate", 48000);
+    setField(audioRecord, "channelCount", 1);
+    setField(audioRecord, "audioRecord", platformAudioRecord);
+    return platformAudioRecord;
+  }
+
+  private static int invokeInitRecording(
+      WebRtcAudioRecord audioRecord, int sampleRate, int channelCount) throws Exception {
+    Method method =
+        WebRtcAudioRecord.class.getDeclaredMethod("initRecording", int.class, int.class);
+    method.setAccessible(true);
+    return (int) method.invoke(audioRecord, sampleRate, channelCount);
+  }
+
+  private static Object getField(Object target, String name) throws Exception {
+    Field field = WebRtcAudioRecord.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = WebRtcAudioRecord.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static final class TestWebRtcAudioRecord extends WebRtcAudioRecord {
+    private final Object audioRecordStateLock;
+    private final Object audioThreadStateLock;
+    private boolean audioRecordStateLockWasHeldWhileJoining;
+    private boolean audioThreadStateLockWasHeldWhileJoining;
+
+    TestWebRtcAudioRecord(Context context, AudioManager audioManager) throws Exception {
+      super(
+          context,
+          WebRtcAudioRecord.newDefaultScheduler(),
+          audioManager,
+          AudioSource.VOICE_COMMUNICATION,
+          AudioFormat.ENCODING_PCM_16BIT,
+          null,
+          null,
+          null,
+          null,
+          false,
+          false,
+          48000,
+          1);
+      audioRecordStateLock = getField(this, "audioRecordStateLock");
+      audioThreadStateLock = getField(this, "audioThreadStateLock");
+    }
+
+    @Override
+    boolean joinAudioRecordThread(Thread thread) {
+      audioRecordStateLockWasHeldWhileJoining = Thread.holdsLock(audioRecordStateLock);
+      audioThreadStateLockWasHeldWhileJoining = Thread.holdsLock(audioThreadStateLock);
+      return super.joinAudioRecordThread(thread);
+    }
+  }
+
+  private static final class TimeoutWebRtcAudioRecord extends WebRtcAudioRecord {
+    private boolean simulateTimeout = true;
+
+    TimeoutWebRtcAudioRecord(Context context, AudioManager audioManager) {
+      super(
+          context,
+          WebRtcAudioRecord.newDefaultScheduler(),
+          audioManager,
+          AudioSource.VOICE_COMMUNICATION,
+          AudioFormat.ENCODING_PCM_16BIT,
+          null,
+          null,
+          null,
+          null,
+          false,
+          false,
+          48000,
+          1);
+    }
+
+    @Override
+    boolean joinAudioRecordThread(Thread thread) {
+      boolean joined = super.joinAudioRecordThread(thread);
+      if (simulateTimeout) {
+        simulateTimeout = false;
+        assertTrue(joined);
+        return false;
+      }
+      return joined;
+    }
+  }
+
+  private static final class CallbackWebRtcAudioRecord extends WebRtcAudioRecord {
+    CallbackWebRtcAudioRecord(
+        Context context, AudioManager audioManager, AudioRecordStateCallback stateCallback) {
+      super(
+          context,
+          WebRtcAudioRecord.newDefaultScheduler(),
+          audioManager,
+          AudioSource.VOICE_COMMUNICATION,
+          AudioFormat.ENCODING_PCM_16BIT,
+          null,
+          stateCallback,
+          null,
+          null,
+          false,
+          false,
+          48000,
+          1);
+    }
+  }
+
+  private static final class GenerationWebRtcAudioRecord extends WebRtcAudioRecord {
+    private final AtomicReference<ByteBuffer> cachedBuffer = new AtomicReference<>();
+    private final CountDownLatch joinStarted = new CountDownLatch(1);
+
+    GenerationWebRtcAudioRecord(
+        Context context, AudioManager audioManager, AudioBufferCallback audioBufferCallback) {
+      super(
+          context,
+          WebRtcAudioRecord.newDefaultScheduler(),
+          audioManager,
+          AudioSource.VOICE_COMMUNICATION,
+          AudioFormat.ENCODING_PCM_16BIT,
+          null,
+          null,
+          null,
+          audioBufferCallback,
+          false,
+          false,
+          48000,
+          1);
+    }
+
+    @Override
+    void cacheDirectBufferAddress(ByteBuffer byteBuffer) {
+      cachedBuffer.set(byteBuffer);
+    }
+
+    @Override
+    boolean joinAudioRecordThread(Thread thread) {
+      joinStarted.countDown();
+      return super.joinAudioRecordThread(thread);
+    }
+  }
+
+  private static final class BlockingAudioBufferCallback implements AudioBufferCallback {
+    private final AtomicInteger bufferCount = new AtomicInteger();
+    private final AtomicReference<ByteBuffer> firstBuffer = new AtomicReference<>();
+    private final CountDownLatch firstBufferReady = new CountDownLatch(1);
+    private final CountDownLatch continueFirstBuffer = new CountDownLatch(1);
+    private final CountDownLatch secondBufferReady = new CountDownLatch(1);
+
+    @Override
+    public long onBuffer(
+        ByteBuffer buffer,
+        int audioFormat,
+        int channelCount,
+        int sampleRate,
+        int bytesRead,
+        long captureTimeNs) {
+      int count = bufferCount.incrementAndGet();
+      if (count == 1) {
+        firstBuffer.set(buffer);
+        firstBufferReady.countDown();
+        try {
+          continueFirstBuffer.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      } else if (count == 2) {
+        secondBufferReady.countDown();
+      }
+      return captureTimeNs;
+    }
+  }
+
+  private static final class RestartOnStopCallback implements AudioRecordStateCallback {
+    private WebRtcAudioRecord audioRecord;
+    private boolean shouldRestart = true;
+    private boolean restartResult;
+
+    @Override
+    public void onWebRtcAudioRecordStart() {}
+
+    @Override
+    public void onWebRtcAudioRecordStop() {
+      if (shouldRestart) {
+        shouldRestart = false;
+        restartResult = audioRecord.startRecordingIfNeeded();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Make Android `WebRtcAudioRecord` start/stop and buffer ownership safe under overlapping client/native lifecycle calls. The recording thread now owns an immutable buffer generation, stop never joins while holding state locks, and replacement starts reuse retained resources only after the previous thread has exited.

## Why

Three production crash groups (`CG009`, `CG149`, and `CG154`) converge on two races in the prefixed WebRTC SDK: a stop/join lock inversion around `AudioRecordJavaThread`, and publication of a new direct-buffer/silence-array generation while the previous capture thread still used the old one. These could deadlock or release/mix native audio buffers during rapid voice lifecycle transitions.

## Implementation notes

- Serialize thread-state transitions without holding either state lock during `join`.
- Retain timed-out-stop resources until the old thread exits, then transfer or release them based on the latest request state.
- Pair each capture thread with its own direct buffer, silence buffer, sample rate, and channel count; native init reuses only a matching generation.

## Test plan

- Added deterministic Android tests for stop/join lock ownership, timed-out stop recovery, callback-driven restart, and prewarm/native-init overlap.
- Added muted and unmuted buffer-generation replacement regressions plus configuration/capacity checks.
- `git diff --check` and standalone Java compilation pass.
- This sparse checkout does not contain a runnable GN/Android test toolchain, so the new GN test target is left for CI.
