### PR TITLE
Pass resolved voice processing state to OnEngineWillEnable

### DIFF
--- a/api/audio/audio_device.h
+++ b/api/audio/audio_device.h
@@ -292,8 +292,14 @@ class AudioDeviceObserver {
   // AVAudioEngine lifecycle
   virtual int32_t OnEngineDidCreate(AVAudioEngine* engine) { return 0; }
 
+  // `voice_processing_enabled` reports the resolved Apple Voice Processing I/O
+  // state the engine is transitioning to. It is passed explicitly because the
+  // transition has not been committed to the device state yet when this fires,
+  // and observers that configure the audio session need it up front (iOS uses
+  // a reduced call-tuned speaker gain in the chat session modes that only
+  // Apple voice processing compensates for).
   virtual int32_t OnEngineWillEnable(AVAudioEngine* engine, bool playout_enabled,
-                                     bool recording_enabled) {
+                                     bool recording_enabled, bool voice_processing_enabled) {
     return 0;
   }
 

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1838,8 +1838,10 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
   if (state.DidAnyEnable() && observer_ != nullptr) {
     // Invoke here before configuring nodes. In iOS, session configuration is required before
     // enabling AGC, muted talker etc.
-    int32_t result = observer_->OnEngineWillEnable(
-        engine_manual_input_, state.next.IsOutputEnabled(), state.next.IsInputEnabled());
+    int32_t result = observer_->OnEngineWillEnable(engine_manual_input_,
+                                                   state.next.IsOutputEnabled(),
+                                                   state.next.IsInputEnabled(),
+                                                   state.next.voice_processing_enabled);
     if (result != 0) {
       LOGE() << "Call to OnEngineWillEnable returned error: " << result;
       return rollback(result);
@@ -2266,8 +2268,12 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   if (state.DidAnyEnable() && observer_ != nullptr) {
     // Invoke here before configuring nodes. In iOS, session configuration is required before
     // enabling AGC, muted talker etc.
+    // Voice processing is resolved in `state.next` but not committed to
+    // `engine_state_` yet, so observers cannot read it back and it is passed
+    // explicitly instead.
     int32_t result = observer_->OnEngineWillEnable(engine_device_, state.next.IsOutputEnabled(),
-                                                   state.next.IsInputEnabled());
+                                                   state.next.IsInputEnabled(),
+                                                   state.next.voice_processing_enabled);
     if (result != 0) {
       LOGE() << "Call to OnEngineWillEnable returned error: " << result;
       return rollback(result);

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1838,10 +1838,12 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
   if (state.DidAnyEnable() && observer_ != nullptr) {
     // Invoke here before configuring nodes. In iOS, session configuration is required before
     // enabling AGC, muted talker etc.
+    // Manual rendering never instantiates Voice Processing I/O, report false
+    // so the value always reflects whether a VPIO unit will actually exist.
     int32_t result = observer_->OnEngineWillEnable(engine_manual_input_,
                                                    state.next.IsOutputEnabled(),
                                                    state.next.IsInputEnabled(),
-                                                   state.next.voice_processing_enabled);
+                                                   /*voice_processing_enabled=*/false);
     if (result != 0) {
       LOGE() << "Call to OnEngineWillEnable returned error: " << result;
       return rollback(result);
@@ -2270,10 +2272,17 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     // enabling AGC, muted talker etc.
     // Voice processing is resolved in `state.next` but not committed to
     // `engine_state_` yet, so observers cannot read it back and it is passed
-    // explicitly instead.
+    // explicitly instead. The simulator never instantiates Voice Processing
+    // I/O (the configure step is skipped there), report false so the value
+    // always reflects whether a VPIO unit will actually exist.
+#if TARGET_OS_SIMULATOR
+    const bool will_enable_voice_processing = false;
+#else
+    const bool will_enable_voice_processing = state.next.voice_processing_enabled;
+#endif
     int32_t result = observer_->OnEngineWillEnable(engine_device_, state.next.IsOutputEnabled(),
                                                    state.next.IsInputEnabled(),
-                                                   state.next.voice_processing_enabled);
+                                                   will_enable_voice_processing);
     if (result != 0) {
       LOGE() << "Call to OnEngineWillEnable returned error: " << result;
       return rollback(result);

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -140,11 +140,16 @@ RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
                didCreateEngine:(AVAudioEngine *)engine
     NS_SWIFT_NAME(audioDeviceModule(_:didCreateEngine:));
 
+// `isVoiceProcessingEnabled` reports the resolved Apple Voice Processing I/O
+// state the engine is transitioning to, which is not yet readable from the
+// module when this fires. Observers that configure the audio session use it
+// to pick a session mode matching the processing implementation.
 - (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
               willEnableEngine:(AVAudioEngine *)engine
               isPlayoutEnabled:(BOOL)isPlayoutEnabled
             isRecordingEnabled:(BOOL)isRecordingEnabled
-    NS_SWIFT_NAME(audioDeviceModule(_:willEnableEngine:isPlayoutEnabled:isRecordingEnabled:));
+      isVoiceProcessingEnabled:(BOOL)isVoiceProcessingEnabled
+    NS_SWIFT_NAME(audioDeviceModule(_:willEnableEngine:isPlayoutEnabled:isRecordingEnabled:isVoiceProcessingEnabled:));
 
 - (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
                willStartEngine:(AVAudioEngine *)engine

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -95,12 +95,13 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   }
 
   int32_t OnEngineWillEnable(AVAudioEngine *engine, bool playout_enabled,
-                             bool recording_enabled) override {
+                             bool recording_enabled, bool voice_processing_enabled) override {
     if (delegate_ == nil) return 0;
     return [delegate_ audioDeviceModule:adm_
                        willEnableEngine:engine
                        isPlayoutEnabled:playout_enabled
-                     isRecordingEnabled:recording_enabled];
+                     isRecordingEnabled:recording_enabled
+               isVoiceProcessingEnabled:voice_processing_enabled];
   }
 
   int32_t OnEngineWillStart(AVAudioEngine *engine, bool playout_enabled,


### PR DESCRIPTION
## Motivation

Observers that configure the `AVAudioSession` need to know which voice processing implementation the engine is transitioning to. iOS applies a reduced, call tuned speaker gain when the session mode is `.videoChat` or `.voiceChat` while the microphone is active. Apple Voice Processing I/O compensates with its own loudness stage on the playout path, WebRTC software processing does not, so a session observer should pick `.default` mode when VPIO is off to keep media playback loudness (see livekit/client-sdk-swift#1072 for the device verified root cause analysis).

The engine transition state is not committed to `engine_state_` until the transition completes, so observers cannot read the resolved voice processing state back from the module when `OnEngineWillEnable` fires. This change passes the resolved value explicitly.

## Changes

- `AudioDeviceObserver::OnEngineWillEnable` gains a `voice_processing_enabled` parameter, passed from `state.next.voice_processing_enabled` at both call sites (device and manual rendering).
- `RTCAudioDeviceModuleDelegate.audioDeviceModule(_:willEnableEngine:isPlayoutEnabled:isRecordingEnabled:)` gains `isVoiceProcessingEnabled:` and the bridge forwards it.

This is a breaking signature change to the fork owned delegate. The Swift SDK adapter is the only known consumer and will adopt it together with the xcframework bump; there are no other implementers in this tree.

## Notes for review

- The value reports whether a VPIO unit will be instantiated. A bypassed unit still reports true, which is correct for session configuration since iOS applies voice call treatment whenever the unit exists on the IO path.
- The simulator and manual rendering call sites report false because VPIO can never be instantiated there.
- If the engine transition fails after the callback fired (for example setVoiceProcessingEnabled rejecting), the transition rolls back while an observer may have already configured the session for the new state. This transient mismatch in an already exceptional path heals on the next successful transition.

## Follow up

Once released, livekit/client-sdk-swift can replace the Swift side voice processing expectation plumbing from PR 1072 with this callback value, removing the duplicated resolution logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
