### PR TITLE
Couple engine output to input only while voice processing is enabled

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -191,7 +191,13 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     // AUDIO STATE LOGIC
     //
     // Device Mode:
-    // - Output follows input to keep AVAudioEngine IO active for capture.
+    // - Output follows input only while voice processing is enabled: Apple's
+    //   Voice Processing I/O couples the input and output units, so a VP
+    //   engine must run both. Without voice processing there is no structural
+    //   requirement, and keeping output off avoids claiming the shared output
+    //   device for capture-only states (input warm-up, mic-only before any
+    //   remote track), which is audible as a dip in other apps' audio on
+    //   macOS.
     // - Input respects mute mode restrictions (RestartEngine + input_muted)
     //
     // Manual Mode:
@@ -207,7 +213,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
       switch (render_mode) {
         case RenderMode::Device:
-          return IsInputEnabled() || output_enabled;
+          return (IsInputEnabled() && voice_processing_enabled) || output_enabled;
         case RenderMode::Manual:
           return output_enabled || input_enabled || input_enabled_persistent_mode;
       }
@@ -218,7 +224,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
       switch (render_mode) {
         case RenderMode::Device:
-          return IsInputRunning() || output_running;
+          return (IsInputRunning() && voice_processing_enabled) || output_running;
         case RenderMode::Manual:
           return output_running || input_running;
       }


### PR DESCRIPTION
## Motivation

Reported in livekit/client-sdk-swift#1076. On macOS, every input driven engine start also enabled the playout side, three times during a single connect (mic warm up, capture start, remote track arrival), even with all audio processing disabled.

The coupling is intentional for the voice processing case, Apple's Voice Processing I/O runs the input and output units together, so a VP engine must enable both. It was applied unconditionally though, including configurations with voice processing off where no structural requirement exists.

## Changes

Device mode output state now follows input only while `voice_processing_enabled` is set:

- `IsOutputEnabled()`: `(IsInputEnabled() && voice_processing_enabled) || output_enabled`
- `IsOutputRunning()`: `(IsInputRunning() && voice_processing_enabled) || output_running`

Voice processing configurations keep the exact previous behavior. With voice processing off, playout is enabled solely by explicit requests, `InitPlayout` from `AudioState` when a receiving stream exists, or direct callers. Manual rendering mode is unchanged.

## What this does and does not fix

This is a state correctness change, not a fix for the audible symptom in the linked issue. Measurements with a standalone probe (AVAudioEngine on macOS, kAudioOutputUnitProperty_IsRunning and device readbacks) show that `engine.start()` starts the output unit and claims the default output device in every graph shape, including input only graphs with nothing wired to output. The device nominal sample rate is not changed by any wiring variant either. So capture only engine starts continue to touch the output device with or without this patch, and the dips reported in the issue most likely track the number of engine starts, which this patch does not reduce.

What the patch does deliver:

- `isPlayoutEnabled` reported to engine observers tells the truth, output no longer reads enabled for capture only states without voice processing
- No output graph wiring (source node, mainMixer to output connect) for capture only states without voice processing
- `StopPlayout` genuinely takes the output side down when the last receiving stream ends while the mic stays on with voice processing off

## Behavior notes for review

With voice processing off, the first receiving stream now triggers an engine reconfiguration (output side added to a running capture engine) that previously did not happen because output was already up. This trade needs on device evaluation for capture glitches at subscription time before merging, tracked as a verification item below.

## Verification status

Syntax verified (`clang -fsyntax-only` on `audio_engine_device.mm`). Kept as draft until:

1. On device evaluation of the new engine reconfiguration at first subscription (iOS agent flow, mic on with software processing before any remote track)
2. Swift SDK SoundPlayer and app audio paths verified against the changed state combinations
3. Reporter feedback on livekit/client-sdk-swift#1076 (how options are applied, and the output route, a Bluetooth route would point at an A2DP to HFP profile switch instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)