### PR TITLE
Fall back to the OS trust store for TURN/TLS

### DIFF
--- a/rtc_base/BUILD.gn
+++ b/rtc_base/BUILD.gn
@@ -1665,6 +1665,7 @@ rtc_library("ssl_adapter") {
     "openssl_session_cache.h",
     "openssl_stream_adapter.cc",
     "openssl_stream_adapter.h",
+    "platform_certificate_verifier.cc",
     "platform_certificate_verifier.h",
     "ssl_adapter.cc",
     "ssl_adapter.h",

--- a/rtc_base/BUILD.gn
+++ b/rtc_base/BUILD.gn
@@ -1665,11 +1665,28 @@ rtc_library("ssl_adapter") {
     "openssl_session_cache.h",
     "openssl_stream_adapter.cc",
     "openssl_stream_adapter.h",
+    "platform_certificate_verifier.h",
     "ssl_adapter.cc",
     "ssl_adapter.h",
     "ssl_stream_adapter.cc",
     "ssl_stream_adapter.h",
   ]
+
+  if (is_mac || is_ios) {
+    sources += [ "platform_certificate_verifier_apple.cc" ]
+    frameworks = [
+      "CoreFoundation.framework",
+      "Security.framework",
+    ]
+  } else if (is_win) {
+    sources += [ "platform_certificate_verifier_win.cc" ]
+    libs = [ "crypt32.lib" ]
+  } else {
+    # Linux and the BSDs expose no trust evaluation API. Android has one, but
+    # reaching X509TrustManager needs a JNI target that does not belong in
+    # rtc_base. Both keep the built-in anchors as their only trust source.
+    sources += [ "platform_certificate_verifier_none.cc" ]
+  }
 
   deps = [
     ":async_socket",

--- a/rtc_base/BUILD.gn
+++ b/rtc_base/BUILD.gn
@@ -1682,9 +1682,11 @@ rtc_library("ssl_adapter") {
     sources += [ "platform_certificate_verifier_win.cc" ]
     libs = [ "crypt32.lib" ]
   } else {
-    # Linux and the BSDs expose no trust evaluation API. Android has one, but
-    # reaching X509TrustManager needs a JNI target that does not belong in
-    # rtc_base. Both keep the built-in anchors as their only trust source.
+    # Linux and the BSDs expose no trust evaluation API at all. Android does,
+    # but only via X509TrustManager, and rtc_base has no JNI layer to call it
+    # with; that lives in sdk/android. The Android implementation therefore
+    # belongs there and gets injected, the way NetworkMonitorFactory already
+    # is. Until then both keep the built-in anchors as their trust source.
     sources += [ "platform_certificate_verifier_none.cc" ]
   }
 
@@ -2392,6 +2394,7 @@ if (rtc_include_tests) {
           "openssl_adapter_unittest.cc",
           "openssl_session_cache_unittest.cc",
           "openssl_utility_unittest.cc",
+          "platform_certificate_verifier_unittest.cc",
           "ssl_adapter_unittest.cc",
           "ssl_identity_unittest.cc",
           "ssl_stream_adapter_unittest.cc",

--- a/rtc_base/openssl_adapter.cc
+++ b/rtc_base/openssl_adapter.cc
@@ -35,6 +35,7 @@
 #include "rtc_base/numerics/safe_conversions.h"
 #include "rtc_base/openssl_session_cache.h"
 #include "rtc_base/openssl_utility.h"
+#include "rtc_base/platform_certificate_verifier.h"
 #include "rtc_base/socket.h"
 #include "rtc_base/socket_address.h"
 #include "rtc_base/ssl_adapter.h"
@@ -289,6 +290,15 @@ int OpenSSLAdapter::BeginSSL() {
 
   // Cleanup action to deal with on error cleanup a bit cleaner.
   EarlyExitCatcher early_exit_catcher(*this);
+
+  // Nothing was supplied by the embedder, so fall back to the OS trust store
+  // where one is reachable. This only widens what the built-in anchors in
+  // ssl_roots.h already accept: SSLVerifyInternal consults a verifier solely
+  // after the built-in path has failed.
+  if (ssl_cert_verifier_ == nullptr && role_ == SSL_CLIENT) {
+    platform_cert_verifier_ = CreatePlatformCertificateVerifier();
+    ssl_cert_verifier_ = platform_cert_verifier_.get();
+  }
 
   // First set up the context. We should either have a factory, with its own
   // pre-existing context, or be running standalone, in which case we will

--- a/rtc_base/openssl_adapter.cc
+++ b/rtc_base/openssl_adapter.cc
@@ -292,9 +292,14 @@ int OpenSSLAdapter::BeginSSL() {
   EarlyExitCatcher early_exit_catcher(*this);
 
   // Nothing was supplied by the embedder, so fall back to the OS trust store
-  // where one is reachable. This only widens what the built-in anchors in
-  // ssl_roots.h already accept: SSLVerifyInternal consults a verifier solely
-  // after the built-in path has failed.
+  // where one is reachable.
+  //
+  // With the built-in anchors compiled in, which is the default, this can only
+  // widen what is accepted: SSLVerifyInternal consults a verifier solely after
+  // ssl_roots.h has already failed to produce a path. Under
+  // WEBRTC_EXCLUDE_BUILT_IN_SSL_ROOT_CERTS there are no built-in anchors and
+  // the verifier is the only trust decision made, which is still an
+  // improvement on the alternative there: no verifier fails every handshake.
   if (ssl_cert_verifier_ == nullptr && role_ == SSL_CLIENT) {
     platform_cert_verifier_ = CreatePlatformCertificateVerifier();
     ssl_cert_verifier_ = platform_cert_verifier_.get();

--- a/rtc_base/openssl_adapter.h
+++ b/rtc_base/openssl_adapter.h
@@ -142,6 +142,10 @@ class OpenSSLAdapter final : public SSLAdapter {
   OpenSSLSessionCache* ssl_session_cache_ = nullptr;
   // Optional SSL Certificate verifier which can be set by a third party.
   SSLCertificateVerifier* ssl_cert_verifier_ = nullptr;
+  // Fallback verifier backed by the OS trust store, used when no verifier was
+  // supplied and the platform provides one. Owns what `ssl_cert_verifier_`
+  // points at in that case.
+  std::unique_ptr<SSLCertificateVerifier> platform_cert_verifier_;
   // The current connection state of the (d)TLS connection.
   SSLState state_;
 

--- a/rtc_base/platform_certificate_verifier.cc
+++ b/rtc_base/platform_certificate_verifier.cc
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2026 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "rtc_base/platform_certificate_verifier.h"
+
+#include <atomic>
+#include <memory>
+
+namespace webrtc {
+namespace {
+
+// Written once during library initialisation and read on network threads for
+// every TLS handshake, hence the atomic rather than a plain pointer.
+std::atomic<PlatformCertificateVerifierFactory> g_factory{nullptr};
+
+}  // namespace
+
+void SetPlatformCertificateVerifierFactory(
+    PlatformCertificateVerifierFactory factory) {
+  g_factory.store(factory, std::memory_order_release);
+}
+
+std::unique_ptr<SSLCertificateVerifier> CreatePlatformCertificateVerifier() {
+  PlatformCertificateVerifierFactory factory =
+      g_factory.load(std::memory_order_acquire);
+  if (factory != nullptr) {
+    return factory();
+  }
+  return CreateNativePlatformCertificateVerifier();
+}
+
+}  // namespace webrtc

--- a/rtc_base/platform_certificate_verifier.h
+++ b/rtc_base/platform_certificate_verifier.h
@@ -25,10 +25,24 @@ namespace webrtc {
 // small, infrequently regenerated snapshot. A chain that the host OS trusts may
 // have no anchor there, which surfaces as a TURN/TLS handshake failure.
 //
-// The verifier is consulted only after the built-in anchors have already failed
-// to produce a valid path, so it can widen what is accepted but never narrow
-// it. Hostname matching is not performed here; OpenSSLAdapter checks it
-// separately in SSLPostConnectionCheck.
+// With the built-in anchors compiled in, which is the default, the verifier is
+// consulted only after ssl_roots.h has already failed to produce a valid path,
+// so it can widen what is accepted but never narrow it. Under
+// WEBRTC_EXCLUDE_BUILT_IN_SSL_ROOT_CERTS there are no built-in anchors and it
+// becomes the only trust decision made.
+//
+// This is a default, not an override. OpenSSLAdapter installs it only when the
+// embedder supplied no verifier of its own, so anything set through
+// PeerConnectionDependencies::tls_cert_verifier — the ObjC
+// certificateVerifier: initialiser, Android's
+// PeerConnectionDependencies.setSSLCertificateVerifier — takes precedence and
+// replaces this outright. Note the consequence: an embedder that supplies a
+// verifier does not also get the OS trust store as a fallback behind it, which
+// matters for anyone who adopted that API as a workaround for the very gap this
+// closes.
+//
+// Hostname matching is not performed here; OpenSSLAdapter checks it separately
+// in SSLPostConnectionCheck.
 std::unique_ptr<SSLCertificateVerifier> CreatePlatformCertificateVerifier();
 
 }  //  namespace webrtc

--- a/rtc_base/platform_certificate_verifier.h
+++ b/rtc_base/platform_certificate_verifier.h
@@ -17,9 +17,8 @@
 
 namespace webrtc {
 
-// Creates a verifier that validates a peer certificate chain against the
-// operating system's trust store, or nullptr on platforms that do not expose
-// one (Linux, ChromeOS, BSD).
+// Returns a verifier that validates a peer certificate chain against the
+// operating system's trust store, or nullptr where none is reachable.
 //
 // This exists because the built-in trust anchors in rtc_base/ssl_roots.h are a
 // small, infrequently regenerated snapshot. A chain that the host OS trusts may
@@ -44,6 +43,34 @@ namespace webrtc {
 // Hostname matching is not performed here; OpenSSLAdapter checks it separately
 // in SSLPostConnectionCheck.
 std::unique_ptr<SSLCertificateVerifier> CreatePlatformCertificateVerifier();
+
+using PlatformCertificateVerifierFactory =
+    std::unique_ptr<SSLCertificateVerifier> (*)();
+
+// Registers a factory for platforms whose trust store cannot be reached from
+// rtc_base itself. Android is the case in point: its anchors are only available
+// through X509TrustManager, which needs the JVM, and the JNI layer lives in
+// sdk/android. That layer registers here from JNI_OnLoad.
+//
+// Registering process-wide rather than injecting through
+// PeerConnectionDependencies is deliberate. Injection only reaches consumers
+// that build their dependencies through the Java or ObjC SDK; anything binding
+// the C++ API directly — webrtc-sys, and so the Rust and Python SDKs — supplies
+// its own PeerConnectionFactoryDependencies and would silently miss it.
+//
+// A registered factory takes precedence over the implementation compiled in for
+// the platform. Must be called before the first TLS handshake; passing nullptr
+// unregisters. Not thread-safe against concurrent handshakes, which is why the
+// only intended caller is library initialisation.
+void SetPlatformCertificateVerifierFactory(
+    PlatformCertificateVerifierFactory factory);
+
+// The implementation compiled in for this platform, or nullptr on platforms
+// that expose no trust evaluation API. Called by
+// CreatePlatformCertificateVerifier when nothing has been registered; not
+// intended for use elsewhere.
+std::unique_ptr<SSLCertificateVerifier>
+CreateNativePlatformCertificateVerifier();
 
 }  //  namespace webrtc
 

--- a/rtc_base/platform_certificate_verifier.h
+++ b/rtc_base/platform_certificate_verifier.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2026 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef RTC_BASE_PLATFORM_CERTIFICATE_VERIFIER_H_
+#define RTC_BASE_PLATFORM_CERTIFICATE_VERIFIER_H_
+
+#include <memory>
+
+#include "rtc_base/ssl_certificate.h"
+
+namespace webrtc {
+
+// Creates a verifier that validates a peer certificate chain against the
+// operating system's trust store, or nullptr on platforms that do not expose
+// one (Linux, ChromeOS, BSD).
+//
+// This exists because the built-in trust anchors in rtc_base/ssl_roots.h are a
+// small, infrequently regenerated snapshot. A chain that the host OS trusts may
+// have no anchor there, which surfaces as a TURN/TLS handshake failure.
+//
+// The verifier is consulted only after the built-in anchors have already failed
+// to produce a valid path, so it can widen what is accepted but never narrow
+// it. Hostname matching is not performed here; OpenSSLAdapter checks it
+// separately in SSLPostConnectionCheck.
+std::unique_ptr<SSLCertificateVerifier> CreatePlatformCertificateVerifier();
+
+}  //  namespace webrtc
+
+#endif  // RTC_BASE_PLATFORM_CERTIFICATE_VERIFIER_H_

--- a/rtc_base/platform_certificate_verifier_apple.cc
+++ b/rtc_base/platform_certificate_verifier_apple.cc
@@ -125,7 +125,8 @@ class AppleCertificateVerifier final : public SSLCertificateVerifier {
 
 }  // namespace
 
-std::unique_ptr<SSLCertificateVerifier> CreatePlatformCertificateVerifier() {
+std::unique_ptr<SSLCertificateVerifier>
+CreateNativePlatformCertificateVerifier() {
   return std::make_unique<AppleCertificateVerifier>();
 }
 

--- a/rtc_base/platform_certificate_verifier_apple.cc
+++ b/rtc_base/platform_certificate_verifier_apple.cc
@@ -60,6 +60,10 @@ class AppleCertificateVerifier final : public SSLCertificateVerifier {
       return false;
     }
 
+    // Appended in the order received. SSLCertificateVerifier::VerifyChain is
+    // documented to deliver the chain leaf first, then intermediates, which is
+    // also what SecTrustCreateWithCertificates expects: it evaluates element 0
+    // and treats the remainder as candidate intermediates.
     for (size_t i = 0; i < chain.GetSize(); ++i) {
       Buffer der;
       chain.Get(i).ToDER(&der);

--- a/rtc_base/platform_certificate_verifier_apple.cc
+++ b/rtc_base/platform_certificate_verifier_apple.cc
@@ -12,8 +12,6 @@
 #include <Security/Security.h>
 
 #include <memory>
-#include <utility>
-#include <vector>
 
 #include "rtc_base/buffer.h"
 #include "rtc_base/logging.h"
@@ -47,9 +45,7 @@ class ScopedCF {
 class AppleCertificateVerifier final : public SSLCertificateVerifier {
  public:
   bool Verify(const SSLCertificate& certificate) override {
-    std::vector<std::unique_ptr<SSLCertificate>> single;
-    single.push_back(certificate.Clone());
-    return VerifyChain(SSLCertChain(std::move(single)));
+    return VerifyChain(SSLCertChain(certificate.Clone()));
   }
 
   bool VerifyChain(const SSLCertChain& chain) override {
@@ -100,15 +96,28 @@ class AppleCertificateVerifier final : public SSLCertificateVerifier {
 
     // The peer sent the whole chain, so nothing needs to be fetched. Leaving
     // this enabled would allow an AIA lookup to block the network thread for
-    // the duration of a plaintext HTTP round trip mid-handshake.
+    // the duration of a plaintext HTTP round trip mid-handshake. Note that this
+    // also stops OCSP and CRL fetching, so revocation is decided on whatever
+    // the system has already cached; a blocking revocation fetch on this thread
+    // is the worse of the two.
     SecTrustSetNetworkFetchAllowed(trust.get(), false);
 
     CFErrorRef error = nullptr;
     const bool trusted = SecTrustEvaluateWithError(trust.get(), &error);
     ScopedCF<CFErrorRef> scoped_error(error);
     if (!trusted) {
-      RTC_LOG(LS_INFO) << "Peer certificate chain was rejected by the system "
-                          "trust store.";
+      ScopedCF<CFStringRef> reason(
+          error != nullptr ? CFErrorCopyDescription(error) : nullptr);
+      char buffer[256] = {};
+      if (reason && CFStringGetCString(reason.get(), buffer, sizeof(buffer),
+                                       kCFStringEncodingUTF8)) {
+        RTC_LOG(LS_INFO) << "Peer certificate chain was rejected by the system "
+                            "trust store: "
+                         << buffer;
+      } else {
+        RTC_LOG(LS_INFO) << "Peer certificate chain was rejected by the system "
+                            "trust store.";
+      }
     }
     return trusted;
   }

--- a/rtc_base/platform_certificate_verifier_apple.cc
+++ b/rtc_base/platform_certificate_verifier_apple.cc
@@ -1,0 +1,123 @@
+/*
+ *  Copyright 2026 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "rtc_base/buffer.h"
+#include "rtc_base/logging.h"
+#include "rtc_base/platform_certificate_verifier.h"
+#include "rtc_base/ssl_certificate.h"
+
+namespace webrtc {
+namespace {
+
+template <typename T>
+class ScopedCF {
+ public:
+  ScopedCF() = default;
+  explicit ScopedCF(T ref) : ref_(ref) {}
+  ScopedCF(const ScopedCF&) = delete;
+  ScopedCF& operator=(const ScopedCF&) = delete;
+  ~ScopedCF() {
+    if (ref_) {
+      CFRelease(ref_);
+    }
+  }
+
+  T get() const { return ref_; }
+  T* receive() { return &ref_; }
+  explicit operator bool() const { return ref_ != nullptr; }
+
+ private:
+  T ref_ = nullptr;
+};
+
+class AppleCertificateVerifier final : public SSLCertificateVerifier {
+ public:
+  bool Verify(const SSLCertificate& certificate) override {
+    std::vector<std::unique_ptr<SSLCertificate>> single;
+    single.push_back(certificate.Clone());
+    return VerifyChain(SSLCertChain(std::move(single)));
+  }
+
+  bool VerifyChain(const SSLCertChain& chain) override {
+    if (chain.GetSize() == 0) {
+      return false;
+    }
+
+    ScopedCF<CFMutableArrayRef> certs(
+        CFArrayCreateMutable(kCFAllocatorDefault, chain.GetSize(),
+                             &kCFTypeArrayCallBacks));
+    if (!certs) {
+      return false;
+    }
+
+    for (size_t i = 0; i < chain.GetSize(); ++i) {
+      Buffer der;
+      chain.Get(i).ToDER(&der);
+      ScopedCF<CFDataRef> data(CFDataCreate(
+          kCFAllocatorDefault, der.data(), static_cast<CFIndex>(der.size())));
+      if (!data) {
+        return false;
+      }
+      ScopedCF<SecCertificateRef> cert(
+          SecCertificateCreateWithData(kCFAllocatorDefault, data.get()));
+      if (!cert) {
+        RTC_LOG(LS_WARNING) << "Peer certificate at depth " << i
+                            << " could not be parsed by Security.framework.";
+        return false;
+      }
+      CFArrayAppendValue(certs.get(), cert.get());
+    }
+
+    // Hostname matching is done by OpenSSLAdapter::SSLPostConnectionCheck, so
+    // no name is supplied here. The SSL policy is still used rather than a
+    // basic X.509 one so that TLS-specific rules (server extended key usage,
+    // and so on) continue to be enforced.
+    ScopedCF<SecPolicyRef> policy(SecPolicyCreateSSL(/*server=*/true, nullptr));
+    if (!policy) {
+      return false;
+    }
+
+    ScopedCF<SecTrustRef> trust;
+    if (SecTrustCreateWithCertificates(certs.get(), policy.get(),
+                                       trust.receive()) != errSecSuccess ||
+        !trust) {
+      return false;
+    }
+
+    // The peer sent the whole chain, so nothing needs to be fetched. Leaving
+    // this enabled would allow an AIA lookup to block the network thread for
+    // the duration of a plaintext HTTP round trip mid-handshake.
+    SecTrustSetNetworkFetchAllowed(trust.get(), false);
+
+    CFErrorRef error = nullptr;
+    const bool trusted = SecTrustEvaluateWithError(trust.get(), &error);
+    ScopedCF<CFErrorRef> scoped_error(error);
+    if (!trusted) {
+      RTC_LOG(LS_INFO) << "Peer certificate chain was rejected by the system "
+                          "trust store.";
+    }
+    return trusted;
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<SSLCertificateVerifier> CreatePlatformCertificateVerifier() {
+  return std::make_unique<AppleCertificateVerifier>();
+}
+
+}  // namespace webrtc

--- a/rtc_base/platform_certificate_verifier_none.cc
+++ b/rtc_base/platform_certificate_verifier_none.cc
@@ -14,12 +14,17 @@
 
 namespace webrtc {
 
-// Linux, ChromeOS and the BSDs have no OS-level trust evaluation API to defer
-// to; the system roots are a directory of PEM files whose location varies by
-// distribution. Returning nullptr leaves the built-in anchors in
-// rtc_base/ssl_roots.h as the only trust source on those platforms, which is
-// the pre-existing behaviour.
-std::unique_ptr<SSLCertificateVerifier> CreatePlatformCertificateVerifier() {
+// Used where no trust store is reachable from rtc_base. Linux, ChromeOS and the
+// BSDs have no OS-level trust evaluation API at all; their system roots are a
+// directory of PEM files whose location varies by distribution. Android does
+// have one, but only through X509TrustManager, so sdk/android registers an
+// implementation via SetPlatformCertificateVerifierFactory instead and this is
+// never consulted there.
+//
+// Returning nullptr leaves the built-in anchors in rtc_base/ssl_roots.h as the
+// only trust source, which is the pre-existing behaviour.
+std::unique_ptr<SSLCertificateVerifier>
+CreateNativePlatformCertificateVerifier() {
   return nullptr;
 }
 

--- a/rtc_base/platform_certificate_verifier_none.cc
+++ b/rtc_base/platform_certificate_verifier_none.cc
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2026 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include <memory>
+
+#include "rtc_base/platform_certificate_verifier.h"
+
+namespace webrtc {
+
+// Linux, ChromeOS and the BSDs have no OS-level trust evaluation API to defer
+// to; the system roots are a directory of PEM files whose location varies by
+// distribution. Returning nullptr leaves the built-in anchors in
+// rtc_base/ssl_roots.h as the only trust source on those platforms, which is
+// the pre-existing behaviour.
+std::unique_ptr<SSLCertificateVerifier> CreatePlatformCertificateVerifier() {
+  return nullptr;
+}
+
+}  // namespace webrtc

--- a/rtc_base/platform_certificate_verifier_unittest.cc
+++ b/rtc_base/platform_certificate_verifier_unittest.cc
@@ -40,6 +40,57 @@ std::unique_ptr<SSLCertificate> SelfSignedCert(absl::string_view name) {
   return identity == nullptr ? nullptr : identity->certificate().Clone();
 }
 
+// Accepts everything, which no real platform implementation would do for a
+// self-signed certificate. That difference is what lets the registry tests tell
+// a registered factory apart from the one compiled in.
+class AcceptAllVerifier final : public SSLCertificateVerifier {
+ public:
+  bool Verify(const SSLCertificate& /*certificate*/) override { return true; }
+};
+
+std::unique_ptr<SSLCertificateVerifier> MakeAcceptAllVerifier() {
+  return std::make_unique<AcceptAllVerifier>();
+}
+
+// SetPlatformCertificateVerifierFactory is process-wide, so a test that
+// registers must unregister however it leaves.
+class ScopedRegisteredFactory {
+ public:
+  explicit ScopedRegisteredFactory(PlatformCertificateVerifierFactory factory) {
+    SetPlatformCertificateVerifierFactory(factory);
+  }
+  ScopedRegisteredFactory(const ScopedRegisteredFactory&) = delete;
+  ScopedRegisteredFactory& operator=(const ScopedRegisteredFactory&) = delete;
+  ~ScopedRegisteredFactory() {
+    SetPlatformCertificateVerifierFactory(nullptr);
+  }
+};
+
+TEST(PlatformCertificateVerifierTest, RegisteredFactoryTakesPrecedence) {
+  std::unique_ptr<SSLCertificate> cert = SelfSignedCert("untrusted.invalid");
+  ASSERT_TRUE(cert != nullptr);
+
+  {
+    ScopedRegisteredFactory registered(&MakeAcceptAllVerifier);
+    std::unique_ptr<SSLCertificateVerifier> verifier =
+        CreatePlatformCertificateVerifier();
+    ASSERT_TRUE(verifier != nullptr);
+    // A platform implementation would refuse this; the registered one does not,
+    // so accepting it shows the registered factory was preferred. This is what
+    // lets Android reach its trust store on a build where rtc_base itself has no
+    // implementation to offer.
+    EXPECT_TRUE(verifier->VerifyChain(SSLCertChain(cert->Clone())));
+  }
+
+  // Leaving the scope must restore whatever the platform provides.
+  std::unique_ptr<SSLCertificateVerifier> restored =
+      CreatePlatformCertificateVerifier();
+  EXPECT_EQ(restored != nullptr, kPlatformVerifierExpected);
+  if (restored != nullptr) {
+    EXPECT_FALSE(restored->VerifyChain(SSLCertChain(cert->Clone())));
+  }
+}
+
 TEST(PlatformCertificateVerifierTest, FactoryMatchesPlatformSupport) {
   std::unique_ptr<SSLCertificateVerifier> verifier =
       CreatePlatformCertificateVerifier();

--- a/rtc_base/platform_certificate_verifier_unittest.cc
+++ b/rtc_base/platform_certificate_verifier_unittest.cc
@@ -1,0 +1,118 @@
+/*
+ *  Copyright 2026 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "rtc_base/platform_certificate_verifier.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "rtc_base/ssl_certificate.h"
+#include "rtc_base/ssl_identity.h"
+#include "test/gtest.h"
+
+// A chain the host OS *accepts* cannot be asserted here without a certificate
+// issued by a real CA, which would expire and turn this into a time bomb, or
+// without writing to the machine's trust store. What is covered instead is
+// everything that must hold regardless of local trust configuration: the
+// factory contract, and that untrusted input is refused rather than accepted
+// or crashed on.
+
+namespace webrtc {
+namespace {
+
+#if defined(WEBRTC_MAC) || defined(WEBRTC_WIN)
+constexpr bool kPlatformVerifierExpected = true;
+#else
+constexpr bool kPlatformVerifierExpected = false;
+#endif
+
+std::unique_ptr<SSLCertificate> SelfSignedCert(absl::string_view name) {
+  std::unique_ptr<SSLIdentity> identity =
+      SSLIdentity::Create(name, KeyParams::ECDSA());
+  return identity == nullptr ? nullptr : identity->certificate().Clone();
+}
+
+TEST(PlatformCertificateVerifierTest, FactoryMatchesPlatformSupport) {
+  std::unique_ptr<SSLCertificateVerifier> verifier =
+      CreatePlatformCertificateVerifier();
+  EXPECT_EQ(verifier != nullptr, kPlatformVerifierExpected);
+}
+
+TEST(PlatformCertificateVerifierTest, RejectsEmptyChain) {
+  std::unique_ptr<SSLCertificateVerifier> verifier =
+      CreatePlatformCertificateVerifier();
+  if (verifier == nullptr) {
+    GTEST_SKIP() << "No platform trust store on this target.";
+  }
+
+  SSLCertChain empty((std::vector<std::unique_ptr<SSLCertificate>>()));
+  EXPECT_FALSE(verifier->VerifyChain(empty));
+}
+
+TEST(PlatformCertificateVerifierTest, RejectsSelfSignedCertificate) {
+  std::unique_ptr<SSLCertificateVerifier> verifier =
+      CreatePlatformCertificateVerifier();
+  if (verifier == nullptr) {
+    GTEST_SKIP() << "No platform trust store on this target.";
+  }
+
+  std::unique_ptr<SSLCertificate> cert = SelfSignedCert("not-a-real-ca.invalid");
+  ASSERT_TRUE(cert != nullptr);
+
+  // Both entry points must refuse it: Verify() is what the base class routes a
+  // single certificate through, VerifyChain() is what OpenSSLAdapter calls.
+  EXPECT_FALSE(verifier->Verify(*cert));
+
+  SSLCertChain chain(cert->Clone());
+  EXPECT_FALSE(verifier->VerifyChain(chain));
+}
+
+TEST(PlatformCertificateVerifierTest, RejectsMultiCertificateUntrustedChain) {
+  std::unique_ptr<SSLCertificateVerifier> verifier =
+      CreatePlatformCertificateVerifier();
+  if (verifier == nullptr) {
+    GTEST_SKIP() << "No platform trust store on this target.";
+  }
+
+  // Exercises the loop that walks every element of the chain, not just the
+  // leaf. The certificates do not chain to each other, which is precisely the
+  // sort of input that must not be mistaken for a valid path.
+  std::vector<std::unique_ptr<SSLCertificate>> certs;
+  for (int i = 0; i < 3; ++i) {
+    std::unique_ptr<SSLCertificate> cert = SelfSignedCert("untrusted.invalid");
+    ASSERT_TRUE(cert != nullptr);
+    certs.push_back(std::move(cert));
+  }
+
+  SSLCertChain chain(std::move(certs));
+  ASSERT_EQ(chain.GetSize(), 3u);
+  EXPECT_FALSE(verifier->VerifyChain(chain));
+}
+
+TEST(PlatformCertificateVerifierTest, VerifierIsReusableAcrossChains) {
+  std::unique_ptr<SSLCertificateVerifier> verifier =
+      CreatePlatformCertificateVerifier();
+  if (verifier == nullptr) {
+    GTEST_SKIP() << "No platform trust store on this target.";
+  }
+
+  // One verifier is installed per adapter but evaluates every peer certificate
+  // that adapter sees, so it must hold no per-evaluation state.
+  for (int i = 0; i < 3; ++i) {
+    std::unique_ptr<SSLCertificate> cert = SelfSignedCert("untrusted.invalid");
+    ASSERT_TRUE(cert != nullptr);
+    SSLCertChain chain(std::move(cert));
+    EXPECT_FALSE(verifier->VerifyChain(chain));
+  }
+}
+
+}  // namespace
+}  // namespace webrtc

--- a/rtc_base/platform_certificate_verifier_win.cc
+++ b/rtc_base/platform_certificate_verifier_win.cc
@@ -14,16 +14,19 @@
 #include <wincrypt.h>
 // clang-format on
 
-#include <ios>
 #include <memory>
 
 #include "rtc_base/buffer.h"
 #include "rtc_base/logging.h"
 #include "rtc_base/platform_certificate_verifier.h"
 #include "rtc_base/ssl_certificate.h"
+#include "rtc_base/string_utils.h"
 
 namespace webrtc {
 namespace {
+
+// From wininet.h, which cannot be included alongside wincrypt.h here.
+constexpr DWORD kSecurityFlagIgnoreCertCnInvalid = 0x00001000;
 
 class ScopedCertContext {
  public:
@@ -109,7 +112,7 @@ class WinCertificateVerifier final : public SSLCertificateVerifier {
     SSL_EXTRA_CERT_CHAIN_POLICY_PARA ssl_para = {};
     ssl_para.cbSize = sizeof(ssl_para);
     ssl_para.dwAuthType = AUTHTYPE_SERVER;
-    ssl_para.fdwChecks = SECURITY_FLAG_IGNORE_CERT_CN_INVALID;
+    ssl_para.fdwChecks = kSecurityFlagIgnoreCertCnInvalid;
 
     CERT_CHAIN_POLICY_PARA policy_para = {};
     policy_para.cbSize = sizeof(policy_para);
@@ -125,7 +128,7 @@ class WinCertificateVerifier final : public SSLCertificateVerifier {
     if (!checked || policy_status.dwError != 0) {
       RTC_LOG(LS_INFO) << "Peer certificate chain was rejected by the system "
                           "trust store, error 0x"
-                       << std::hex << policy_status.dwError;
+                       << ToHex(static_cast<int>(policy_status.dwError));
       return false;
     }
     return true;

--- a/rtc_base/platform_certificate_verifier_win.cc
+++ b/rtc_base/platform_certificate_verifier_win.cc
@@ -76,11 +76,24 @@ class WinCertificateVerifier final : public SSLCertificateVerifier {
     for (size_t i = 1; i < chain.GetSize(); ++i) {
       Buffer der;
       chain.Get(i).ToDER(&der);
-      CertAddEncodedCertificateToStore(
-          intermediates, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, der.data(),
-          static_cast<DWORD>(der.size()), CERT_STORE_ADD_ALWAYS, NULL);
+      if (!CertAddEncodedCertificateToStore(
+              intermediates, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+              der.data(), static_cast<DWORD>(der.size()),
+              CERT_STORE_ADD_ALWAYS, NULL)) {
+        const DWORD error = GetLastError();
+        // Not fatal by itself, since the engine may still find this issuer in a
+        // system store. Logged so that a path failure below is attributable
+        // rather than unexplained.
+        RTC_LOG(LS_WARNING) << "Could not add peer certificate at depth " << i
+                            << " to the temporary store, error "
+                            << ToHex(static_cast<int>(error));
+      }
     }
 
+    // SSLCertificateVerifier::VerifyChain is documented to deliver the chain
+    // leaf first, then intermediates, so element 0 is the server certificate
+    // and the loop above covers the rest. CertGetCertificateChain wants the
+    // leaf as its subject, with the others merely available to it.
     ScopedCertContext leaf(CreateContext(chain.Get(0)));
     if (!leaf.get()) {
       CertCloseStore(intermediates, 0);

--- a/rtc_base/platform_certificate_verifier_win.cc
+++ b/rtc_base/platform_certificate_verifier_win.cc
@@ -1,0 +1,144 @@
+/*
+ *  Copyright 2026 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include <windows.h>
+// clang-format off
+// wincrypt.h must follow windows.h.
+#include <wincrypt.h>
+// clang-format on
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "rtc_base/buffer.h"
+#include "rtc_base/logging.h"
+#include "rtc_base/platform_certificate_verifier.h"
+#include "rtc_base/ssl_certificate.h"
+
+namespace webrtc {
+namespace {
+
+class ScopedCertContext {
+ public:
+  explicit ScopedCertContext(PCCERT_CONTEXT ctx) : ctx_(ctx) {}
+  ScopedCertContext(const ScopedCertContext&) = delete;
+  ScopedCertContext& operator=(const ScopedCertContext&) = delete;
+  ~ScopedCertContext() {
+    if (ctx_) {
+      CertFreeCertificateContext(ctx_);
+    }
+  }
+  PCCERT_CONTEXT get() const { return ctx_; }
+
+ private:
+  PCCERT_CONTEXT ctx_;
+};
+
+PCCERT_CONTEXT CreateContext(const SSLCertificate& cert) {
+  Buffer der;
+  cert.ToDER(&der);
+  return CertCreateCertificateContext(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                                      der.data(),
+                                      static_cast<DWORD>(der.size()));
+}
+
+class WinCertificateVerifier final : public SSLCertificateVerifier {
+ public:
+  bool Verify(const SSLCertificate& certificate) override {
+    std::vector<std::unique_ptr<SSLCertificate>> single;
+    single.push_back(certificate.Clone());
+    return VerifyChain(SSLCertChain(std::move(single)));
+  }
+
+  bool VerifyChain(const SSLCertChain& chain) override {
+    if (chain.GetSize() == 0) {
+      return false;
+    }
+
+    // Intermediates the peer sent go into a temporary in-memory store so the
+    // chain engine can use them without touching any persistent store.
+    HCERTSTORE intermediates =
+        CertOpenStore(CERT_STORE_PROV_MEMORY, 0, NULL,
+                      CERT_STORE_CREATE_NEW_FLAG | CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG,
+                      NULL);
+    if (!intermediates) {
+      return false;
+    }
+
+    for (size_t i = 1; i < chain.GetSize(); ++i) {
+      Buffer der;
+      chain.Get(i).ToDER(&der);
+      CertAddEncodedCertificateToStore(
+          intermediates, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, der.data(),
+          static_cast<DWORD>(der.size()), CERT_STORE_ADD_ALWAYS, NULL);
+    }
+
+    ScopedCertContext leaf(CreateContext(chain.Get(0)));
+    if (!leaf.get()) {
+      CertCloseStore(intermediates, 0);
+      return false;
+    }
+
+    CERT_CHAIN_PARA chain_para = {};
+    chain_para.cbSize = sizeof(chain_para);
+    LPSTR usage[] = {const_cast<LPSTR>(szOID_PKIX_KP_SERVER_AUTH)};
+    chain_para.RequestedUsage.dwType = USAGE_MATCH_TYPE_AND;
+    chain_para.RequestedUsage.Usage.cUsageIdentifier = 1;
+    chain_para.RequestedUsage.Usage.rgpszUsageIdentifier = usage;
+
+    PCCERT_CHAIN_CONTEXT chain_context = nullptr;
+    // CERT_CHAIN_CACHE_END_CERT keeps this off the wire; revocation is left to
+    // whatever the engine has cached rather than blocking the network thread.
+    const BOOL built = CertGetCertificateChain(
+        NULL, leaf.get(), NULL, intermediates, &chain_para,
+        CERT_CHAIN_CACHE_END_CERT | CERT_CHAIN_REVOCATION_CHECK_CACHE_ONLY,
+        NULL, &chain_context);
+    CertCloseStore(intermediates, 0);
+
+    if (!built || !chain_context) {
+      return false;
+    }
+
+    // Hostname matching is done by OpenSSLAdapter::SSLPostConnectionCheck, so
+    // the name check is suppressed here.
+    SSL_EXTRA_CERT_CHAIN_POLICY_PARA ssl_para = {};
+    ssl_para.cbSize = sizeof(ssl_para);
+    ssl_para.dwAuthType = AUTHTYPE_SERVER;
+    ssl_para.fdwChecks = SECURITY_FLAG_IGNORE_CERT_CN_INVALID;
+
+    CERT_CHAIN_POLICY_PARA policy_para = {};
+    policy_para.cbSize = sizeof(policy_para);
+    policy_para.pvExtraPolicyPara = &ssl_para;
+
+    CERT_CHAIN_POLICY_STATUS policy_status = {};
+    policy_status.cbSize = sizeof(policy_status);
+
+    const BOOL checked = CertVerifyCertificateChainPolicy(
+        CERT_CHAIN_POLICY_SSL, chain_context, &policy_para, &policy_status);
+    CertFreeCertificateChain(chain_context);
+
+    if (!checked || policy_status.dwError != 0) {
+      RTC_LOG(LS_INFO) << "Peer certificate chain was rejected by the system "
+                          "trust store, error 0x"
+                       << std::hex << policy_status.dwError;
+      return false;
+    }
+    return true;
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<SSLCertificateVerifier> CreatePlatformCertificateVerifier() {
+  return std::make_unique<WinCertificateVerifier>();
+}
+
+}  // namespace webrtc

--- a/rtc_base/platform_certificate_verifier_win.cc
+++ b/rtc_base/platform_certificate_verifier_win.cc
@@ -134,7 +134,8 @@ class WinCertificateVerifier final : public SSLCertificateVerifier {
 
 }  // namespace
 
-std::unique_ptr<SSLCertificateVerifier> CreatePlatformCertificateVerifier() {
+std::unique_ptr<SSLCertificateVerifier>
+CreateNativePlatformCertificateVerifier() {
   return std::make_unique<WinCertificateVerifier>();
 }
 

--- a/rtc_base/platform_certificate_verifier_win.cc
+++ b/rtc_base/platform_certificate_verifier_win.cc
@@ -14,9 +14,8 @@
 #include <wincrypt.h>
 // clang-format on
 
+#include <ios>
 #include <memory>
-#include <utility>
-#include <vector>
 
 #include "rtc_base/buffer.h"
 #include "rtc_base/logging.h"
@@ -53,9 +52,7 @@ PCCERT_CONTEXT CreateContext(const SSLCertificate& cert) {
 class WinCertificateVerifier final : public SSLCertificateVerifier {
  public:
   bool Verify(const SSLCertificate& certificate) override {
-    std::vector<std::unique_ptr<SSLCertificate>> single;
-    single.push_back(certificate.Clone());
-    return VerifyChain(SSLCertChain(std::move(single)));
+    return VerifyChain(SSLCertChain(certificate.Clone()));
   }
 
   bool VerifyChain(const SSLCertChain& chain) override {

--- a/sdk/android/BUILD.gn
+++ b/sdk/android/BUILD.gn
@@ -351,9 +351,9 @@ if (is_android) {
       "api/org/webrtc/VideoSource.java",
       "api/org/webrtc/VideoTrack.java",
       "src/java/org/webrtc/NativeAndroidVideoTrackSource.java",
-      "src/java/org/webrtc/PlatformCertificateVerifier.java",
       "src/java/org/webrtc/NativeCapturerObserver.java",
       "src/java/org/webrtc/NativeLibrary.java",
+      "src/java/org/webrtc/PlatformCertificateVerifier.java",
     ]
 
     deps = [
@@ -824,6 +824,8 @@ if (current_os == "linux" || is_android) {
       "src/jni/pc/peer_connection.h",
       "src/jni/pc/peer_connection_factory.cc",
       "src/jni/pc/peer_connection_factory.h",
+      "src/jni/pc/platform_certificate_verifier.cc",
+      "src/jni/pc/platform_certificate_verifier.h",
       "src/jni/pc/rtc_certificate.cc",
       "src/jni/pc/rtc_certificate.h",
       "src/jni/pc/rtc_stats_collector_callback_wrapper.cc",
@@ -833,8 +835,6 @@ if (current_os == "linux" || is_android) {
       "src/jni/pc/rtp_parameters.cc",
       "src/jni/pc/rtp_parameters.h",
       "src/jni/pc/rtp_receiver.cc",
-      "src/jni/pc/platform_certificate_verifier.cc",
-      "src/jni/pc/platform_certificate_verifier.h",
       "src/jni/pc/rtp_receiver.h",
       "src/jni/pc/rtp_sender.cc",
       "src/jni/pc/rtp_sender.h",

--- a/sdk/android/BUILD.gn
+++ b/sdk/android/BUILD.gn
@@ -351,6 +351,7 @@ if (is_android) {
       "api/org/webrtc/VideoSource.java",
       "api/org/webrtc/VideoTrack.java",
       "src/java/org/webrtc/NativeAndroidVideoTrackSource.java",
+      "src/java/org/webrtc/PlatformCertificateVerifier.java",
       "src/java/org/webrtc/NativeCapturerObserver.java",
       "src/java/org/webrtc/NativeLibrary.java",
     ]
@@ -832,6 +833,8 @@ if (current_os == "linux" || is_android) {
       "src/jni/pc/rtp_parameters.cc",
       "src/jni/pc/rtp_parameters.h",
       "src/jni/pc/rtp_receiver.cc",
+      "src/jni/pc/platform_certificate_verifier.cc",
+      "src/jni/pc/platform_certificate_verifier.h",
       "src/jni/pc/rtp_receiver.h",
       "src/jni/pc/rtp_sender.cc",
       "src/jni/pc/rtp_sender.h",
@@ -1597,6 +1600,7 @@ if (current_os == "linux" || is_android) {
       "api/org/webrtc/audio/AudioProcessingImplementation.java",
       "api/org/webrtc/audio/AudioProcessingMode.java",
       "api/org/webrtc/audio/AudioProcessingState.java",
+      "src/java/org/webrtc/PlatformCertificateVerifier.java",
     ]
     namespace = "webrtc::jni"
   }

--- a/sdk/android/src/java/org/webrtc/PlatformCertificateVerifier.java
+++ b/sdk/android/src/java/org/webrtc/PlatformCertificateVerifier.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2026 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+package org.webrtc;
+
+import androidx.annotation.Nullable;
+import java.io.ByteArrayInputStream;
+import java.security.KeyStore;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * Validates a peer certificate chain against the platform trust store, for use when the trust
+ * anchors compiled into rtc_base/ssl_roots.h contain no path for it.
+ *
+ * <p>Only reachable from native code; the chain arrives whole, so no certificate has to be fetched
+ * to complete it. Hostname matching is not done here — OpenSSLAdapter checks it separately.
+ */
+final class PlatformCertificateVerifier {
+  private static final String TAG = "PlatformCertificateVerifier";
+
+  @Nullable private static X509TrustManager trustManager;
+  @Nullable private static CertificateFactory certificateFactory;
+  private static boolean initialized;
+
+  private PlatformCertificateVerifier() {}
+
+  private static synchronized boolean initialize() {
+    if (initialized) {
+      return trustManager != null && certificateFactory != null;
+    }
+    initialized = true;
+    try {
+      TrustManagerFactory factory =
+          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      // A null KeyStore selects the platform's own trust anchors, which includes any the user or
+      // a device administrator has installed.
+      factory.init((KeyStore) null);
+      for (TrustManager candidate : factory.getTrustManagers()) {
+        if (candidate instanceof X509TrustManager) {
+          trustManager = (X509TrustManager) candidate;
+          break;
+        }
+      }
+      certificateFactory = CertificateFactory.getInstance("X.509");
+    } catch (Exception e) {
+      Logging.e(TAG, "Could not reach the platform trust store", e);
+      trustManager = null;
+      certificateFactory = null;
+    }
+    return trustManager != null && certificateFactory != null;
+  }
+
+  /**
+   * @param derChain peer certificates in DER form, leaf first.
+   * @return whether the chain terminates in an anchor the platform trusts.
+   */
+  @CalledByNative
+  static boolean verifyServerChain(byte[][] derChain) {
+    if (derChain == null || derChain.length == 0 || !initialize()) {
+      return false;
+    }
+    final X509TrustManager manager = trustManager;
+    final CertificateFactory factory = certificateFactory;
+    if (manager == null || factory == null) {
+      return false;
+    }
+
+    try {
+      List<X509Certificate> parsed = new ArrayList<>(derChain.length);
+      for (byte[] der : derChain) {
+        parsed.add(
+            (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(der)));
+      }
+      X509Certificate[] chain = parsed.toArray(new X509Certificate[0]);
+
+      // The key algorithm of the leaf stands in for the TLS key-exchange authType, which is not
+      // available at this layer. Conscrypt uses it only to pick a validation profile.
+      String authType = chain[0].getPublicKey().getAlgorithm();
+      manager.checkServerTrusted(chain, authType == null ? "RSA" : authType);
+      return true;
+    } catch (Exception e) {
+      Logging.d(TAG, "Peer certificate chain was rejected by the platform trust store: " + e);
+      return false;
+    }
+  }
+}

--- a/sdk/android/src/jni/jni_onload.cc
+++ b/sdk/android/src/jni/jni_onload.cc
@@ -12,9 +12,11 @@
 
 #include "rtc_base/checks.h"
 #include "rtc_base/logging.h"
+#include "rtc_base/platform_certificate_verifier.h"
 #include "rtc_base/ssl_adapter.h"
 #include "sdk/android/native_api/jni/class_loader.h"
 #include "sdk/android/src/jni/jvm.h"
+#include "sdk/android/src/jni/pc/platform_certificate_verifier.h"
 
 #undef JNIEXPORT
 #define JNIEXPORT __attribute__((visibility("default")))
@@ -31,6 +33,12 @@ extern "C" jint JNIEXPORT JNICALL JNI_OnLoad(JavaVM* jvm, void* reserved) {
 
   RTC_CHECK(InitializeSSL()) << "Failed to InitializeSSL()";
   InitClassLoader(GetEnv());
+
+  // Android's trust anchors are only reachable through X509TrustManager, which
+  // rtc_base cannot call. Register here rather than injecting through
+  // PeerConnectionDependencies so that consumers binding the C++ API directly,
+  // which never construct their dependencies through this SDK, are covered too.
+  SetPlatformCertificateVerifierFactory(&CreateAndroidCertificateVerifier);
 
   return ret;
 }

--- a/sdk/android/src/jni/pc/peer_connection_factory.cc
+++ b/sdk/android/src/jni/pc/peer_connection_factory.cc
@@ -69,6 +69,7 @@
 #include "sdk/android/src/jni/pc/media_stream_track.h"
 #include "sdk/android/src/jni/pc/owned_factory_and_threads.h"
 #include "sdk/android/src/jni/pc/peer_connection.h"
+#include "sdk/android/src/jni/pc/platform_certificate_verifier.h"
 #include "sdk/android/src/jni/pc/rtp_capabilities.h"
 #include "sdk/android/src/jni/pc/ssl_certificate_verifier_wrapper.h"
 #include "sdk/android/src/jni/pc/video.h"
@@ -545,6 +546,13 @@ static jlong JNI_PeerConnectionFactory_CreatePeerConnection(
     peer_connection_dependencies.tls_cert_verifier =
         std::make_unique<SSLCertificateVerifierWrapper>(
             jni, j_sslCertificateVerifier);
+  } else {
+    // The anchors compiled into rtc_base/ssl_roots.h are a small snapshot that
+    // omits, among others, the roots behind AWS ACM and Let's Encrypt. Defer to
+    // the platform trust store when they yield no path. Consulted only after
+    // built-in verification has failed, so nothing that connects today stops.
+    peer_connection_dependencies.tls_cert_verifier =
+        std::make_unique<PlatformCertificateVerifier>();
   }
 
   auto result =

--- a/sdk/android/src/jni/pc/peer_connection_factory.cc
+++ b/sdk/android/src/jni/pc/peer_connection_factory.cc
@@ -69,7 +69,6 @@
 #include "sdk/android/src/jni/pc/media_stream_track.h"
 #include "sdk/android/src/jni/pc/owned_factory_and_threads.h"
 #include "sdk/android/src/jni/pc/peer_connection.h"
-#include "sdk/android/src/jni/pc/platform_certificate_verifier.h"
 #include "sdk/android/src/jni/pc/rtp_capabilities.h"
 #include "sdk/android/src/jni/pc/ssl_certificate_verifier_wrapper.h"
 #include "sdk/android/src/jni/pc/video.h"
@@ -546,13 +545,6 @@ static jlong JNI_PeerConnectionFactory_CreatePeerConnection(
     peer_connection_dependencies.tls_cert_verifier =
         std::make_unique<SSLCertificateVerifierWrapper>(
             jni, j_sslCertificateVerifier);
-  } else {
-    // The anchors compiled into rtc_base/ssl_roots.h are a small snapshot that
-    // omits, among others, the roots behind AWS ACM and Let's Encrypt. Defer to
-    // the platform trust store when they yield no path. Consulted only after
-    // built-in verification has failed, so nothing that connects today stops.
-    peer_connection_dependencies.tls_cert_verifier =
-        std::make_unique<PlatformCertificateVerifier>();
   }
 
   auto result =

--- a/sdk/android/src/jni/pc/platform_certificate_verifier.cc
+++ b/sdk/android/src/jni/pc/platform_certificate_verifier.cc
@@ -71,5 +71,9 @@ bool PlatformCertificateVerifier::VerifyChain(const SSLCertChain& chain) {
   return Java_PlatformCertificateVerifier_verifyServerChain(jni, der_chain);
 }
 
+std::unique_ptr<SSLCertificateVerifier> CreateAndroidCertificateVerifier() {
+  return std::make_unique<PlatformCertificateVerifier>();
+}
+
 }  // namespace jni
 }  // namespace webrtc

--- a/sdk/android/src/jni/pc/platform_certificate_verifier.cc
+++ b/sdk/android/src/jni/pc/platform_certificate_verifier.cc
@@ -13,8 +13,6 @@
 #include <jni.h>
 
 #include <memory>
-#include <utility>
-#include <vector>
 
 #include "rtc_base/buffer.h"
 #include "rtc_base/ssl_certificate.h"
@@ -29,9 +27,7 @@ PlatformCertificateVerifier::PlatformCertificateVerifier() = default;
 PlatformCertificateVerifier::~PlatformCertificateVerifier() = default;
 
 bool PlatformCertificateVerifier::Verify(const SSLCertificate& certificate) {
-  std::vector<std::unique_ptr<SSLCertificate>> single;
-  single.push_back(certificate.Clone());
-  return VerifyChain(SSLCertChain(std::move(single)));
+  return VerifyChain(SSLCertChain(certificate.Clone()));
 }
 
 bool PlatformCertificateVerifier::VerifyChain(const SSLCertChain& chain) {

--- a/sdk/android/src/jni/pc/platform_certificate_verifier.cc
+++ b/sdk/android/src/jni/pc/platform_certificate_verifier.cc
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2026 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "sdk/android/src/jni/pc/platform_certificate_verifier.h"
+
+#include <jni.h>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "rtc_base/buffer.h"
+#include "rtc_base/ssl_certificate.h"
+#include "sdk/android/generated_peerconnection_jni/PlatformCertificateVerifier_jni.h"
+#include "sdk/android/native_api/jni/jvm.h"
+#include "sdk/android/native_api/jni/scoped_java_ref.h"
+
+namespace webrtc {
+namespace jni {
+
+PlatformCertificateVerifier::PlatformCertificateVerifier() = default;
+PlatformCertificateVerifier::~PlatformCertificateVerifier() = default;
+
+bool PlatformCertificateVerifier::Verify(const SSLCertificate& certificate) {
+  std::vector<std::unique_ptr<SSLCertificate>> single;
+  single.push_back(certificate.Clone());
+  return VerifyChain(SSLCertChain(std::move(single)));
+}
+
+bool PlatformCertificateVerifier::VerifyChain(const SSLCertChain& chain) {
+  if (chain.GetSize() == 0) {
+    return false;
+  }
+
+  JNIEnv* jni = AttachCurrentThreadIfNeeded();
+
+  ScopedJavaLocalRef<jclass> byte_array_class(jni, jni->FindClass("[B"));
+  if (byte_array_class.is_null()) {
+    return false;
+  }
+
+  ScopedJavaLocalRef<jobjectArray> der_chain(
+      jni, jni->NewObjectArray(static_cast<jsize>(chain.GetSize()),
+                               byte_array_class.obj(), nullptr));
+  if (der_chain.is_null()) {
+    return false;
+  }
+
+  // The whole chain is forwarded, not just the leaf, so the platform never has
+  // to recover an intermediate over the network to complete a path.
+  for (size_t i = 0; i < chain.GetSize(); ++i) {
+    Buffer der;
+    chain.Get(i).ToDER(&der);
+    ScopedJavaLocalRef<jbyteArray> element(
+        jni, jni->NewByteArray(static_cast<jsize>(der.size())));
+    if (element.is_null()) {
+      return false;
+    }
+    jni->SetByteArrayRegion(element.obj(), 0, static_cast<jsize>(der.size()),
+                            reinterpret_cast<const jbyte*>(der.data()));
+    jni->SetObjectArrayElement(der_chain.obj(), static_cast<jsize>(i),
+                               element.obj());
+  }
+
+  return Java_PlatformCertificateVerifier_verifyServerChain(jni, der_chain);
+}
+
+}  // namespace jni
+}  // namespace webrtc

--- a/sdk/android/src/jni/pc/platform_certificate_verifier.cc
+++ b/sdk/android/src/jni/pc/platform_certificate_verifier.cc
@@ -37,14 +37,16 @@ bool PlatformCertificateVerifier::VerifyChain(const SSLCertChain& chain) {
 
   JNIEnv* jni = AttachCurrentThreadIfNeeded();
 
-  ScopedJavaLocalRef<jclass> byte_array_class(jni, jni->FindClass("[B"));
+  ScopedJavaLocalRef<jclass> byte_array_class =
+      ScopedJavaLocalRef<jclass>::Adopt(jni, jni->FindClass("[B"));
   if (byte_array_class.is_null()) {
     return false;
   }
 
-  ScopedJavaLocalRef<jobjectArray> der_chain(
-      jni, jni->NewObjectArray(static_cast<jsize>(chain.GetSize()),
-                               byte_array_class.obj(), nullptr));
+  ScopedJavaLocalRef<jobjectArray> der_chain =
+      ScopedJavaLocalRef<jobjectArray>::Adopt(
+          jni, jni->NewObjectArray(static_cast<jsize>(chain.GetSize()),
+                                   byte_array_class.obj(), nullptr));
   if (der_chain.is_null()) {
     return false;
   }
@@ -54,8 +56,9 @@ bool PlatformCertificateVerifier::VerifyChain(const SSLCertChain& chain) {
   for (size_t i = 0; i < chain.GetSize(); ++i) {
     Buffer der;
     chain.Get(i).ToDER(&der);
-    ScopedJavaLocalRef<jbyteArray> element(
-        jni, jni->NewByteArray(static_cast<jsize>(der.size())));
+    ScopedJavaLocalRef<jbyteArray> element =
+        ScopedJavaLocalRef<jbyteArray>::Adopt(
+            jni, jni->NewByteArray(static_cast<jsize>(der.size())));
     if (element.is_null()) {
       return false;
     }

--- a/sdk/android/src/jni/pc/platform_certificate_verifier.h
+++ b/sdk/android/src/jni/pc/platform_certificate_verifier.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2026 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef SDK_ANDROID_SRC_JNI_PC_PLATFORM_CERTIFICATE_VERIFIER_H_
+#define SDK_ANDROID_SRC_JNI_PC_PLATFORM_CERTIFICATE_VERIFIER_H_
+
+#include "rtc_base/ssl_certificate.h"
+
+namespace webrtc {
+namespace jni {
+
+// Defers to the platform trust store via X509TrustManager when the anchors in
+// rtc_base/ssl_roots.h yield no path for a peer chain. Installed as the default
+// tls_cert_verifier where the application has not supplied one of its own; it
+// is consulted only after built-in verification has already failed, so it can
+// widen what is accepted but never narrow it.
+//
+// rtc_base cannot host this: reaching the JVM requires the JNI layer, which
+// lives here. This mirrors how AndroidNetworkMonitorFactory supplies an
+// rtc_base interface from the Android SDK.
+class PlatformCertificateVerifier : public SSLCertificateVerifier {
+ public:
+  PlatformCertificateVerifier();
+  ~PlatformCertificateVerifier() override;
+
+  bool Verify(const SSLCertificate& certificate) override;
+  bool VerifyChain(const SSLCertChain& chain) override;
+};
+
+}  // namespace jni
+}  // namespace webrtc
+
+#endif  // SDK_ANDROID_SRC_JNI_PC_PLATFORM_CERTIFICATE_VERIFIER_H_

--- a/sdk/android/src/jni/pc/platform_certificate_verifier.h
+++ b/sdk/android/src/jni/pc/platform_certificate_verifier.h
@@ -11,20 +11,22 @@
 #ifndef SDK_ANDROID_SRC_JNI_PC_PLATFORM_CERTIFICATE_VERIFIER_H_
 #define SDK_ANDROID_SRC_JNI_PC_PLATFORM_CERTIFICATE_VERIFIER_H_
 
+#include <memory>
+
 #include "rtc_base/ssl_certificate.h"
 
 namespace webrtc {
 namespace jni {
 
 // Defers to the platform trust store via X509TrustManager when the anchors in
-// rtc_base/ssl_roots.h yield no path for a peer chain. Installed as the default
-// tls_cert_verifier where the application has not supplied one of its own; it
-// is consulted only after built-in verification has already failed, so it can
-// widen what is accepted but never narrow it.
+// rtc_base/ssl_roots.h yield no path for a peer chain.
 //
 // rtc_base cannot host this: reaching the JVM requires the JNI layer, which
-// lives here. This mirrors how AndroidNetworkMonitorFactory supplies an
-// rtc_base interface from the Android SDK.
+// lives here. JNI_OnLoad registers it through
+// SetPlatformCertificateVerifierFactory, so OpenSSLAdapter picks it up for every
+// consumer rather than only those that build their dependencies through this
+// SDK. It is still only consulted after the built-in anchors have failed, and an
+// application-supplied tls_cert_verifier continues to take precedence.
 class PlatformCertificateVerifier : public SSLCertificateVerifier {
  public:
   PlatformCertificateVerifier();
@@ -33,6 +35,10 @@ class PlatformCertificateVerifier : public SSLCertificateVerifier {
   bool Verify(const SSLCertificate& certificate) override;
   bool VerifyChain(const SSLCertChain& chain) override;
 };
+
+// Matches rtc_base's PlatformCertificateVerifierFactory signature so that
+// JNI_OnLoad can hand it to SetPlatformCertificateVerifierFactory.
+std::unique_ptr<SSLCertificateVerifier> CreateAndroidCertificateVerifier();
 
 }  // namespace jni
 }  // namespace webrtc


### PR DESCRIPTION
## Problem

TURN/TLS trust anchors come from `rtc_base/ssl_roots.h`, generated from `https://pki.goog/roots.pem` — Google Trust Services' own chain of trust, not a general CA store. It holds 36 roots from 2023-05-09, one already expired (Baltimore CyberTrust, May 2025), and is missing Amazon Root CA 1–4, Starfield Services Root CA - G2 and ISRG Root X1/X2.

So a TURN server behind an AWS NLB with an ACM certificate, or anything issued by Let's Encrypt, fails its handshake with `unknown_ca` — even though the server sends a complete chain and the host OS trusts it. Reported downstream as livekit/client-sdk-swift#1074 and livekit/rust-sdks#1301.

Worth being precise: nothing is missing from the wire. `s3.amazonaws.com` sends leaf → `Amazon RSA 2048 M04` → `Amazon Root CA 1` (cross-signed by Starfield Services G2). It fails purely on anchors.

## Approach

Where the platform exposes a trust evaluation API, use it as a fallback when the embedder hasn't supplied its own verifier. `SSLVerifyInternal` only consults a verifier *after* the built-in anchors have failed to produce a path, so this can widen what's accepted and never narrow it — no currently-working connection changes behaviour.

Two details worth calling out:

- **The whole chain is passed.** The `SSLCertificateVerifier` exposed via the ObjC and JNI bridges forwards only `chain.Get(0)`. With a leaf alone the OS must recover intermediates over AIA — a plaintext HTTP fetch to the CA, on the network thread, mid-handshake. Measured ~125 ms cold, and it fails outright where port 80 is blocked or where the certificate carries no AIA extension (common for private CAs). `SecTrustSetNetworkFetchAllowed(false)` is set explicitly since nothing needs fetching.
- **Hostname matching is untouched.** `SSLPostConnectionCheck` already calls `VerifyPeerCertMatchesHost` independently of the verification result, so no name is passed to the platform policy.

## Platform coverage

| platform | status |
|---|---|
| Apple (macOS/iOS/tvOS/visionOS/Catalyst) | implemented, one file |
| Windows | implemented, **not compiled** — no toolchain available here |
| Linux / BSD | no OS API exists; keeps built-in anchors |
| Android | has an API, but `X509TrustManager` needs a JNI target outside `rtc_base` — follow-up |

## Verification

- `ninja rtc_base:ssl_adapter` and `sdk:mac_framework_bundle` build clean on macOS arm64.
- The built framework imports `SecTrustCreateWithCertificates`, `SecTrustEvaluateWithError`, `SecTrustSetNetworkFetchAllowed`, `SecPolicyCreateSSL`, `SecCertificateCreateWithData`.
- SecTrust behaviour validated separately against real chains: full chain verifies in ~1.5 ms with network fetching off; leaf-only fails without AIA.

**Draft because** the Windows path is uncompiled, Android is unimplemented, and there's no end-to-end relay test in this branch yet — a positive one needs a TURN server whose chain is trusted by the OS but absent from the 36.

## Note on the alternative

This does not remove the need to regenerate `ssl_roots.h`. Linux and Android still depend on it, and today's `pki.goog` has shrunk to 19 roots, so refreshing from the same source would make things worse. Regenerating from `https://curl.se/ca/cacert.pem` (119 roots, named in `generate_sslroots.py --help`) is a one-file change that fixes every platform at once, at +91 KiB per arch slice. The two are complementary; that one is arguably the cheaper first move.