### PR TITLE
Link AVFoundation for the macOS AudioEngine device

### DIFF
--- a/modules/audio_device/BUILD.gn
+++ b/modules/audio_device/BUILD.gn
@@ -429,6 +429,9 @@ if (is_mac) {
   rtc_source_set("audio_device_impl_frameworks") {
     visibility = [ ":*" ]
     frameworks = [
+      # Needed for AVAudioEngine in audio_engine_device.mm:
+      "AVFoundation.framework",
+
       # Needed for CoreGraphics:
       "ApplicationServices.framework",
 


### PR DESCRIPTION
audio_engine_device.mm is compiled for is_mac || is_ios, but only iOS pulls in AVFoundation (through sdk:audio_session_objc). On macOS audio_device_impl ends up with undefined AVFoundation symbols:

  Undefined symbols for architecture arm64:
    "_OBJC_CLASS_$_AVAudioEngine", "_OBJC_CLASS_$_AVAudioSinkNode",
    "_AVAudioEngineConfigurationChangeNotification", ...
      referenced from: libaudio_device_impl.a(audio_engine_device.o)

The shipped macOS framework links AVFoundation itself, which hides the missing dependency; anything else that links audio_device_impl (such as rtc_unittests, or libwebrtc.a consumers) fails to link.