### PR TITLE
feat: expose enableSctpSnap on RTCConfiguration (ObjC and Android) for WARP

### DIFF
--- a/sdk/android/api/org/webrtc/PeerConnection.java
+++ b/sdk/android/api/org/webrtc/PeerConnection.java
@@ -586,6 +586,16 @@ public class PeerConnection {
      */
     public boolean enableIceGatheringOnAnyAddressPorts;
 
+    /**
+     * Enable SNAP (SCTP INIT in SDP), part of WARP. Saves a round trip on
+     * data channel setup when the remote peer also supports it.
+     * See: https://www.ietf.org/archive/id/draft-hancke-tsvwg-snap-00.html
+     * This maps to an immutable field of the native configuration, so it must
+     * hold the same value at peer connection creation and on every
+     * setConfiguration call.
+     */
+    public boolean enableSctpSnap;
+
     /** Limit ports used for connections. */
     public int portAllocatorMinPort;
     public int portAllocatorMaxPort;
@@ -637,6 +647,7 @@ public class PeerConnection {
       portAllocatorMaxPort = 0;
       portAllocatorFlags = 0;
       enableIceGatheringOnAnyAddressPorts = false;
+      enableSctpSnap = false;
     }
 
     @CalledByNative
@@ -860,6 +871,11 @@ public class PeerConnection {
     @CalledByNative("RTCConfiguration")
     boolean getEnableIceGatheringOnAnyAddressPorts() {
       return enableIceGatheringOnAnyAddressPorts;
+    }
+
+    @CalledByNative("RTCConfiguration")
+    boolean getEnableSctpSnap() {
+      return enableSctpSnap;
     }
   };
 

--- a/sdk/android/src/jni/pc/peer_connection.cc
+++ b/sdk/android/src/jni/pc/peer_connection.cc
@@ -311,6 +311,9 @@ void JavaToNativeRTCConfiguration(
   rtc_config->enable_any_address_ports =
       Java_RTCConfiguration_getEnableIceGatheringOnAnyAddressPorts(jni, j_rtc_config);
 
+  rtc_config->enable_sctp_snap =
+      Java_RTCConfiguration_getEnableSctpSnap(jni, j_rtc_config);
+
   jni_zero::ScopedJavaLocalRef<jstring> j_turn_logging_id =
       Java_RTCConfiguration_getTurnLoggingId(jni, j_rtc_config);
   if (!IsNull(jni, j_turn_logging_id)) {

--- a/sdk/objc/api/peerconnection/RTCConfiguration.h
+++ b/sdk/objc/api/peerconnection/RTCConfiguration.h
@@ -271,6 +271,15 @@ RTC_OBJC_EXPORT
   */
 @property(nonatomic, assign) BOOL enableIceGatheringOnAnyAddressPorts;
 
+/** Enable SNAP (SCTP INIT in SDP), part of WARP. Saves a round trip on
+ *  data channel setup when the remote peer also supports it.
+ *  See: https://www.ietf.org/archive/id/draft-hancke-tsvwg-snap-00.html
+ *  This maps to an immutable field of the native configuration, so it must
+ *  hold the same value at peer connection creation and on every
+ *  setConfiguration call. Defaults to false.
+ */
+@property(nonatomic, assign) BOOL enableSctpSnap;
+
 - (instancetype)init;
 
 @end

--- a/sdk/objc/api/peerconnection/RTCConfiguration.mm
+++ b/sdk/objc/api/peerconnection/RTCConfiguration.mm
@@ -66,6 +66,7 @@
 @synthesize iceUnwritableMinChecks = _iceUnwritableMinChecks;
 @synthesize iceInactiveTimeout = _iceInactiveTimeout;
 @synthesize enableIceGatheringOnAnyAddressPorts = _enableIceGatheringOnAnyAddressPorts;
+@synthesize enableSctpSnap = _enableSctpSnap;
 
 - (instancetype)init {
   // Copy defaults.
@@ -172,6 +173,7 @@
         [NSNumber numberWithInt:*config.ice_inactive_timeout] :
         nil;
     _enableIceGatheringOnAnyAddressPorts = config.enable_any_address_ports;
+    _enableSctpSnap = config.enable_sctp_snap;
   }
   return self;
 }
@@ -334,6 +336,7 @@
         std::optional<int>(_iceInactiveTimeout.intValue);
   }
   nativeConfig->enable_any_address_ports = _enableIceGatheringOnAnyAddressPorts;
+  nativeConfig->enable_sctp_snap = _enableSctpSnap;
   return nativeConfig.release();
 }
 


### PR DESCRIPTION
## Description

Exposes the native `RTCConfiguration.enable_sctp_snap` field (m150, [draft-hancke-tsvwg-snap](https://www.ietf.org/archive/id/draft-hancke-tsvwg-snap-00.html)) through the ObjC and Android SDK wrappers so client SDKs can enable SNAP (SCTP INIT in SDP), the data channel half of WARP.

- ObjC: `enableSctpSnap` property on `RTCConfiguration`, mapped in both directions (init from native defaults, `createNativeConfiguration`)
- Android: `enableSctpSnap` field on `PeerConnection.RTCConfiguration` with a `CalledByNative` getter, mapped in the JNI conversion

Defaults to false on both platforms, so this is a no-op for existing users.

## Why the config field instead of the `WebRTC-Sctp-Snap` field trial

`enable_sctp_snap` is not in the modifiable list checked by `ApplyConfiguration`. If the field trial flips it to true inside the peer connection while the wrapper keeps passing false, every later `setConfiguration` call fails with INVALID_MODIFICATION. Carrying it on the configuration object keeps creation and reconfiguration consistent. This mirrors how livekit/rust-sdks#1342 handled it.

## SPED (the other half of WARP)

No new API needed. The DTLS-in-STUN field trial `WebRTC-IceHandshakeDtls` is already reachable via `+[RTCPeerConnectionFactory configureFieldTrials:]` on ObjC and `InitializationOptions.setFieldTrials` on Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)