### PR TITLE
Guard simulcast-factory AV1 advertisement; fail fast on nil ObjC encoder/decoder

### DIFF
--- a/sdk/objc/components/video_codec/RTCVideoEncoderFactorySimulcast.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderFactorySimulcast.mm
@@ -53,11 +53,13 @@
         [addingCodecs addObject: codec];
     }
 
+#if defined(RTC_USE_LIBAOM_AV1_ENCODER)
     auto av1Format = webrtc::SdpVideoFormat(
          webrtc::kAv1CodecName, webrtc::CodecParameterMap(),
          webrtc::LibaomAv1EncoderSupportedScalabilityModes());
     RTC_OBJC_TYPE(RTCVideoCodecInfo) *av1Codec = [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithNativeSdpVideoFormat: av1Format];
     [addingCodecs addObject: av1Codec];
+#endif
 
     // H265
     auto *h265Codec = [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc]

--- a/sdk/objc/native/src/objc_video_decoder_factory.mm
+++ b/sdk/objc/native/src/objc_video_decoder_factory.mm
@@ -104,6 +104,14 @@ std::unique_ptr<VideoDecoder> ObjCVideoDecoderFactory::Create(
       id<RTC_OBJC_TYPE(RTCVideoDecoder)> decoder =
           [decoder_factory_ createDecoder:codecInfo];
 
+      if (decoder == nil) {
+        // A nil decoder would still be wrapped below and silently drop every
+        // frame through nil messaging. Fail the codec selection instead.
+        RTC_LOG(LS_ERROR) << "ObjC decoder factory returned nil decoder for "
+                          << format.name;
+        return nullptr;
+      }
+
       if ([decoder conformsToProtocol:@protocol(RTC_OBJC_TYPE(
                                           RTCNativeVideoDecoderBuilder))]) {
         id<RTC_OBJC_TYPE(RTCNativeVideoDecoderBuilder)> builder =

--- a/sdk/objc/native/src/objc_video_encoder_factory.mm
+++ b/sdk/objc/native/src/objc_video_encoder_factory.mm
@@ -243,6 +243,14 @@ std::unique_ptr<VideoEncoder> ObjCVideoEncoderFactory::Create(
       alloc] initWithNativeSdpVideoFormat:format];
   id<RTC_OBJC_TYPE(RTCVideoEncoder)> encoder =
       [encoder_factory_ createEncoder:info];
+  if (encoder == nil) {
+    // A nil encoder would still be wrapped below and, through nil messaging,
+    // report success from InitEncode without ever producing frames. Fail the
+    // codec selection instead.
+    RTC_LOG(LS_ERROR) << "ObjC encoder factory returned nil encoder for "
+                      << format.name;
+    return nullptr;
+  }
   if ([encoder conformsToProtocol:@protocol(RTC_OBJC_TYPE(
                                       RTCNativeVideoEncoderBuilder))]) {
     id<RTC_OBJC_TYPE(RTCNativeVideoEncoderBuilder)> builder =


### PR DESCRIPTION
`RTCVideoEncoderFactorySimulcast` advertised AV1 unconditionally, so builds with `enable_libaom=false` (e.g. the stripped Apple variant, webrtc-sdk/webrtc-build#64) offer AV1 in SDP while `createEncoder:` cannot create it — the nil encoder gets wrapped and nil-messaging makes `InitEncode` report success, yielding a silently dead track. This guards the AV1 entry with `RTC_USE_LIBAOM_AV1_ENCODER`, matching `RTCDefaultVideoEncoderFactory`. As defense in depth, the ObjC native encoder/decoder factories now return `nullptr` with an error log when the wrapped factory returns nil, instead of wrapping nil. No behavior change for regular builds where AV1 is compiled in. The same change was compile- and link-verified on m144 in both regular and stripped configurations; m150 build verification of this branch is in progress and will be confirmed in a comment.