### PR TITLE
Ship missing ObjC headers in the mac framework

### DIFF
--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1712,6 +1712,7 @@ if (is_ios || is_mac) {
           "objc/api/peerconnection/RTCTracing.h",
           "objc/api/peerconnection/RTCVideoSource.h",
           "objc/api/peerconnection/RTCVideoTrack.h",
+          "objc/api/video_codec/RTCVideoCodecConstants.h",
           "objc/api/video_codec/RTCVideoDecoderAV1.h",
           "objc/api/video_codec/RTCVideoDecoderVP8.h",
           "objc/api/video_codec/RTCVideoDecoderVP9.h",

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1769,6 +1769,14 @@ if (is_ios || is_mac) {
           "objc/components/audio/RTCAudioCustomProcessingDelegate.h",
           "objc/components/audio/RTCAudioProcessingConfig.h",
         ]
+        if (rtc_use_h265) {
+          sources += [
+            "objc/components/video_codec/RTCCodecSpecificInfoH265.h",
+            "objc/components/video_codec/RTCH265ProfileLevelId.h",
+            "objc/components/video_codec/RTCVideoDecoderH265.h",
+            "objc/components/video_codec/RTCVideoEncoderH265.h",
+          ]
+        }
         if (!build_with_chromium) {
           sources += [
             "objc/api/logging/RTCCallbackLogger.h",

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1798,9 +1798,6 @@ if (is_ios || is_mac) {
           ":videocodec_objc",
           ":videotoolbox_objc",
         ]
-        if (is_ios && (target_environment != "xrdevice" && target_environment != "xrsimulator")) {
-          deps += [ ":metal_objc" ]
-        }
         if (!build_with_chromium) {
           deps += [
             ":callback_logger_objc",

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1765,6 +1765,7 @@ if (is_ios || is_mac) {
           "objc/components/video_codec/RTCVideoEncoderFactorySimulcast.h",
           "objc/api/video_codec/RTCVideoEncoderSimulcast.h",
           "objc/components/audio/RTCAudioBuffer.h",
+          "objc/components/audio/RTCAudioDevice.h",
           "objc/components/audio/RTCAudioProcessingModule.h",
           "objc/components/audio/RTCDefaultAudioProcessingModule.h",
           "objc/components/audio/RTCAudioCustomProcessingDelegate.h",


### PR DESCRIPTION
The mac framework compiles several public ObjC APIs into the binary without shipping their headers, so they are unusable from apps on macOS while every other platform slice exposes them.

- H265: RTCCodecSpecificInfoH265, RTCH265ProfileLevelId, RTCVideoDecoderH265, RTCVideoEncoderH265 (mirrors the iOS rtc_use_h265 block)
- RTCVideoCodecConstants.h: kRTCVideoCodecVp8/Vp9/Av1Name constants, paired VP8/VP9/AV1 codec headers already ship on mac
- RTCAudioDevice.h: the shipped RTCPeerConnectionFactory.h exposes the audioDevice: initializer but the protocol header was iOS only
- Also removes a dead is_ios deps block from mac_framework_objc