### PR TITLE
Do not instantiate AVAudioEngine.inputNode on playout-only engine teardown

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -504,6 +504,12 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   AVAudioInputNode* InputNodeOrNil() const;
   AVAudioOutputNode* OutputNode(const EngineStateUpdate& state);
 
+  // Stops the device engine's I/O audio units explicitly before the engine is
+  // released. Required for VPIO, which creates an aggregate device and IO thread
+  // that -[AVAudioEngine stop] alone may not fully tear down, and harmless for
+  // standard I/O nodes. Must be called on `thread_` with engine_device_ set.
+  void StopDeviceEngineAudioUnits();
+
 // Device related
 #if TARGET_OS_OSX
   static OSStatus objectListenerProc(AudioObjectID objectId, UInt32 numberAddresses,

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -556,6 +556,12 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   // AVAudioEngine objects
   AVAudioEngine* engine_device_ RTC_GUARDED_BY(thread_);
+  // True once the current `engine_device_` instance has instantiated its
+  // inputNode. -[AVAudioEngine inputNode] creates the input audio unit on first
+  // access, and on iOS that alone triggers the microphone permission prompt.
+  // A playout-only engine must therefore never reach for the input node, not
+  // even while stopping units on teardown.
+  bool input_node_instantiated_ RTC_GUARDED_BY(thread_) = false;
   AVAudioEngine* engine_manual_input_ RTC_GUARDED_BY(thread_);
 
   // Used for manual rendering mode

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -493,6 +493,14 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   // AudioEngine observer methods. May be called from any thread.
   void ReconfigureEngine();
 
+  // The only two ways to reach engine_device_.inputNode. -[AVAudioEngine inputNode]
+  // instantiates the input audio unit on first access, which on iOS triggers the
+  // microphone permission prompt, so callers must be explicit about intent:
+  // InputNode() instantiates (input is being enabled), InputNodeOrNil() never
+  // does and returns nil unless this engine instance already instantiated it.
+  AVAudioInputNode* InputNode();
+  AVAudioInputNode* InputNodeOrNil() const;
+
 // Device related
 #if TARGET_OS_OSX
   static OSStatus objectListenerProc(AudioObjectID objectId, UInt32 numberAddresses,
@@ -557,10 +565,8 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   // AVAudioEngine objects
   AVAudioEngine* engine_device_ RTC_GUARDED_BY(thread_);
   // True once the current `engine_device_` instance has instantiated its
-  // inputNode. -[AVAudioEngine inputNode] creates the input audio unit on first
-  // access, and on iOS that alone triggers the microphone permission prompt.
-  // A playout-only engine must therefore never reach for the input node, not
-  // even while stopping units on teardown.
+  // inputNode. Never read engine_device_.inputNode directly, go through
+  // InputNode() or InputNodeOrNil() so this flag stays accurate.
   bool input_node_instantiated_ RTC_GUARDED_BY(thread_) = false;
   AVAudioEngine* engine_manual_input_ RTC_GUARDED_BY(thread_);
 

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -493,13 +493,18 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   // AudioEngine observer methods. May be called from any thread.
   void ReconfigureEngine();
 
+  // Accessors for the device engine's I/O nodes. They take the in-flight
+  // transition so they can assert the node is only reached while the matching
+  // side is, or is being, enabled.
+  //
   // The only two ways to reach engine_device_.inputNode. -[AVAudioEngine inputNode]
   // instantiates the input audio unit on first access, which on iOS triggers the
   // microphone permission prompt, so callers must be explicit about intent:
   // InputNode() instantiates (input is being enabled), InputNodeOrNil() never
   // does and returns nil unless this engine instance already instantiated it.
-  AVAudioInputNode* InputNode();
+  AVAudioInputNode* InputNode(const EngineStateUpdate& state);
   AVAudioInputNode* InputNodeOrNil() const;
+  AVAudioOutputNode* OutputNode(const EngineStateUpdate& state);
 
 // Device related
 #if TARGET_OS_OSX

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -570,8 +570,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   // AVAudioEngine objects
   AVAudioEngine* engine_device_ RTC_GUARDED_BY(thread_);
   // True once the current `engine_device_` instance has instantiated its
-  // inputNode. Never read engine_device_.inputNode directly, go through
-  // InputNode() or InputNodeOrNil() so this flag stays accurate.
+  // inputNode. Reset whenever a new engine is allocated, meaningless while
+  // engine_device_ is nil. Never read engine_device_.inputNode directly, go
+  // through InputNode() or InputNodeOrNil() so this flag stays accurate.
   bool input_node_instantiated_ RTC_GUARDED_BY(thread_) = false;
   AVAudioEngine* engine_manual_input_ RTC_GUARDED_BY(thread_);
 

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -493,15 +493,13 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   // AudioEngine observer methods. May be called from any thread.
   void ReconfigureEngine();
 
-  // Accessors for the device engine's I/O nodes. They take the in-flight
-  // transition so they can assert the node is only reached while the matching
-  // side is, or is being, enabled.
-  //
-  // The only two ways to reach engine_device_.inputNode. -[AVAudioEngine inputNode]
-  // instantiates the input audio unit on first access, which on iOS triggers the
-  // microphone permission prompt, so callers must be explicit about intent:
-  // InputNode() instantiates (input is being enabled), InputNodeOrNil() never
-  // does and returns nil unless this engine instance already instantiated it.
+  // Device engine I/O node accessors. Must be called on `thread_`. The ones
+  // taking the in-flight transition assert that the matching side is, or is
+  // being, enabled. -[AVAudioEngine inputNode] instantiates the input audio
+  // unit on first access, which on iOS triggers the microphone permission
+  // prompt, so these are the only two ways to reach it: InputNode()
+  // instantiates it (input is being enabled), InputNodeOrNil() never does and
+  // returns nil unless this engine instance already instantiated it.
   AVAudioInputNode* InputNode(const EngineStateUpdate& state);
   AVAudioInputNode* InputNodeOrNil() const;
   AVAudioOutputNode* OutputNode(const EngineStateUpdate& state);

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -2253,7 +2253,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     }
 
     engine_device_ = nil;
-    input_node_instantiated_ = false;
   }
 
   // --------------------------------------------------------------------------------------------
@@ -2265,13 +2264,15 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     RTC_DCHECK(engine_device_ == nil);
 
     engine_device_ = [[AVAudioEngine alloc] init];
+    // Per engine instance: a fresh engine has no input node yet. This is the
+    // only place the flag needs resetting, it is unobservable while
+    // engine_device_ is nil.
     input_node_instantiated_ = false;
 
     rollback_actions.push_back([this]() {
       RTC_DCHECK_RUN_ON(thread_);
       LOGI() << "Rolling back create AVAudioEngine (device)...";
       engine_device_ = nil;
-      input_node_instantiated_ = false;
     });
 
     if (observer_ != nullptr) {
@@ -3098,7 +3099,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
 
     LOGI() << "Releasing AVAudioEngine...";
     engine_device_ = nil;
-    input_node_instantiated_ = false;
   }
 
   // --- Diagnostic: final state after apply ---

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1181,14 +1181,12 @@ AudioDeviceModule::PlatformAudioProcessingState AudioEngineDevice::GetPlatformAu
   state.is_voice_processing_bypassed_requested = engine_state_.voice_processing_bypassed;
   state.is_voice_processing_agc_enabled_requested = engine_state_.voice_processing_agc_enabled;
 
-  // Without an instantiated input node there is no hardware VP state to read,
-  // and reading -[AVAudioEngine inputNode] here would create the input unit and
-  // trigger the microphone permission prompt on a playout-only engine.
-  if (engine_device_ == nil || !input_node_instantiated_) {
+  // Without an instantiated input node there is no hardware VP state to read.
+  AVAudioInputNode* input_node = InputNodeOrNil();
+  if (input_node == nil) {
     return state;
   }
 
-  AVAudioInputNode *input_node = engine_device_.inputNode;
   @try {
     const bool vp_active = input_node.isVoiceProcessingEnabled;
     const bool bypassed_active = vp_active ? input_node.voiceProcessingBypassed : true;
@@ -1583,6 +1581,21 @@ int32_t AudioEngineDevice::InitRecordingPersistentMode(bool* enabled) {
 
 // ----------------------------------------------------------------------------------------------------
 // Private - Engine Related
+
+AVAudioInputNode* AudioEngineDevice::InputNode() {
+  RTC_DCHECK_RUN_ON(thread_);
+  RTC_DCHECK(engine_device_ != nil);
+  input_node_instantiated_ = true;
+  return engine_device_.inputNode;
+}
+
+AVAudioInputNode* AudioEngineDevice::InputNodeOrNil() const {
+  RTC_DCHECK_RUN_ON(thread_);
+  if (engine_device_ == nil || !input_node_instantiated_) {
+    return nil;
+  }
+  return engine_device_.inputNode;
+}
 
 void AudioEngineDevice::ReconfigureEngine() {
   LOGI() << "ReconfigureEngine";
@@ -2139,10 +2152,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
 
   auto inputNode = [this, state]() {
     RTC_DCHECK_RUN_ON(thread_);
-    RTC_DCHECK(engine_device_ != nil);
     RTC_DCHECK(state.prev.IsInputEnabled() || state.next.IsInputEnabled());
-    input_node_instantiated_ = true;
-    return engine_device_.inputNode;
+    return InputNode();
   };
 
   auto outputNode = [this, state]() {
@@ -2218,14 +2229,10 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       // Stop AudioUnits explicitly before releasing the engine. Required for VPIO
       // which creates an aggregate device and IO thread that may not be fully torn
       // down by -[AVAudioEngine stop] alone, and harmless for standard I/O nodes.
-      // Only stop the input unit if this engine instance ever instantiated the
-      // input node. Reading -[AVAudioEngine inputNode] creates the input unit on
-      // first access, which on iOS triggers the microphone permission prompt. A
-      // playout-only engine (for example a subscribe-only viewer) has no input
-      // unit to stop and must not be the reason the prompt appears on teardown.
-      if (input_node_instantiated_) {
-        AVAudioInputNode* input_node = engine_device_.inputNode;
-        if (input_node != nil && input_node.audioUnit != nullptr) {
+      // A playout-only engine (for example a subscribe-only viewer) never
+      // instantiated its input node, so there is no input unit to stop.
+      if (AVAudioInputNode* input_node = InputNodeOrNil()) {
+        if (input_node.audioUnit != nullptr) {
           OSStatus err = AudioOutputUnitStop(input_node.audioUnit);
           if (err != noErr) {
             LOGW() << "AudioOutputUnitStop (input) returned: " << err;
@@ -3066,14 +3073,10 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       // Stop AudioUnits explicitly before releasing the engine. Required for VPIO
       // which creates an aggregate device and IO thread that may not be fully torn
       // down by -[AVAudioEngine stop] alone, and harmless for standard I/O nodes.
-      // Only stop the input unit if this engine instance ever instantiated the
-      // input node. Reading -[AVAudioEngine inputNode] creates the input unit on
-      // first access, which on iOS triggers the microphone permission prompt. A
-      // playout-only engine (for example a subscribe-only viewer) has no input
-      // unit to stop and must not be the reason the prompt appears on teardown.
-      if (input_node_instantiated_) {
-        AVAudioInputNode* input_node = engine_device_.inputNode;
-        if (input_node != nil && input_node.audioUnit != nullptr) {
+      // A playout-only engine (for example a subscribe-only viewer) never
+      // instantiated its input node, so there is no input unit to stop.
+      if (AVAudioInputNode* input_node = InputNodeOrNil()) {
+        if (input_node.audioUnit != nullptr) {
           OSStatus err = AudioOutputUnitStop(input_node.audioUnit);
           if (err != noErr) {
             LOGW() << "AudioOutputUnitStop (input) returned: " << err;

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1582,9 +1582,10 @@ int32_t AudioEngineDevice::InitRecordingPersistentMode(bool* enabled) {
 // ----------------------------------------------------------------------------------------------------
 // Private - Engine Related
 
-AVAudioInputNode* AudioEngineDevice::InputNode() {
+AVAudioInputNode* AudioEngineDevice::InputNode(const EngineStateUpdate& state) {
   RTC_DCHECK_RUN_ON(thread_);
   RTC_DCHECK(engine_device_ != nil);
+  RTC_DCHECK(state.prev.IsInputEnabled() || state.next.IsInputEnabled());
   input_node_instantiated_ = true;
   return engine_device_.inputNode;
 }
@@ -1595,6 +1596,13 @@ AVAudioInputNode* AudioEngineDevice::InputNodeOrNil() const {
     return nil;
   }
   return engine_device_.inputNode;
+}
+
+AVAudioOutputNode* AudioEngineDevice::OutputNode(const EngineStateUpdate& state) {
+  RTC_DCHECK_RUN_ON(thread_);
+  RTC_DCHECK(engine_device_ != nil);
+  RTC_DCHECK(state.prev.IsOutputEnabled() || state.next.IsOutputEnabled());
+  return engine_device_.outputNode;
 }
 
 void AudioEngineDevice::ReconfigureEngine() {
@@ -2150,19 +2158,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     return result;
   };
 
-  auto inputNode = [this, state]() {
-    RTC_DCHECK_RUN_ON(thread_);
-    RTC_DCHECK(state.prev.IsInputEnabled() || state.next.IsInputEnabled());
-    return InputNode();
-  };
-
-  auto outputNode = [this, state]() {
-    RTC_DCHECK_RUN_ON(thread_);
-    RTC_DCHECK(engine_device_ != nil);
-    RTC_DCHECK(state.prev.IsOutputEnabled() || state.next.IsOutputEnabled());
-    return engine_device_.outputNode;
-  };
-
   // --------------------------------------------------------------------------------------------
   // Step: Stop AVAudioEngine
   //
@@ -2355,7 +2350,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     NSError* error = nil;
     BOOL set_vp_result = NO;
     @try {
-      set_vp_result = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
+      set_vp_result = [InputNode(state) setVoiceProcessingEnabled:state.next.voice_processing_enabled
                                                        error:&error];
     } @catch (NSException* exception) {
       LOGE() << "setVoiceProcessingEnabled threw exception: "
@@ -2375,7 +2370,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       // VP mute defaults to false on fresh enable; set unconditionally to avoid
       // a potentially unsafe hardware read.
       if (state.next.mute_mode == MuteMode::RestartEngine) {
-        inputNode().voiceProcessingInputMuted = false;
+        InputNode(state).voiceProcessingInputMuted = false;
       }
 
       // Muted talker detection.
@@ -2397,7 +2392,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
           }));
         };
 
-        BOOL set_listener_result = [inputNode() setMutedSpeechActivityEventListener:listener_block];
+        BOOL set_listener_result = [InputNode(state) setMutedSpeechActivityEventListener:listener_block];
         if (set_listener_result) {
           LOGI() << "setMutedSpeechActivityEventListener success";
         } else {
@@ -2416,7 +2411,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     LOGI() << "Enabling output for AVAudioEngine...";
     RTC_DCHECK(!engine_device_.running);
 
-    AVAudioFormat* output_node_format = [outputNode() outputFormatForBus:0];
+    AVAudioFormat* output_node_format = [OutputNode(state) outputFormatForBus:0];
 
     LOGI() << "Output format sampleRate: " << output_node_format.sampleRate
            << " channels: " << output_node_format.channelCount
@@ -2496,7 +2491,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       // mainMixerNode -> outputNode is connected by default by AVAudioEngine, but we connect anyways
       // with format.
       [engine_device_ connect:engine_device_.mainMixerNode
-                           to:outputNode()
+                           to:OutputNode(state)
                        format:engine_output_format];
     } @catch (NSException* exception) {
       LOGE() << "Failed to connect output nodes: " << exception.reason.UTF8String;
@@ -2507,7 +2502,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       NSDictionary* context = @{};
       int32_t result =
           this->observer_->OnEngineWillConnectOutput(engine_device_, engine_device_.mainMixerNode,
-                                                     outputNode(), engine_output_format, context);
+                                                     OutputNode(state), engine_output_format, context);
       if (result != 0) {
         LOGE() << "Call to OnEngineWillConnectOutput returned error: " << result;
         return rollback(result);
@@ -2548,7 +2543,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     // hardware format) for a nonzero sample rate and channel count to see if input is in an enabled
     // state. Trying to perform input through the input node when it isn’t available or in an
     // enabled state causes the engine to throw an error (when possible) or an exception.
-    AVAudioFormat* input_node_format = [inputNode() outputFormatForBus:0];
+    AVAudioFormat* input_node_format = [InputNode(state) outputFormatForBus:0];
     // Example formats:
     // Airpods: 1 ch,  24000 Hz, Float32
     // Mac: 9 ch,  48000 Hz, Float32
@@ -2681,7 +2676,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
         kAudioEngineInputMixerNodeKey : input_mixer_node_,
       };
       int32_t result = observer_->OnEngineWillConnectInput(
-          engine_device_, inputNode(), input_mixer_node_, engine_input_format, context);
+          engine_device_, InputNode(state), input_mixer_node_, engine_input_format, context);
       if (result != 0) {
         LOGE() << "Call to OnEngineWillConnectInput returned error: " << result;
         return rollback(result);
@@ -2701,7 +2696,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       if (input_mixer_connections.count == 0) {
         LOGI() << "Nothing connected to input mixer, connecting input node...";
         // Default implementation.
-        [engine_device_ connect:inputNode() to:input_mixer_node_ format:engine_input_format];
+        [engine_device_ connect:InputNode(state) to:input_mixer_node_ format:engine_input_format];
       }
     } @catch (NSException* exception) {
       LOGE() << "Failed to connect input nodes: " << exception.reason.UTF8String;
@@ -2740,7 +2735,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     // Set unconditionally to avoid a potentially unsafe VP property read.
     if (state.prev.voice_processing_enabled) {
       LOGI() << "Update mute (voice processing) unmuting vp for stop-recording";
-      inputNode().voiceProcessingInputMuted = false;
+      InputNode(state).voiceProcessingInputMuted = false;
     }
 
     // Detach input mixer node
@@ -2805,7 +2800,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
         (state.prev.mute_mode == MuteMode::VoiceProcessing) && state.prev.input_muted;
     if (should_vp_mute != prev_vp_mute) {
       LOGI() << "Update mute (voice processing): " << should_vp_mute;
-      inputNode().voiceProcessingInputMuted = should_vp_mute;
+      InputNode(state).voiceProcessingInputMuted = should_vp_mute;
     }
   }
 
@@ -2838,7 +2833,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       ducking_config.duckingLevel = ToAVDuckingLevel(state.next.ducking_level);
 
       LOGI() << "setVoiceProcessingOtherAudioDuckingConfiguration";
-      inputNode().voiceProcessingOtherAudioDuckingConfiguration = ducking_config;
+      InputNode(state).voiceProcessingOtherAudioDuckingConfiguration = ducking_config;
     }
   }
 #endif
@@ -2850,7 +2845,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       (!vp_was_configured ||
        state.prev.voice_processing_bypassed != state.next.voice_processing_bypassed)) {
     LOGI() << "setting voiceProcessingBypassed: " << state.next.voice_processing_bypassed;
-    inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
+    InputNode(state).voiceProcessingBypassed = state.next.voice_processing_bypassed;
   }
 
   // --------------------------------------------------------------------------------------------
@@ -2860,7 +2855,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       (!vp_was_configured ||
        state.prev.voice_processing_agc_enabled != state.next.voice_processing_agc_enabled)) {
     LOGI() << "setting voiceProcessingAGCEnabled: " << state.next.voice_processing_agc_enabled;
-    inputNode().voiceProcessingAGCEnabled = state.next.voice_processing_agc_enabled;
+    InputNode(state).voiceProcessingAGCEnabled = state.next.voice_processing_agc_enabled;
   }
 
   // --------------------------------------------------------------------------------------------
@@ -2877,7 +2872,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
         LOGI() << "Setting input device: " << input_device_name.value_or("Unknown") << " ("
                << requested_input_device_id << ")";
 
-        AudioUnit input_unit = inputNode().audioUnit;
+        AudioUnit input_unit = InputNode(state).audioUnit;
         OSStatus set_input_err = AudioUnitSetProperty(
             input_unit, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 1,
             &requested_input_device_id, sizeof(requested_input_device_id));
@@ -2900,7 +2895,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
         auto output_device_name = mac_audio_utils::GetDeviceName(output_deviceId);
         LOGI() << "Setting output device: " << output_device_name.value_or("Unknown") << " ("
                << output_deviceId << ")";
-        AudioUnit outputUnit = outputNode().audioUnit;
+        AudioUnit outputUnit = OutputNode(state).audioUnit;
         OSStatus err = AudioUnitSetProperty(outputUnit, kAudioOutputUnitProperty_CurrentDevice,
                                             kAudioUnitScope_Global, 0, &output_deviceId,
                                             sizeof(output_deviceId));

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1181,7 +1181,10 @@ AudioDeviceModule::PlatformAudioProcessingState AudioEngineDevice::GetPlatformAu
   state.is_voice_processing_bypassed_requested = engine_state_.voice_processing_bypassed;
   state.is_voice_processing_agc_enabled_requested = engine_state_.voice_processing_agc_enabled;
 
-  if (engine_device_ == nil) {
+  // Without an instantiated input node there is no hardware VP state to read,
+  // and reading -[AVAudioEngine inputNode] here would create the input unit and
+  // trigger the microphone permission prompt on a playout-only engine.
+  if (engine_device_ == nil || !input_node_instantiated_) {
     return state;
   }
 
@@ -2138,6 +2141,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     RTC_DCHECK_RUN_ON(thread_);
     RTC_DCHECK(engine_device_ != nil);
     RTC_DCHECK(state.prev.IsInputEnabled() || state.next.IsInputEnabled());
+    input_node_instantiated_ = true;
     return engine_device_.inputNode;
   };
 
@@ -2214,15 +2218,22 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       // Stop AudioUnits explicitly before releasing the engine. Required for VPIO
       // which creates an aggregate device and IO thread that may not be fully torn
       // down by -[AVAudioEngine stop] alone, and harmless for standard I/O nodes.
-      AVAudioInputNode* input_node = engine_device_.inputNode;
-      AVAudioOutputNode* output_node = engine_device_.outputNode;
-
-      if (input_node != nil && input_node.audioUnit != nullptr) {
-        OSStatus err = AudioOutputUnitStop(input_node.audioUnit);
-        if (err != noErr) {
-          LOGW() << "AudioOutputUnitStop (input) returned: " << err;
+      // Only stop the input unit if this engine instance ever instantiated the
+      // input node. Reading -[AVAudioEngine inputNode] creates the input unit on
+      // first access, which on iOS triggers the microphone permission prompt. A
+      // playout-only engine (for example a subscribe-only viewer) has no input
+      // unit to stop and must not be the reason the prompt appears on teardown.
+      if (input_node_instantiated_) {
+        AVAudioInputNode* input_node = engine_device_.inputNode;
+        if (input_node != nil && input_node.audioUnit != nullptr) {
+          OSStatus err = AudioOutputUnitStop(input_node.audioUnit);
+          if (err != noErr) {
+            LOGW() << "AudioOutputUnitStop (input) returned: " << err;
+          }
         }
       }
+      AVAudioOutputNode* output_node = engine_device_.outputNode;
+
       if (output_node != nil && output_node.audioUnit != nullptr) {
         OSStatus err = AudioOutputUnitStop(output_node.audioUnit);
         if (err != noErr) {
@@ -2240,6 +2251,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     }
 
     engine_device_ = nil;
+    input_node_instantiated_ = false;
   }
 
   // --------------------------------------------------------------------------------------------
@@ -2251,11 +2263,13 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     RTC_DCHECK(engine_device_ == nil);
 
     engine_device_ = [[AVAudioEngine alloc] init];
+    input_node_instantiated_ = false;
 
     rollback_actions.push_back([this]() {
       RTC_DCHECK_RUN_ON(thread_);
       LOGI() << "Rolling back create AVAudioEngine (device)...";
       engine_device_ = nil;
+      input_node_instantiated_ = false;
     });
 
     if (observer_ != nullptr) {
@@ -3052,15 +3066,22 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       // Stop AudioUnits explicitly before releasing the engine. Required for VPIO
       // which creates an aggregate device and IO thread that may not be fully torn
       // down by -[AVAudioEngine stop] alone, and harmless for standard I/O nodes.
-      AVAudioInputNode* input_node = engine_device_.inputNode;
-      AVAudioOutputNode* output_node = engine_device_.outputNode;
-
-      if (input_node != nil && input_node.audioUnit != nullptr) {
-        OSStatus err = AudioOutputUnitStop(input_node.audioUnit);
-        if (err != noErr) {
-          LOGW() << "AudioOutputUnitStop (input) returned: " << err;
+      // Only stop the input unit if this engine instance ever instantiated the
+      // input node. Reading -[AVAudioEngine inputNode] creates the input unit on
+      // first access, which on iOS triggers the microphone permission prompt. A
+      // playout-only engine (for example a subscribe-only viewer) has no input
+      // unit to stop and must not be the reason the prompt appears on teardown.
+      if (input_node_instantiated_) {
+        AVAudioInputNode* input_node = engine_device_.inputNode;
+        if (input_node != nil && input_node.audioUnit != nullptr) {
+          OSStatus err = AudioOutputUnitStop(input_node.audioUnit);
+          if (err != noErr) {
+            LOGW() << "AudioOutputUnitStop (input) returned: " << err;
+          }
         }
       }
+      AVAudioOutputNode* output_node = engine_device_.outputNode;
+
       if (output_node != nil && output_node.audioUnit != nullptr) {
         OSStatus err = AudioOutputUnitStop(output_node.audioUnit);
         if (err != noErr) {
@@ -3079,6 +3100,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
 
     LOGI() << "Releasing AVAudioEngine...";
     engine_device_ = nil;
+    input_node_instantiated_ = false;
   }
 
   // --- Diagnostic: final state after apply ---

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1605,6 +1605,31 @@ AVAudioOutputNode* AudioEngineDevice::OutputNode(const EngineStateUpdate& state)
   return engine_device_.outputNode;
 }
 
+void AudioEngineDevice::StopDeviceEngineAudioUnits() {
+  RTC_DCHECK_RUN_ON(thread_);
+  RTC_DCHECK(engine_device_ != nil);
+
+  // A playout-only engine (for example a subscribe-only viewer) never
+  // instantiated its input node, so there is no input unit to stop and it must
+  // not be instantiated here.
+  if (AVAudioInputNode* input_node = InputNodeOrNil()) {
+    if (input_node.audioUnit != nullptr) {
+      OSStatus err = AudioOutputUnitStop(input_node.audioUnit);
+      if (err != noErr) {
+        LOGW() << "AudioOutputUnitStop (input) returned: " << err;
+      }
+    }
+  }
+
+  AVAudioOutputNode* output_node = engine_device_.outputNode;
+  if (output_node != nil && output_node.audioUnit != nullptr) {
+    OSStatus err = AudioOutputUnitStop(output_node.audioUnit);
+    if (err != noErr) {
+      LOGW() << "AudioOutputUnitStop (output) returned: " << err;
+    }
+  }
+}
+
 void AudioEngineDevice::ReconfigureEngine() {
   LOGI() << "ReconfigureEngine";
 
@@ -2221,27 +2246,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     LOGI() << "Recreate required, releasing AVAudioEngine...";
 
     if (engine_device_ != nil) {
-      // Stop AudioUnits explicitly before releasing the engine. Required for VPIO
-      // which creates an aggregate device and IO thread that may not be fully torn
-      // down by -[AVAudioEngine stop] alone, and harmless for standard I/O nodes.
-      // A playout-only engine (for example a subscribe-only viewer) never
-      // instantiated its input node, so there is no input unit to stop.
-      if (AVAudioInputNode* input_node = InputNodeOrNil()) {
-        if (input_node.audioUnit != nullptr) {
-          OSStatus err = AudioOutputUnitStop(input_node.audioUnit);
-          if (err != noErr) {
-            LOGW() << "AudioOutputUnitStop (input) returned: " << err;
-          }
-        }
-      }
-      AVAudioOutputNode* output_node = engine_device_.outputNode;
-
-      if (output_node != nil && output_node.audioUnit != nullptr) {
-        OSStatus err = AudioOutputUnitStop(output_node.audioUnit);
-        if (err != noErr) {
-          LOGW() << "AudioOutputUnitStop (output) returned: " << err;
-        }
-      }
+      StopDeviceEngineAudioUnits();
     }
 
     if (observer_ != nullptr && engine_device_ != nil) {
@@ -3065,29 +3070,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   if (state.prev.IsAnyEnabled() && !state.next.IsAnyEnabled()) {
     RTC_DCHECK(engine_device_ != nullptr);
 
-    {
-      // Stop AudioUnits explicitly before releasing the engine. Required for VPIO
-      // which creates an aggregate device and IO thread that may not be fully torn
-      // down by -[AVAudioEngine stop] alone, and harmless for standard I/O nodes.
-      // A playout-only engine (for example a subscribe-only viewer) never
-      // instantiated its input node, so there is no input unit to stop.
-      if (AVAudioInputNode* input_node = InputNodeOrNil()) {
-        if (input_node.audioUnit != nullptr) {
-          OSStatus err = AudioOutputUnitStop(input_node.audioUnit);
-          if (err != noErr) {
-            LOGW() << "AudioOutputUnitStop (input) returned: " << err;
-          }
-        }
-      }
-      AVAudioOutputNode* output_node = engine_device_.outputNode;
-
-      if (output_node != nil && output_node.audioUnit != nullptr) {
-        OSStatus err = AudioOutputUnitStop(output_node.audioUnit);
-        if (err != noErr) {
-          LOGW() << "AudioOutputUnitStop (output) returned: " << err;
-        }
-      }
-    }
+    StopDeviceEngineAudioUnits();
 
     if (observer_ != nullptr) {
       int32_t result = observer_->OnEngineWillRelease(engine_device_);


### PR DESCRIPTION
## Problem

Since #228 the engine release step (and the recreate step) read `engine_device_.inputNode` unconditionally to `AudioOutputUnitStop` the input unit. `-[AVAudioEngine inputNode]` instantiates the input audio unit on first access, and on iOS that alone triggers the microphone permission prompt. For a playout-only engine this is the first time the input node is touched, so a subscribe-only viewer gets a mic prompt on room teardown. `ReconfigureEngine()` (route change, `AVAudioEngineConfigurationChangeNotification`) goes through the same release step, so it can also fire mid-session. `GetPlatformAudioProcessingState` had the same unconditional read.

Reproduced with livekit_client 2.11.0 (WebRTC-SDK 144.7559.09), iPhone 17 Pro / iOS 27, fresh install, `canPublish=false`, `mediaPlayback`, engine input unavailable: no prompt on connect or playback, prompt on disconnect. Affects WebRTC-SDK 144.7559.02 and later.

## Fix

- `input_node_instantiated_` tracks whether the current `engine_device_` instance ever instantiated its input node. Reset only where a new engine is allocated.
- `InputNode(state)` is the only instantiating accessor (asserts input is or is being enabled). `InputNodeOrNil()` never instantiates. `OutputNode(state)` mirrors it. The device-mode lambdas are gone, `engine_device_.inputNode` is read only inside these accessors.
- Teardown uses `InputNodeOrNil()` via a shared `StopDeviceEngineAudioUnits()`, so engines that did enable input (including the Speaker+Mic to Speaker-only recreate #228 targeted) still get the explicit stop.

## Status

- [x] Syntax verified: `clang -fsyntax-only` on `audio_engine_device.mm` against the macOS and iOS SDKs, 0 errors
- [x] Full build: [webrtc-build run 32967912289](https://github.com/webrtc-sdk/webrtc-build/actions/runs/32967912289) on `1198bd125b`, all Apple and Android jobs green
- [ ] Verify on device with that xcframework (fresh install: connect, play, disconnect, plus AirPods route change while playing)
- [ ] Port to `m144_release` (same patch minus the `GetPlatformAudioProcessingState` hunk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
