### PR TITLE
android: do not assert when prewarmRecording runs after a failed recorder init

### DIFF
--- a/sdk/android/api/org/webrtc/audio/JavaAudioDeviceModule.java
+++ b/sdk/android/api/org/webrtc/audio/JavaAudioDeviceModule.java
@@ -495,24 +495,47 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
     audioInput.setUseAudioRecord(enable);
   }
 
-  public void prewarmRecording() {
-    prewarmRecording(null);
+  public boolean prewarmRecording() {
+    return prewarmRecording(null);
   }
 
-  public void prewarmRecording(@Nullable AudioProcessingOptions options) {
+  /**
+   * Applies the platform audio processing options and starts recording ahead of the native
+   * start request so the first captured frames are available sooner.
+   *
+   * @return true if recording is running, false if the recorder could not be initialized or
+   *     started. Failures are also reported through the registered
+   *     {@link AudioRecordErrorCallback}. The options are applied either way and the native
+   *     start path retries the recorder later, so a false result is not fatal.
+   */
+  public boolean prewarmRecording(@Nullable AudioProcessingOptions options) {
     audioInput.applyPlatformAudioProcessingOptions(options);
-    audioInput.initRecordingIfNeeded();
-    audioInput.prewarmRecordingIfNeeded();
+    if (!audioInput.initRecordingIfNeeded()) {
+      Logging.w(TAG, "prewarmRecording: recorder initialization failed, skipping prewarm");
+      return false;
+    }
+    return audioInput.prewarmRecordingIfNeeded();
   }
 
-  public void requestStartRecording() {
-    requestStartRecording(null);
+  public boolean requestStartRecording() {
+    return requestStartRecording(null);
   }
 
-  public void requestStartRecording(@Nullable AudioProcessingOptions options) {
+  /**
+   * Applies the platform audio processing options and starts recording on behalf of the client.
+   * Recording keeps running until {@link #requestStopRecording()} is called.
+   *
+   * @return true if recording is running, false if the recorder could not be initialized or
+   *     started. Failures are also reported through the registered
+   *     {@link AudioRecordErrorCallback}.
+   */
+  public boolean requestStartRecording(@Nullable AudioProcessingOptions options) {
     audioInput.applyPlatformAudioProcessingOptions(options);
-    audioInput.initRecordingIfNeeded();
-    audioInput.startRecordingIfNeeded();
+    if (!audioInput.initRecordingIfNeeded()) {
+      Logging.w(TAG, "requestStartRecording: recorder initialization failed");
+      return false;
+    }
+    return audioInput.startRecordingIfNeeded();
   }
 
   public void requestStopRecording() {

--- a/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
+++ b/sdk/android/src/java/org/webrtc/audio/WebRtcAudioRecord.java
@@ -728,7 +728,14 @@ class WebRtcAudioRecord {
         // Disabling useAudioRecord allows for "recordingless" recording, 
         // where we emit audio buffers to be mixed in by client.
         if (useAudioRecord) {
-          assertTrue(audioRecord != null);
+          // A failed initRecording leaves audioRecord null. Client callers such as
+          // prewarmRecordingIfNeeded can reach this point in that state, so report
+          // it as a start error instead of asserting.
+          if (audioRecord == null) {
+            reportWebRtcAudioRecordStartError(AudioRecordStartErrorCode.AUDIO_RECORD_START_STATE_MISMATCH,
+                "AudioRecord.startRecording failed: recorder was not initialized");
+            return false;
+          }
           try {
             audioRecord.startRecording();
           } catch (IllegalStateException e) {


### PR DESCRIPTION
## Summary

`JavaAudioDeviceModule.prewarmRecording()` and `requestStartRecording()` ignore a failed `initRecordingIfNeeded()` and go on to start recording, which trips `assertTrue(audioRecord != null)` in `WebRtcAudioRecord.startRecordingImpl()`. The `AssertionError` escapes to the client SDK: a crash on Android (livekit/client-sdk-android#700) and an aborted mic publish on Flutter (livekit/client-sdk-flutter#1188). Both methods now return `false` instead, and the assertion is replaced by a reported start error.

## Details

AudioRecord creation fails when the microphone is held by another process, permission is missing, or `getMinBufferSize` rejects the configuration. `initAudioRecord()` then releases its resources and leaves `audioRecord` null, and the only diagnostic is the init error logged under `WebRtcAudioRecordExternal`.

- `prewarmRecording()` / `requestStartRecording()` return `boolean`. They log and return `false` when init fails, otherwise return the result of the start call. Existing callers ignored the void result, so this is source compatible. It is not binary compatible with prebuilt consumers.
- `startRecordingImpl()` reports `AUDIO_RECORD_START_STATE_MISMATCH` and returns `false` when `audioRecord` is null. Native callers cannot reach this state since `AudioState` only starts after a successful `InitRecording`, but client callers can.

The platform audio processing options are still applied before the init attempt, and the native start path re-enters `initRecordingImpl()` because `audioRecord` is null, so a failed prewarm degrades to the pre-prewarm behaviour instead of a hard failure.

Follow-ups: same change on `m144_release`, then have client-sdk-flutter and client-sdk-android check the returned boolean.

## Test plan

- `javac` against `android.jar` with both files on the sourcepath reports no errors from the change (only unresolved external dependencies).
- No GN build in this checkout. Needs an on-device check with the microphone held by another app before and after.
