### PR TITLE
Honor resolutionAlignment and allow ObjC encoders to report software encoding

### DIFF
--- a/sdk/objc/base/RTCVideoEncoder.h
+++ b/sdk/objc/base/RTCVideoEncoder.h
@@ -57,6 +57,13 @@ RTC_OBJC_EXPORT
    expected output size. */
 @property(nonatomic, readonly) BOOL supportsNativeHandle;
 
+@optional
+
+/** Whether the encoder is hardware accelerated. Affects CPU overuse detection
+   thresholds and the power efficiency reported in stats. Assumed YES when not
+   implemented, matching the built in encoders. */
+@property(nonatomic, readonly) BOOL isHardwareAccelerated;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sdk/objc/native/src/objc_video_encoder_factory.mm
+++ b/sdk/objc/native/src/objc_video_encoder_factory.mm
@@ -113,11 +113,16 @@ class ObjCVideoEncoder : public VideoEncoder {
         ScalingSettings(qp_thresholds.low, qp_thresholds.high) :
         ScalingSettings::kOff;
 
-    info.requested_resolution_alignment = encoder_.resolutionAlignment > 0 ?: 1;
+    NSInteger alignment = encoder_.resolutionAlignment;
+    info.requested_resolution_alignment =
+        alignment > 0 ? static_cast<uint32_t>(alignment) : 1;
     info.apply_alignment_to_all_simulcast_layers =
         encoder_.applyAlignmentToAllSimulcastLayers;
     info.supports_native_handle = encoder_.supportsNativeHandle;
-    info.is_hardware_accelerated = true;
+    info.is_hardware_accelerated =
+        [encoder_ respondsToSelector:@selector(isHardwareAccelerated)] ?
+        encoder_.isHardwareAccelerated :
+        true;
     return info;
   }
 


### PR DESCRIPTION
Two fixes in the ObjC encoder bridge (`ObjCVideoEncoder::GetEncoderInfo`), found while building custom encoder support in livekit/client-sdk-swift#1109.

- `requested_resolution_alignment` was computed as `resolutionAlignment > 0 ?: 1`. The elvis operator returns the boolean, so the value was always 1 and `applyAlignmentToAllSimulcastLayers` had no effect. The alignment is now forwarded when positive.
- `is_hardware_accelerated` was hardcoded to `true`. A software encoder plugged in via `RTCVideoEncoder` therefore got the relaxed CPU overuse thresholds meant for hardware encoders and reported itself as power efficient in stats. `RTCVideoEncoder` gains an optional `isHardwareAccelerated` property, read when implemented and defaulting to `YES` otherwise, so the built in VideoToolbox encoders are unchanged.

Syntax checked against the macOS SDK with `clang -fsyntax-only`, not yet built or runtime tested.
