### PR TITLE
android: do not RTC_CHECK in OnRemoveStream for a stream the Java observer never saw

### DIFF
--- a/sdk/android/src/jni/pc/peer_connection.cc
+++ b/sdk/android/src/jni/pc/peer_connection.cc
@@ -437,8 +437,17 @@ void PeerConnectionObserverJni::OnRemoveStream(
   RTC_ALLOW_PLAN_B_DEPRECATION_BEGIN();
   JNIEnv* env = AttachCurrentThreadIfNeeded();
   NativeToJavaStreamsMap::iterator it = remote_streams_.find(stream.get());
-  RTC_CHECK(it != remote_streams_.end())
-      << "unexpected stream: " << stream.get();
+  if (it == remote_streams_.end()) {
+    // The Java observer never saw this stream (it was not surfaced through
+    // OnAddStream), so there is nothing to tell it and nothing to erase.
+    // Aborting the process here -- the previous RTC_CHECK -- took down
+    // production apps during subscribe/unsubscribe churn
+    // (react-native-webrtc#1787, livekit/react-native-webrtc#77).
+    RTC_LOG(LS_WARNING) << "OnRemoveStream: unknown stream " << stream.get()
+                        << ", ignoring";
+    RTC_ALLOW_PLAN_B_DEPRECATION_END();
+    return;
+  }
   Java_Observer_onRemoveStream(env, j_observer_global_,
                                it->second.j_media_stream());
   remote_streams_.erase(it);


### PR DESCRIPTION
## The problem

`PeerConnectionObserverJni::OnRemoveStream` aborts the whole process when the
signalling layer removes a stream the Java observer never saw:

```cpp
NativeToJavaStreamsMap::iterator it = remote_streams_.find(stream.get());
RTC_CHECK(it != remote_streams_.end()) << "unexpected stream: " << stream.get();
```

This is not theoretical. We are seeing it in production on
`io.github.webrtc-sdk:android:144.7559.05`, ~1.4 SIGABRTs/day across a small
user base, every one of them a flagship Samsung on Android 16 during
subscribe/unsubscribe churn in a live SFU room. Resolving the raw frame offsets
in the crash reports against the published arm64 `.so` lands exactly here — the
call site loads, from `.rodata`:

```
x0 = "../../../sdk/android/src/jni/pc/peer_connection.cc"
w1 = 428
x2 = "it != remote_streams_.end()"
x4 = "unexpected stream: "
```

on the libwebrtc signalling thread. The same crash is reported publicly in
[livekit/react-native-webrtc#77](https://github.com/livekit/react-native-webrtc/issues/77)
and [react-native-webrtc#1787](https://github.com/react-native-webrtc/react-native-webrtc/issues/1787).

## Why downgrading the check is safe

Both known Java consumers implement the callback this check guards as a no-op:

- react-native-webrtc's `PeerConnectionObserver.onRemoveStream(MediaStream)` is
  an **empty method**, commented "Plan B is not supported anymore";
- flutter-webrtc likewise does not act on it.

The only other side effect in the function is `remote_streams_.erase(it)`, which
is meaningless when `it == end()`. So on the not-found path there is nothing to
deliver and nothing to erase — returning early loses no state and no lifetime
guarantee. This PR logs a warning instead of aborting.

## The change

One branch, plus a warning log. `RTC_ALLOW_PLAN_B_DEPRECATION_END()` is emitted
on the early-return path so the macro pairing stays lexically balanced.

## Request

Could this be picked into the next `m144_release` point release as well? We are
currently shipping a build-time byte patch of the published AAR to work around
it, and we would very much like to delete that.
