### PR TITLE
android: expose configured stereo mode on JavaAudioDeviceModule (m144)

### DIFF
--- a/sdk/android/api/org/webrtc/audio/JavaAudioDeviceModule.java
+++ b/sdk/android/api/org/webrtc/audio/JavaAudioDeviceModule.java
@@ -481,6 +481,16 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
     this.stopRecordingOnMute = stopRecordingOnMute;
   }
 
+  /** Returns whether the audio input is configured to capture stereo. */
+  public boolean useStereoInput() {
+    return useStereoInput;
+  }
+
+  /** Returns whether the audio output is configured to play out stereo. */
+  public boolean useStereoOutput() {
+    return useStereoOutput;
+  }
+
   @Override
   public long getNative(long webrtcEnvRef) {
     synchronized (nativeLock) {


### PR DESCRIPTION
## Summary

`JavaAudioDeviceModule.Builder` accepts `setUseStereoInput(boolean)` / `setUseStereoOutput(boolean)`, but the built module keeps the values only in `private final` fields, so embedders cannot read back what the audio device module was configured to do. SDKs layered on top of it (e.g. publisher-side stereo configuration in LiveKit's Android SDK) currently cannot align their own state with the module configuration.

Two getters on `JavaAudioDeviceModule` expose the already-tracked configuration:

- `useStereoInput()` — returns whether the audio input is configured to capture stereo
- `useStereoOutput()` — returns whether the audio output is configured to play out stereo

Java-only change: accessors over existing fields, no new imports, no behavior change.

## Test plan

- `javac` against `android.jar` (API 35) with `sdk/android/api`, `sdk/android/src/java`, and `rtc_base/java/src` on the sourcepath and `androidx.annotation:annotation-jvm` on the classpath: compiles with no errors, all `JavaAudioDeviceModule` classes emitted.
- No GN build in this checkout. No behavior is touched, so no additional runtime coverage is introduced.
