### PR TITLE
Query VideoToolbox H.264 profile levels lazily instead of in a static initializer

### DIFF
--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.h
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.h
@@ -15,8 +15,13 @@
 RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecH264Name);
 RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCLevel31ConstrainedHigh);
 RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCLevel31ConstrainedBaseline);
-RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh);
-RTC_OBJC_EXPORT extern NSString *const RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline);
+/** Highest H.264 Constrained High profile-level-id the local encoder supports.
+ *  Computed lazily: the first call may query VideoToolbox and take tens of
+ *  milliseconds, so avoid calling it on the main thread during app launch. */
+RTC_EXTERN NSString *RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh)(void);
+/** Highest H.264 Constrained Baseline profile-level-id the local encoder supports.
+ *  See the note above. */
+RTC_EXTERN NSString *RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline)(void);
 
 /** H264 Profiles and levels. */
 typedef NS_ENUM(NSUInteger, RTC_OBJC_TYPE(RTCH264Profile)) {

--- a/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
+++ b/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
@@ -33,10 +33,23 @@ NSString *MaxSupportedProfileLevelConstrainedBaseline();
 NSString *const RTC_CONSTANT_TYPE(RTCVideoCodecH264Name) = @(webrtc::kH264CodecName);
 NSString *const RTC_CONSTANT_TYPE(RTCLevel31ConstrainedHigh) = @"640c1f";
 NSString *const RTC_CONSTANT_TYPE(RTCLevel31ConstrainedBaseline) = @"42e01f";
-NSString *const RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh) =
-    MaxSupportedProfileLevelConstrainedHigh();
-NSString *const RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline) =
-    MaxSupportedProfileLevelConstrainedBaseline();
+NSString *RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh)(void) {
+  static NSString *profileLevel = nil;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    profileLevel = MaxSupportedProfileLevelConstrainedHigh();
+  });
+  return profileLevel;
+}
+
+NSString *RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline)(void) {
+  static NSString *profileLevel = nil;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    profileLevel = MaxSupportedProfileLevelConstrainedBaseline();
+  });
+  return profileLevel;
+}
 
 namespace {
 

--- a/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH264.m
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH264.m
@@ -21,7 +21,7 @@
   NSString *codecName = RTC_CONSTANT_TYPE(RTCVideoCodecH264Name);
 
   NSDictionary<NSString *, NSString *> *constrainedHighParams = @{
-    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh),
+    @"profile-level-id" : RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh)(),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };
@@ -32,7 +32,7 @@
   [codecs addObject:constrainedHighInfo];
 
   NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
-    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline),
+    @"profile-level-id" : RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline)(),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };

--- a/sdk/objc/components/video_codec/RTCVideoDecoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderH264.mm
@@ -87,7 +87,7 @@ void decompressionOutputCallback(void *decoderRef,
 
 + (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
   NSDictionary<NSString *, NSString *> *constrainedHighParams = @{
-    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh),
+    @"profile-level-id" : RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh)(),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };
@@ -97,7 +97,7 @@ void decompressionOutputCallback(void *decoderRef,
             parameters:constrainedHighParams];
 
   NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
-    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline),
+    @"profile-level-id" : RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline)(),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };

--- a/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH264.m
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH264.m
@@ -21,7 +21,7 @@
   NSString *codecName = RTC_CONSTANT_TYPE(RTCVideoCodecH264Name);
 
   NSDictionary<NSString *, NSString *> *constrainedHighParams = @{
-    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh),
+    @"profile-level-id" : RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh)(),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };
@@ -32,7 +32,7 @@
   [codecs addObject:constrainedHighInfo];
 
   NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
-    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline),
+    @"profile-level-id" : RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline)(),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -411,7 +411,7 @@ const char *H264ProfileName(const std::optional<webrtc::H264ProfileLevelId> &id)
 
 + (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
   NSDictionary<NSString *, NSString *> *constrainedHighParams = @{
-    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh),
+    @"profile-level-id" : RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedHigh)(),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };
@@ -421,7 +421,7 @@ const char *H264ProfileName(const std::optional<webrtc::H264ProfileLevelId> &id)
             parameters:constrainedHighParams];
 
   NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
-    @"profile-level-id" : RTC_CONSTANT_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline),
+    @"profile-level-id" : RTC_OBJC_TYPE(RTCMaxSupportedH264ProfileLevelConstrainedBaseline)(),
     @"level-asymmetry-allowed" : @"1",
     @"packetization-mode" : @"1",
   };


### PR DESCRIPTION
`RTCH264ProfileLevelId.mm` initialized `kRTCMaxSupportedH264ProfileLevelConstrainedHigh/Baseline` by calling `VTCopySupportedPropertyDictionaryForEncoder` for three sizes from a C++ static initializer (since #252), so every app linking the framework paid a VideoToolbox round trip on the main thread before `main()`, under `dyld4::Loader::findAndRunAllInitializers`, whether or not it ever used video. This replaces the two constants with `dispatch_once`-backed functions and updates the four internal consumers, so the query runs on the first `supportedCodecs` call instead. No consumers outside this repo were found (GitHub code search shows only vendored header copies), and client-sdk-swift does not reference the constants.

Measured on iPhone 12 / iOS 26.6.1 with an otherwise empty app linking LiveKitWebRTC (150.7871.01 vs. this patch built from m150_release tip):

| Scenario | Before | After | Empty app |
|---|---|---|---|
| Warm pre-main | 37 ms | 19 ms | 13.5 ms |
| First launch after reboot, launched first | 158 ms | 64 ms | 32–36 ms |
| First launch after reboot, launched second | 120 ms | 84 ms | |
| The initializer alone, cold (Instruments dyld table) | 69 ms | removed | |
| All LiveKitWebRTC static initializers, warm | 23–37 ms | < 1.5 ms | |

**Possible follow-up, not in this PR (`-Wl,-fixup_chains`):** the framework still ships with opcode-based rebase/bind fixups (36.7k entries) because the xcframework targets iOS 13.0 and Chromium's `build/config/ios/BUILD.gn` only adds `-Wl,-fixup_chains` for deployment targets above 14.0. Rebuilding with `ios_deployment_target="15.0"` produced chained fixups and, on the same device, cut cold dyld time by a further ~15–20 ms (Apply Fixups 28 → 18 ms, Building Closure 68 → 60 ms), with no measurable warm change and a 33 KB smaller binary. Excluded here because it raises the framework's minimum iOS (chained fixups need iOS 13.4+ at runtime).

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>